### PR TITLE
chore: release

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "agp-config"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "agp-tracing",
  "duration-str",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "agp-datapath"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "agp-config",
  "bit-vec",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "agp-gw"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "agp-config",
  "agp-service",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "agp-service"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "agp-config",
  "agp-datapath",
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "agp-tracing"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",

--- a/data-plane/examples/Cargo.toml
+++ b/data-plane/examples/Cargo.toml
@@ -9,9 +9,9 @@ name = "sdk-mock"
 path = "src/sdk-mock/main.rs"
 
 [dependencies]
-agp-config = { path = "../gateway/config", version = "0.1.1" }
-agp-datapath = { path = "../gateway/datapath", version = "0.1.1" }
-agp-gw = { path = "../gateway/gateway", version = "0.3.2" }
+agp-config = { path = "../gateway/config", version = "0.1.2" }
+agp-datapath = { path = "../gateway/datapath", version = "0.1.2" }
+agp-gw = { path = "../gateway/gateway", version = "0.3.3" }
 clap = "4.5"
 tokio = "1"
 tracing = "0.1.41"

--- a/data-plane/gateway/config/CHANGELOG.md
+++ b/data-plane/gateway/config/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/agntcy/agp/compare/agp-config-v0.1.1...agp-config-v0.1.2) - 2025-02-28
+
+### Added
+
+- add message handling metrics
+
 ## [0.1.1](https://github.com/agntcy/agp/compare/agp-config-v0.1.0...agp-config-v0.1.1) - 2025-02-14
 
 ### Other

--- a/data-plane/gateway/config/Cargo.toml
+++ b/data-plane/gateway/config/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "agp-config"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = { workspace = true }
 description = "Configuration utilities"
 
 [dependencies]
-agp-tracing = { path = "../tracing", version = "0.1.1" }
+agp-tracing = { path = "../tracing", version = "0.1.2" }
 duration-str = "0.12.0"
 futures = "0.3.31"
 http = "1.2.0"

--- a/data-plane/gateway/datapath/CHANGELOG.md
+++ b/data-plane/gateway/datapath/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/agntcy/agp/compare/agp-datapath-v0.1.1...agp-datapath-v0.1.2) - 2025-02-28
+
+### Added
+
+- add message handling metrics
+
 ## [0.1.1](https://github.com/agntcy/agp/compare/agp-datapath-v0.1.0...agp-datapath-v0.1.1) - 2025-02-19
 
 ### Added

--- a/data-plane/gateway/datapath/Cargo.toml
+++ b/data-plane/gateway/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agp-datapath"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = { workspace = true }
 description = "Core data plane functionality for AGP"

--- a/data-plane/gateway/gateway/CHANGELOG.md
+++ b/data-plane/gateway/gateway/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3](https://github.com/agntcy/agp/compare/agp-gw-v0.3.2...agp-gw-v0.3.3) - 2025-02-28
+
+### Added
+
+- add message handling metrics
+
 ## [0.3.2](https://github.com/agntcy/agp/compare/agp-gw-v0.3.1...agp-gw-v0.3.2) - 2025-02-24
 
 ### Other

--- a/data-plane/gateway/gateway/Cargo.toml
+++ b/data-plane/gateway/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agp-gw"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 license = { workspace = true }
 description = "The main gateway executable"
@@ -14,10 +14,10 @@ default = ["multicore"]
 multicore = ["tokio/rt-multi-thread", "num_cpus"]
 
 [dependencies]
-agp-config = { path = "../config", version = "0.1.1" }
-agp-service = { path = "../service", version = "0.1.2" }
+agp-config = { path = "../config", version = "0.1.2" }
+agp-service = { path = "../service", version = "0.1.3" }
 agp-signal = { path = "../signal", version = "0.1.0" }
-agp-tracing = { path = "../tracing", version = "0.1.1" }
+agp-tracing = { path = "../tracing", version = "0.1.2" }
 clap = { version = "4.5.23", features = ["derive", "env"] }
 duration-str = "0.12.0"
 lazy_static = "1.5.0"

--- a/data-plane/gateway/nop_component/Cargo.toml
+++ b/data-plane/gateway/nop_component/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = { workspace = true }
 
 [dependencies]
-agp-config = { path = "../config", version = "0.1.1" }
+agp-config = { path = "../config", version = "0.1.2" }
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/data-plane/gateway/service/CHANGELOG.md
+++ b/data-plane/gateway/service/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/agntcy/agp/compare/agp-service-v0.1.2...agp-service-v0.1.3) - 2025-02-28
+
+### Added
+
+- add message handling metrics
+
 ## [0.1.2](https://github.com/agntcy/agp/compare/agp-service-v0.1.1...agp-service-v0.1.2) - 2025-02-19
 
 ### Other

--- a/data-plane/gateway/service/Cargo.toml
+++ b/data-plane/gateway/service/Cargo.toml
@@ -2,12 +2,12 @@
 name = "agp-service"
 edition = "2021"
 license = { workspace = true }
-version = "0.1.2"
+version = "0.1.3"
 description = "Main service and public API to interact with AGP data plane."
 
 [dependencies]
-agp-config = { path = "../config", version = "0.1.1" }
-agp-datapath = { path = "../datapath", version = "0.1.1" }
+agp-config = { path = "../config", version = "0.1.2" }
+agp-datapath = { path = "../datapath", version = "0.1.2" }
 drain = { version = "0.1", features = ["retain"] }
 serde = "1.0.217"
 thiserror = "2.0.9"

--- a/data-plane/gateway/tracing/CHANGELOG.md
+++ b/data-plane/gateway/tracing/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/agntcy/agp/compare/agp-tracing-v0.1.1...agp-tracing-v0.1.2) - 2025-02-28
+
+### Added
+
+- add message handling metrics
+
 ## [0.1.1](https://github.com/agntcy/agp/compare/agp-tracing-v0.1.0...agp-tracing-v0.1.1) - 2025-02-14
 
 ### Added

--- a/data-plane/gateway/tracing/Cargo.toml
+++ b/data-plane/gateway/tracing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agp-tracing"
 edition = "2021"
 license = { workspace = true }
-version = "0.1.1"
+version = "0.1.2"
 description = "Observability for AGP data plane: logs, traces and metrics infrastructure."
 
 [dependencies]

--- a/data-plane/python-bindings/Cargo.toml
+++ b/data-plane/python-bindings/Cargo.toml
@@ -10,10 +10,10 @@ name = "_agp_bindings"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-agp-config = { path = "../gateway/config", version = "0.1.1" }
-agp-datapath = { path = "../gateway/datapath", version = "0.1.1" }
-agp-service = { path = "../gateway/service", version = "0.1.2" }
-agp-tracing = { path = "../gateway/tracing", version = "0.1.1" }
+agp-config = { path = "../gateway/config", version = "0.1.2" }
+agp-datapath = { path = "../gateway/datapath", version = "0.1.2" }
+agp-service = { path = "../gateway/service", version = "0.1.3" }
+agp-tracing = { path = "../gateway/tracing", version = "0.1.2" }
 pyo3 = "0.23.3"
 pyo3-async-runtimes = { version = "0.23.0", features = ["tokio-runtime"] }
 pyo3-stub-gen = "0.7.0"

--- a/data-plane/testing/Cargo.toml
+++ b/data-plane/testing/Cargo.toml
@@ -17,9 +17,9 @@ name = "publisher"
 path = "src/bin/publisher.rs"
 
 [dependencies]
-agp-config = { path = "../gateway/config", version = "0.1.1" }
-agp-datapath = { path = "../gateway/datapath", version = "0.1.0" }
-agp-gw = { path = "../gateway/gateway", version = "0.3.2" }
+agp-config = { path = "../gateway/config", version = "0.1.2" }
+agp-datapath = { path = "../gateway/datapath", version = "0.1.2" }
+agp-gw = { path = "../gateway/gateway", version = "0.3.3" }
 clap = { version = "4.5", features = ["derive"] }
 indicatif = "0.17.11"
 parking_lot = "0.12"


### PR DESCRIPTION



## 🤖 New release

* `agp-tracing`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `agp-config`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `agp-datapath`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `agp-service`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `agp-gw`: 0.3.2 -> 0.3.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `agp-tracing`

<blockquote>

## [0.1.2](https://github.com/agntcy/agp/compare/agp-tracing-v0.1.1...agp-tracing-v0.1.2) - 2025-02-28

### Added

- add message handling metrics
</blockquote>

## `agp-config`

<blockquote>

## [0.1.2](https://github.com/agntcy/agp/compare/agp-config-v0.1.1...agp-config-v0.1.2) - 2025-02-28

### Added

- add message handling metrics
</blockquote>

## `agp-datapath`

<blockquote>

## [0.1.2](https://github.com/agntcy/agp/compare/agp-datapath-v0.1.1...agp-datapath-v0.1.2) - 2025-02-28

### Added

- add message handling metrics
</blockquote>

## `agp-service`

<blockquote>

## [0.1.3](https://github.com/agntcy/agp/compare/agp-service-v0.1.2...agp-service-v0.1.3) - 2025-02-28

### Added

- add message handling metrics
</blockquote>

## `agp-gw`

<blockquote>

## [0.3.3](https://github.com/agntcy/agp/compare/agp-gw-v0.3.2...agp-gw-v0.3.3) - 2025-02-28

### Added

- add message handling metrics
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).