### PR TITLE
feat: add build info to main gateway executable

### DIFF
--- a/data-plane/gateway/gateway/build.rs
+++ b/data-plane/gateway/gateway/build.rs
@@ -14,16 +14,6 @@ fn set_env(name: &str, cmd: &mut Command) {
     println!("cargo:rustc-env={}={}", name, value);
 }
 
-fn version() -> String {
-    if let Ok(v) = std::env::var("VERSION") {
-        if !v.is_empty() {
-            return v;
-        }
-    }
-
-    "0.1.0-dev".to_string()
-}
-
 fn main() {
     set_env(
         "GIT_SHA",
@@ -36,7 +26,10 @@ fn main() {
         Command::new("date").args(["-u", "+%Y-%m-%dT%H:%M:%SZ"]),
     );
 
-    println!("cargo:rustc-env=VERSION={}", version());
+    set_env(
+        "VERSION",
+        Command::new("git").args(["describe", "--tags", "--always", "--match", "agp-gw-v*"]),
+    );
 
     let profile = std::env::var("PROFILE").expect("PROFILE must be set");
     println!("cargo:rustc-env=PROFILE={profile}");

--- a/data-plane/gateway/gateway/src/args.rs
+++ b/data-plane/gateway/gateway/src/args.rs
@@ -4,25 +4,24 @@
 use clap::Parser;
 
 #[derive(Parser)]
-#[command(version, about, long_about = None)]
+#[command(about, long_about = None)]
 pub struct Args {
-    /// Optional name to operate on
-    name: Option<String>,
-
     /// Sets a custom config file
-    #[arg(short, long, value_name = "FILE")]
-    #[clap(long, env, required = true)]
-    config: String,
+    #[arg(short, long, required = true, value_name = "FILE", group = "1")]
+    #[clap(long, env)]
+    config: Option<String>,
+
+    /// Print version
+    #[clap(short, long, action, required = true, group = "1")]
+    version: bool,
 }
 
 impl Args {
-    // Temporary disable warnings
-    #[allow(dead_code)]
-    pub fn name(&self) -> Option<&str> {
-        self.name.as_deref()
+    pub fn config(&self) -> Option<&str> {
+        self.config.as_deref()
     }
 
-    pub fn config(&self) -> &String {
-        &self.config
+    pub fn version(&self) -> bool {
+        self.version
     }
 }

--- a/data-plane/gateway/gateway/src/bin/main.rs
+++ b/data-plane/gateway/gateway/src/bin/main.rs
@@ -14,11 +14,17 @@ use agp_gw::runtime;
 fn main() {
     let args = args::Args::parse();
 
+    // If the version flag is set, print the build info and exit
+    if args.version() {
+        println!("{}", build_info::BUILD_INFO);
+        return;
+    }
+
     // get config file
-    let config_file = args.config();
+    let config_file = args.config().expect("config file is required");
 
     // create configured components
-    let config = config::load_config(config_file).expect("failed to load configuration");
+    let config = config::load_config(&config_file).expect("failed to load configuration");
 
     // print build info
     info!("{}", build_info::BUILD_INFO);

--- a/data-plane/gateway/gateway/src/bin/main.rs
+++ b/data-plane/gateway/gateway/src/bin/main.rs
@@ -24,7 +24,7 @@ fn main() {
     let config_file = args.config().expect("config file is required");
 
     // create configured components
-    let config = config::load_config(&config_file).expect("failed to load configuration");
+    let config = config::load_config(config_file).expect("failed to load configuration");
 
     // print build info
     info!("{}", build_info::BUILD_INFO);

--- a/data-plane/gateway/gateway/src/build_info.rs
+++ b/data-plane/gateway/gateway/src/build_info.rs
@@ -21,7 +21,7 @@ impl std::fmt::Display for BuildInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Version: {} Build Date: {} Git SHA: {} Profile: {}",
+            "Version:\t{}\nBuild Date:\t{}\nGit SHA:\t{}\nProfile:\t{}",
             self.version, self.date, self.git_sha, self.profile
         )
     }


### PR DESCRIPTION
## Motivation

The current gateway main executable does not provide any info about version and build environment.

## Solution

Add the `--version` flag. This can be used in the following way:

```bash
gateway --version
Version:        agp-gw-v0.2.0-1-g53676b0
Build Date:     2025-02-12T18:08:56Z
Git SHA:        53676b0
Profile:        debug
```