### PR TITLE
fix(python-bindings): propagate build PROFILE up to "python-bindings:packaging"  task target

### DIFF
--- a/data-plane/python-bindings/Taskfile.yml
+++ b/data-plane/python-bindings/Taskfile.yml
@@ -41,6 +41,11 @@ tasks:
 
   python-bindings:packaging:
     desc: "Generate the Python bindings for python versions 3.9, 3.10, 3.11, 3.12 and 3.13"
+    vars:
+      PROFILE: '{{.PROFILE | default "debug"}}'
+      RELEASE:
+        sh: '[[ {{.PROFILE}} == "release" ]] && echo "--release" || echo ""'
+      TARGET: '{{.TARGET | default ""}}'
     cmds:
       - rustup target add {{.TARGET}}
       - for:

--- a/data-plane/python-bindings/uv.lock
+++ b/data-plane/python-bindings/uv.lock
@@ -3,7 +3,7 @@ requires-python = ">=3.9, <4.0"
 
 [[package]]
 name = "agp-bindings"
-version = "0.1.1"
+version = "0.1.3"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/data-plane/rust-tooling/toolchain.yml
+++ b/data-plane/rust-tooling/toolchain.yml
@@ -281,7 +281,7 @@ tasks:
     internal: true
     dir: ./python-bindings
     cmds:
-      - task python-bindings:packaging
+      - task python-bindings:packaging PROFILE={{.PROFILE}} TARGET={{.TARGET}}
 
   bindings:python:test:
     desc: "Test the Python bindings"


### PR DESCRIPTION
## Motivation

When building the bindings from the Taskfile in data-plane,
the build profile and target are not propagated by default to the 
"python-bindings:packaging" target.