### PR TITLE
chore: use agp-maintainers team as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @msardara @micpapal @muscariello @pbalogh-sa @zsoltkacsandi
+**/ @agntcy/agp-maintainers


### PR DESCRIPTION
## Motivation

Using the github team as CODEOWNERS is easier to manage.
