### PR TITLE
chore: release

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "agp-datapath"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "agp-config",
  "bit-vec",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "agp-service"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "agp-config",
  "agp-datapath",

--- a/data-plane/examples/Cargo.toml
+++ b/data-plane/examples/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/sdk-mock/main.rs"
 
 [dependencies]
 agp-config = { path = "../gateway/config", version = "0.1.1" }
-agp-datapath = { path = "../gateway/datapath", version = "0.1.0" }
+agp-datapath = { path = "../gateway/datapath", version = "0.1.1" }
 agp-gw = { path = "../gateway/gateway", version = "0.3.0" }
 clap = "4.5"
 tokio = "1"

--- a/data-plane/gateway/datapath/CHANGELOG.md
+++ b/data-plane/gateway/datapath/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/agntcy/agp/compare/agp-datapath-v0.1.0...agp-datapath-v0.1.1) - 2025-02-19
+
+### Added
+
+- *(tables)* distinguish local and remote connections in the subscription table (#55)
+
 ## [0.1.0](https://github.com/agntcy/agp/releases/tag/agp-gw-data-path-v0.1.0) - 2025-02-09
 
 ### Added

--- a/data-plane/gateway/datapath/Cargo.toml
+++ b/data-plane/gateway/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agp-datapath"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = { workspace = true }
 description = "Core data plane functionality for AGP"

--- a/data-plane/gateway/gateway/Cargo.toml
+++ b/data-plane/gateway/gateway/Cargo.toml
@@ -15,7 +15,7 @@ multicore = ["tokio/rt-multi-thread", "num_cpus"]
 
 [dependencies]
 agp-config = { path = "../config", version = "0.1.1" }
-agp-service = { path = "../service", version = "0.1.1" }
+agp-service = { path = "../service", version = "0.1.2" }
 agp-signal = { path = "../signal", version = "0.1.0" }
 agp-tracing = { path = "../tracing", version = "0.1.1" }
 clap = { version = "4.5.23", features = ["derive", "env"] }

--- a/data-plane/gateway/service/CHANGELOG.md
+++ b/data-plane/gateway/service/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/agntcy/agp/compare/agp-service-v0.1.1...agp-service-v0.1.2) - 2025-02-19
+
+### Other
+
+- updated the following local packages: agp-datapath
+
 ## [0.1.1](https://github.com/agntcy/agp/compare/agp-service-v0.1.0...agp-service-v0.1.1) - 2025-02-14
 
 ### Added

--- a/data-plane/gateway/service/Cargo.toml
+++ b/data-plane/gateway/service/Cargo.toml
@@ -2,12 +2,12 @@
 name = "agp-service"
 edition = "2021"
 license = { workspace = true }
-version = "0.1.1"
+version = "0.1.2"
 description = "Main service and public API to interact with AGP data plane."
 
 [dependencies]
 agp-config = { path = "../config", version = "0.1.1" }
-agp-datapath = { path = "../datapath", version = "0.1.0" }
+agp-datapath = { path = "../datapath", version = "0.1.1" }
 drain = { version = "0.1", features = ["retain"] }
 serde = "1.0.217"
 thiserror = "2.0.9"

--- a/data-plane/python-bindings/Cargo.toml
+++ b/data-plane/python-bindings/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 agp-config = { path = "../gateway/config", version = "0.1.1" }
-agp-datapath = { path = "../gateway/datapath", version = "0.1.0" }
-agp-service = { path = "../gateway/service", version = "0.1.1" }
+agp-datapath = { path = "../gateway/datapath", version = "0.1.1" }
+agp-service = { path = "../gateway/service", version = "0.1.2" }
 agp-tracing = { path = "../gateway/tracing", version = "0.1.1" }
 pyo3 = "0.23.3"
 pyo3-async-runtimes = { version = "0.23.0", features = ["tokio-runtime"] }


### PR DESCRIPTION



## 🤖 New release

* `agp-datapath`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `agp-service`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `agp-datapath`

<blockquote>

## [0.1.1](https://github.com/agntcy/agp/compare/agp-datapath-v0.1.0...agp-datapath-v0.1.1) - 2025-02-19

### Added

- *(tables)* distinguish local and remote connections in the subscription table (#55)
</blockquote>

## `agp-service`

<blockquote>

## [0.1.2](https://github.com/agntcy/agp/compare/agp-service-v0.1.1...agp-service-v0.1.2) - 2025-02-19

### Other

- updated the following local packages: agp-datapath
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).