### PR TITLE
ci: temporarily disable python wheels build on ubuntu-24.04-arm

### DIFF
--- a/.github/workflows/reusable-python-build-wheels.yaml
+++ b/.github/workflows/reusable-python-build-wheels.yaml
@@ -19,9 +19,9 @@ jobs:
           - runner: ubuntu-24.04
             os: linux
             target: x86_64
-          - runner: ubuntu-24.04-arm
-            os: linux
-            target: aarch64
+          # - runner: ubuntu-24.04-arm
+          #   os: linux
+          #   target: aarch64
           - runner: windows-latest
             os: windows
             target: x64


### PR DESCRIPTION
## Motivation

arm64 runners are available only for public repos.

## Solution

Disable build of arm64 python wheels.

Re-enable them when thew repo will be public.