### PR TITLE
feat(python-wheels): add aarch64 build

### DIFF
--- a/.github/workflows/reusable-python-build-wheels.yaml
+++ b/.github/workflows/reusable-python-build-wheels.yaml
@@ -19,9 +19,9 @@ jobs:
           - runner: ubuntu-24.04
             os: linux
             target: x86_64
-          # - runner: ubuntu-24.04-arm
-          #   os: linux
-          #   target: aarch64
+          - runner: ubuntu-24.04-arm
+            os: linux
+            target: aarch64
           - runner: windows-latest
             os: windows
             target: x64

--- a/data-plane/python-bindings/README.md
+++ b/data-plane/python-bindings/README.md
@@ -55,7 +55,7 @@ gateway = agp_bindings.Gateway()
 
 
 async def run_server(address: str):
-    # init tracing
+    # init tracing with debug
     agp_bindings.init_tracing(log_level="debug")
 
     # Run as server


### PR DESCRIPTION
## Motivation

Allow linux arm64 users to install the wheel without rebuild it (which requires the rust toolchain stalled).