### PR TITLE
chore: release

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "agp-datapath"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "agp-config",
  "bit-vec",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "agp-gw"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "agp-config",
  "agp-service",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "agp-service"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "agp-config",
  "agp-datapath",

--- a/data-plane/examples/Cargo.toml
+++ b/data-plane/examples/Cargo.toml
@@ -10,8 +10,8 @@ path = "src/sdk-mock/main.rs"
 
 [dependencies]
 agp-config = { path = "../gateway/config", version = "0.1.4" }
-agp-datapath = { path = "../gateway/datapath", version = "0.2.1" }
-agp-gw = { path = "../gateway/gateway", version = "0.3.5" }
+agp-datapath = { path = "../gateway/datapath", version = "0.3.0" }
+agp-gw = { path = "../gateway/gateway", version = "0.3.6" }
 clap = "4.5"
 tokio = "1"
 tracing = "0.1.41"

--- a/data-plane/gateway/datapath/CHANGELOG.md
+++ b/data-plane/gateway/datapath/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/agntcy/agp/compare/agp-datapath-v0.2.1...agp-datapath-v0.3.0) - 2025-03-12
+
+### Added
+
+- notify local app if a message is not processed correctly ([#72](https://github.com/agntcy/agp/pull/72))
+
 ## [0.2.1](https://github.com/agntcy/agp/compare/agp-datapath-v0.2.0...agp-datapath-v0.2.1) - 2025-03-11
 
 ### Other

--- a/data-plane/gateway/datapath/Cargo.toml
+++ b/data-plane/gateway/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agp-datapath"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 license = { workspace = true }
 description = "Core data plane functionality for AGP"

--- a/data-plane/gateway/gateway/CHANGELOG.md
+++ b/data-plane/gateway/gateway/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.6](https://github.com/agntcy/agp/compare/agp-gw-v0.3.5...agp-gw-v0.3.6) - 2025-03-12
+
+### Other
+
+- updated the following local packages: agp-service
+
 ## [0.3.5](https://github.com/agntcy/agp/compare/agp-gw-v0.3.4...agp-gw-v0.3.5) - 2025-03-11
 
 ### Other

--- a/data-plane/gateway/gateway/Cargo.toml
+++ b/data-plane/gateway/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agp-gw"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 license = { workspace = true }
 description = "The main gateway executable"
@@ -15,7 +15,7 @@ multicore = ["tokio/rt-multi-thread", "num_cpus"]
 
 [dependencies]
 agp-config = { path = "../config", version = "0.1.4" }
-agp-service = { path = "../service", version = "0.1.5" }
+agp-service = { path = "../service", version = "0.1.6" }
 agp-signal = { path = "../signal", version = "0.1.0" }
 agp-tracing = { path = "../tracing", version = "0.1.2" }
 clap = { version = "4.5.23", features = ["derive", "env"] }

--- a/data-plane/gateway/service/CHANGELOG.md
+++ b/data-plane/gateway/service/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/agntcy/agp/compare/agp-service-v0.1.5...agp-service-v0.1.6) - 2025-03-12
+
+### Added
+
+- notify local app if a message is not processed correctly ([#72](https://github.com/agntcy/agp/pull/72))
+
 ## [0.1.5](https://github.com/agntcy/agp/compare/agp-service-v0.1.4...agp-service-v0.1.5) - 2025-03-11
 
 ### Other

--- a/data-plane/gateway/service/Cargo.toml
+++ b/data-plane/gateway/service/Cargo.toml
@@ -2,12 +2,12 @@
 name = "agp-service"
 edition = "2021"
 license = { workspace = true }
-version = "0.1.5"
+version = "0.1.6"
 description = "Main service and public API to interact with AGP data plane."
 
 [dependencies]
 agp-config = { path = "../config", version = "0.1.4" }
-agp-datapath = { path = "../datapath", version = "0.2.1" }
+agp-datapath = { path = "../datapath", version = "0.3.0" }
 drain = { version = "0.1", features = ["retain"] }
 serde = "1.0.217"
 thiserror = "2.0.9"

--- a/data-plane/python-bindings/Cargo.toml
+++ b/data-plane/python-bindings/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 agp-config = { path = "../gateway/config", version = "0.1.4" }
-agp-datapath = { path = "../gateway/datapath", version = "0.2.1" }
-agp-service = { path = "../gateway/service", version = "0.1.5" }
+agp-datapath = { path = "../gateway/datapath", version = "0.3.0" }
+agp-service = { path = "../gateway/service", version = "0.1.6" }
 agp-tracing = { path = "../gateway/tracing", version = "0.1.2" }
 pyo3 = "0.23.3"
 pyo3-async-runtimes = { version = "0.23.0", features = ["tokio-runtime"] }

--- a/data-plane/testing/Cargo.toml
+++ b/data-plane/testing/Cargo.toml
@@ -18,8 +18,8 @@ path = "src/bin/publisher.rs"
 
 [dependencies]
 agp-config = { path = "../gateway/config", version = "0.1.4" }
-agp-datapath = { path = "../gateway/datapath", version = "0.2.1" }
-agp-gw = { path = "../gateway/gateway", version = "0.3.5" }
+agp-datapath = { path = "../gateway/datapath", version = "0.3.0" }
+agp-gw = { path = "../gateway/gateway", version = "0.3.6" }
 clap = { version = "4.5", features = ["derive"] }
 indicatif = "0.17.11"
 parking_lot = "0.12"


### PR DESCRIPTION



## 🤖 New release

* `agp-datapath`: 0.2.1 -> 0.3.0 (⚠ API breaking changes)
* `agp-service`: 0.1.5 -> 0.1.6 (✓ API compatible changes)
* `agp-gw`: 0.3.5 -> 0.3.6

### ⚠ `agp-datapath` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/enum_missing.ron

Failed in:
  enum agp_datapath::messages::utils::CommandType, previously in file /tmp/.tmpO3JePV/agp-datapath/src/messages/utils.rs:26
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `agp-datapath`

<blockquote>

## [0.3.0](https://github.com/agntcy/agp/compare/agp-datapath-v0.2.1...agp-datapath-v0.3.0) - 2025-03-12

### Added

- notify local app if a message is not processed correctly ([#72](https://github.com/agntcy/agp/pull/72))
</blockquote>

## `agp-service`

<blockquote>

## [0.1.6](https://github.com/agntcy/agp/compare/agp-service-v0.1.5...agp-service-v0.1.6) - 2025-03-12

### Added

- notify local app if a message is not processed correctly ([#72](https://github.com/agntcy/agp/pull/72))
</blockquote>

## `agp-gw`

<blockquote>

## [0.3.6](https://github.com/agntcy/agp/compare/agp-gw-v0.3.5...agp-gw-v0.3.6) - 2025-03-12

### Other

- updated the following local packages: agp-service
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).