### PR TITLE
fix: use same token for checkout in rust release-plz

### DIFF
--- a/.github/workflows/release-rust.yaml
+++ b/.github/workflows/release-rust.yaml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.AGNTCY_BUILD_BOT_GH_TOKEN }}
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/agentcy/agp/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation
Trigger image release workflow on tag creation
https://release-plz.dev/docs/github/token#how-to-trigger-further-workflow-runs

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Use the same GitHub token for checkout for rust release-plz
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->