### PR TITLE
chore: release

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "agp-datapath"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "agp-config",
  "agp-tracing",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "agp-gw"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "agp-config",
  "agp-service",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "agp-service"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "agp-config",
  "agp-datapath",

--- a/data-plane/examples/Cargo.toml
+++ b/data-plane/examples/Cargo.toml
@@ -10,8 +10,8 @@ path = "src/sdk-mock/main.rs"
 
 [dependencies]
 agp-config = { path = "../gateway/config", version = "0.1.5" }
-agp-datapath = { path = "../gateway/datapath", version = "0.3.1" }
-agp-gw = { path = "../gateway/gateway", version = "0.3.7" }
+agp-datapath = { path = "../gateway/datapath", version = "0.4.0" }
+agp-gw = { path = "../gateway/gateway", version = "0.3.8" }
 clap = "4.5"
 tokio = "1"
 tracing = "0.1.41"

--- a/data-plane/gateway/datapath/CHANGELOG.md
+++ b/data-plane/gateway/datapath/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/agntcy/agp/compare/agp-datapath-v0.3.1...agp-datapath-v0.4.0) - 2025-03-18
+
+### Added
+
+- new message format ([#88](https://github.com/agntcy/agp/pull/88))
+
 ## [0.3.1](https://github.com/agntcy/agp/compare/agp-datapath-v0.3.0...agp-datapath-v0.3.1) - 2025-03-18
 
 ### Added

--- a/data-plane/gateway/datapath/Cargo.toml
+++ b/data-plane/gateway/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agp-datapath"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 license = { workspace = true }
 description = "Core data plane functionality for AGP"

--- a/data-plane/gateway/gateway/CHANGELOG.md
+++ b/data-plane/gateway/gateway/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.8](https://github.com/agntcy/agp/compare/agp-gw-v0.3.7...agp-gw-v0.3.8) - 2025-03-18
+
+### Other
+
+- updated the following local packages: agp-service
+
 ## [0.3.7](https://github.com/agntcy/agp/compare/agp-gw-v0.3.6...agp-gw-v0.3.7) - 2025-03-18
 
 ### Other

--- a/data-plane/gateway/gateway/Cargo.toml
+++ b/data-plane/gateway/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agp-gw"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 license = { workspace = true }
 description = "The main gateway executable"
@@ -15,7 +15,7 @@ multicore = ["tokio/rt-multi-thread", "num_cpus"]
 
 [dependencies]
 agp-config = { path = "../config", version = "0.1.5" }
-agp-service = { path = "../service", version = "0.1.7" }
+agp-service = { path = "../service", version = "0.1.8" }
 agp-signal = { path = "../signal", version = "0.1.0" }
 agp-tracing = { path = "../tracing", version = "0.1.3" }
 clap = { version = "4.5.23", features = ["derive", "env"] }

--- a/data-plane/gateway/service/CHANGELOG.md
+++ b/data-plane/gateway/service/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/agntcy/agp/compare/agp-service-v0.1.7...agp-service-v0.1.8) - 2025-03-18
+
+### Added
+
+- new message format ([#88](https://github.com/agntcy/agp/pull/88))
+
 ## [0.1.7](https://github.com/agntcy/agp/compare/agp-service-v0.1.6...agp-service-v0.1.7) - 2025-03-18
 
 ### Added

--- a/data-plane/gateway/service/Cargo.toml
+++ b/data-plane/gateway/service/Cargo.toml
@@ -2,12 +2,12 @@
 name = "agp-service"
 edition = "2021"
 license = { workspace = true }
-version = "0.1.7"
+version = "0.1.8"
 description = "Main service and public API to interact with AGP data plane."
 
 [dependencies]
 agp-config = { path = "../config", version = "0.1.5" }
-agp-datapath = { path = "../datapath", version = "0.3.1" }
+agp-datapath = { path = "../datapath", version = "0.4.0" }
 drain = { version = "0.1", features = ["retain"] }
 serde = "1.0.217"
 thiserror = "2.0.9"

--- a/data-plane/python-bindings/Cargo.toml
+++ b/data-plane/python-bindings/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 agp-config = { path = "../gateway/config", version = "0.1.5" }
-agp-datapath = { path = "../gateway/datapath", version = "0.3.1" }
-agp-service = { path = "../gateway/service", version = "0.1.7" }
+agp-datapath = { path = "../gateway/datapath", version = "0.4.0" }
+agp-service = { path = "../gateway/service", version = "0.1.8" }
 agp-tracing = { path = "../gateway/tracing", version = "0.1.3" }
 pyo3 = "0.23.3"
 pyo3-async-runtimes = { version = "0.23.0", features = ["tokio-runtime"] }

--- a/data-plane/testing/Cargo.toml
+++ b/data-plane/testing/Cargo.toml
@@ -18,8 +18,8 @@ path = "src/bin/publisher.rs"
 
 [dependencies]
 agp-config = { path = "../gateway/config", version = "0.1.5" }
-agp-datapath = { path = "../gateway/datapath", version = "0.3.1" }
-agp-gw = { path = "../gateway/gateway", version = "0.3.7" }
+agp-datapath = { path = "../gateway/datapath", version = "0.4.0" }
+agp-gw = { path = "../gateway/gateway", version = "0.3.8" }
 clap = { version = "4.5", features = ["derive"] }
 indicatif = "0.17.11"
 parking_lot = "0.12"


### PR DESCRIPTION



## 🤖 New release

* `agp-datapath`: 0.3.1 -> 0.4.0 (⚠ API breaking changes)
* `agp-service`: 0.1.7 -> 0.1.8 (✓ API compatible changes)
* `agp-gw`: 0.3.7 -> 0.3.8

### ⚠ `agp-datapath` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Subscribe.header in /tmp/.tmpjbEVCs/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:5
  field Subscribe.header in /tmp/.tmpjbEVCs/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:5
  field Publish.header in /tmp/.tmpjbEVCs/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:15
  field Publish.control in /tmp/.tmpjbEVCs/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:17
  field Publish.header in /tmp/.tmpjbEVCs/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:15
  field Publish.control in /tmp/.tmpjbEVCs/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:17
  field Unsubscribe.header in /tmp/.tmpjbEVCs/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:10
  field Unsubscribe.header in /tmp/.tmpjbEVCs/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:10

--- failure constructible_struct_adds_private_field: struct no longer constructible due to new private field ---

Description:
A struct constructible with a struct literal has a new non-public field. It can no longer be constructed using a struct literal outside of its crate.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/constructible_struct_adds_private_field.ron

Failed in:
  field Agent.agent_type in /tmp/.tmpjbEVCs/agp/data-plane/gateway/datapath/src/messages/encoder.rs:55
  field Agent.agent_type in /tmp/.tmpjbEVCs/agp/data-plane/gateway/datapath/src/messages/encoder.rs:55

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_missing.ron

Failed in:
  enum agp_datapath::messages::utils::MetadataType, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/messages/utils.rs:26

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_variant_added.ron

Failed in:
  variant MessageError:AgpHeaderNotFound in /tmp/.tmpjbEVCs/agp/data-plane/gateway/datapath/src/messages/utils.rs:19
  variant MessageError:SourceNotFound in /tmp/.tmpjbEVCs/agp/data-plane/gateway/datapath/src/messages/utils.rs:21
  variant MessageError:DestinationNotFound in /tmp/.tmpjbEVCs/agp/data-plane/gateway/datapath/src/messages/utils.rs:23
  variant MessageError:ControlHeaderNotFound in /tmp/.tmpjbEVCs/agp/data-plane/gateway/datapath/src/messages/utils.rs:25

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_variant_missing.ron

Failed in:
  variant MessageError::NameNotFound, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/messages/utils.rs:19
  variant MessageError::ClassNotFound, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/messages/utils.rs:21
  variant MessageError::GroupNotFound, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/messages/utils.rs:23

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/function_missing.ron

Failed in:
  function agp_datapath::messages::encoder::encode_agent_from_string, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/messages/encoder.rs:36
  function agp_datapath::messages::utils::process_name, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/messages/utils.rs:278
  function agp_datapath::messages::encoder::encode_agent_class, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/messages/encoder.rs:29
  function agp_datapath::messages::utils::add_incoming_connection, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/messages/utils.rs:192
  function agp_datapath::messages::utils::create_unsubscription, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/messages/utils.rs:87
  function agp_datapath::messages::encoder::encode_agent_from_class, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/messages/encoder.rs:48
  function agp_datapath::messages::utils::get_agent_id, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/messages/utils.rs:308

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/function_parameter_count_changed.ron

Failed in:
  agp_datapath::messages::utils::create_publication now takes 6 parameters instead of 7, in /tmp/.tmpjbEVCs/agp/data-plane/gateway/datapath/src/messages/utils.rs:341
  agp_datapath::messages::utils::create_subscription now takes 2 parameters instead of 4, in /tmp/.tmpjbEVCs/agp/data-plane/gateway/datapath/src/messages/utils.rs:224

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/struct_missing.ron

Failed in:
  struct agp_datapath::pubsub::proto::pubsub::v1::AgentGroup, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/pubsub/gen/pubsub.proto.v1.rs:28
  struct agp_datapath::pubsub::ProtoAgentGroup, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/pubsub/gen/pubsub.proto.v1.rs:28
  struct agp_datapath::pubsub::proto::pubsub::v1::AgentClass, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/pubsub/gen/pubsub.proto.v1.rs:35
  struct agp_datapath::pubsub::ProtoAgentClass, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/pubsub/gen/pubsub.proto.v1.rs:35
  struct agp_datapath::pubsub::proto::pubsub::v1::AgentId, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/pubsub/gen/pubsub.proto.v1.rs:42
  struct agp_datapath::pubsub::ProtoAgentId, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/pubsub/gen/pubsub.proto.v1.rs:42
  struct agp_datapath::messages::encoder::AgentClass, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/messages/encoder.rs:9
  struct agp_datapath::messages::AgentClass, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/messages/encoder.rs:9

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field source of struct Publish, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/pubsub/gen/pubsub.proto.v1.rs:19
  field name of struct Publish, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/pubsub/gen/pubsub.proto.v1.rs:21
  field source of struct Publish, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/pubsub/gen/pubsub.proto.v1.rs:19
  field name of struct Publish, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/pubsub/gen/pubsub.proto.v1.rs:21
  field agent_class of struct Agent, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/messages/encoder.rs:19
  field agent_id of struct Agent, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/messages/encoder.rs:20
  field agent_class of struct Agent, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/messages/encoder.rs:19
  field agent_id of struct Agent, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/messages/encoder.rs:20
  field source of struct Subscribe, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/pubsub/gen/pubsub.proto.v1.rs:5
  field name of struct Subscribe, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/pubsub/gen/pubsub.proto.v1.rs:7
  field source of struct Subscribe, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/pubsub/gen/pubsub.proto.v1.rs:5
  field name of struct Subscribe, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/pubsub/gen/pubsub.proto.v1.rs:7
  field source of struct Unsubscribe, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/pubsub/gen/pubsub.proto.v1.rs:12
  field name of struct Unsubscribe, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/pubsub/gen/pubsub.proto.v1.rs:14
  field source of struct Unsubscribe, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/pubsub/gen/pubsub.proto.v1.rs:12
  field name of struct Unsubscribe, previously in file /tmp/.tmp2XhRrb/agp-datapath/src/pubsub/gen/pubsub.proto.v1.rs:14

--- failure struct_pub_field_now_doc_hidden: pub struct field is now #[doc(hidden)] ---

Description:
A pub field of a pub struct is now marked #[doc(hidden)] and is no longer part of the public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/struct_pub_field_now_doc_hidden.ron

Failed in:
  field Agent.agent_id in file /tmp/.tmpjbEVCs/agp/data-plane/gateway/datapath/src/messages/encoder.rs:54
  field Agent.agent_id in file /tmp/.tmpjbEVCs/agp/data-plane/gateway/datapath/src/messages/encoder.rs:54
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `agp-datapath`

<blockquote>

## [0.4.0](https://github.com/agntcy/agp/compare/agp-datapath-v0.3.1...agp-datapath-v0.4.0) - 2025-03-18

### Added

- new message format ([#88](https://github.com/agntcy/agp/pull/88))
</blockquote>

## `agp-service`

<blockquote>

## [0.1.8](https://github.com/agntcy/agp/compare/agp-service-v0.1.7...agp-service-v0.1.8) - 2025-03-18

### Added

- new message format ([#88](https://github.com/agntcy/agp/pull/88))
</blockquote>

## `agp-gw`

<blockquote>

## [0.3.8](https://github.com/agntcy/agp/compare/agp-gw-v0.3.7...agp-gw-v0.3.8) - 2025-03-18

### Other

- updated the following local packages: agp-service
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).