### PR TITLE
fix(release-image): trigger workflow for any tag starting with agp-*

### DIFF
--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -7,7 +7,7 @@ name: ci-release-images
 on:
   push:
     tags:
-      - 'agp-gw-*'
+      - 'agp-*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Motivation

When multiple tags are pushed at once, they need to all match the regex that triggers the workflow.

## Solution

Set the regex to `agp-*` to allow matching all tags.