### PR TITLE
chore: release

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "agp-datapath"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "agp-config",
  "agp-tracing",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "agp-gw"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "agp-config",
  "agp-service",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "agp-service"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "agp-config",
  "agp-datapath",

--- a/data-plane/examples/Cargo.toml
+++ b/data-plane/examples/Cargo.toml
@@ -10,8 +10,8 @@ path = "src/sdk-mock/main.rs"
 
 [dependencies]
 agp-config = { path = "../gateway/config", version = "0.1.5" }
-agp-datapath = { path = "../gateway/datapath", version = "0.4.0" }
-agp-gw = { path = "../gateway/gateway", version = "0.3.8" }
+agp-datapath = { path = "../gateway/datapath", version = "0.4.1" }
+agp-gw = { path = "../gateway/gateway", version = "0.3.9" }
 clap = "4.5"
 tokio = "1"
 tracing = "0.1.41"

--- a/data-plane/gateway/datapath/CHANGELOG.md
+++ b/data-plane/gateway/datapath/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/agntcy/agp/compare/agp-datapath-v0.4.0...agp-datapath-v0.4.1) - 2025-03-19
+
+### Added
+
+- *(tables)* do not require Default/Clone traits for elements stored in pool ([#97](https://github.com/agntcy/agp/pull/97))
+
+### Other
+
+- use same API for send_to and publish ([#89](https://github.com/agntcy/agp/pull/89))
+
 ## [0.4.0](https://github.com/agntcy/agp/compare/agp-datapath-v0.3.1...agp-datapath-v0.4.0) - 2025-03-18
 
 ### Added

--- a/data-plane/gateway/datapath/Cargo.toml
+++ b/data-plane/gateway/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agp-datapath"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = { workspace = true }
 description = "Core data plane functionality for AGP"

--- a/data-plane/gateway/gateway/CHANGELOG.md
+++ b/data-plane/gateway/gateway/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.9](https://github.com/agntcy/agp/compare/agp-gw-v0.3.8...agp-gw-v0.3.9) - 2025-03-19
+
+### Other
+
+- updated the following local packages: agp-service
+
 ## [0.3.8](https://github.com/agntcy/agp/compare/agp-gw-v0.3.7...agp-gw-v0.3.8) - 2025-03-18
 
 ### Other

--- a/data-plane/gateway/gateway/Cargo.toml
+++ b/data-plane/gateway/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agp-gw"
-version = "0.3.8"
+version = "0.3.9"
 edition = "2021"
 license = { workspace = true }
 description = "The main gateway executable"
@@ -15,7 +15,7 @@ multicore = ["tokio/rt-multi-thread", "num_cpus"]
 
 [dependencies]
 agp-config = { path = "../config", version = "0.1.5" }
-agp-service = { path = "../service", version = "0.1.8" }
+agp-service = { path = "../service", version = "0.2.0" }
 agp-signal = { path = "../signal", version = "0.1.0" }
 agp-tracing = { path = "../tracing", version = "0.1.3" }
 clap = { version = "4.5.23", features = ["derive", "env"] }

--- a/data-plane/gateway/service/CHANGELOG.md
+++ b/data-plane/gateway/service/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/agntcy/agp/compare/agp-service-v0.1.8...agp-service-v0.2.0) - 2025-03-19
+
+### Other
+
+- use same API for send_to and publish ([#89](https://github.com/agntcy/agp/pull/89))
+
 ## [0.1.8](https://github.com/agntcy/agp/compare/agp-service-v0.1.7...agp-service-v0.1.8) - 2025-03-18
 
 ### Added

--- a/data-plane/gateway/service/Cargo.toml
+++ b/data-plane/gateway/service/Cargo.toml
@@ -2,12 +2,12 @@
 name = "agp-service"
 edition = "2021"
 license = { workspace = true }
-version = "0.1.8"
+version = "0.2.0"
 description = "Main service and public API to interact with AGP data plane."
 
 [dependencies]
 agp-config = { path = "../config", version = "0.1.5" }
-agp-datapath = { path = "../datapath", version = "0.4.0" }
+agp-datapath = { path = "../datapath", version = "0.4.1" }
 drain = { version = "0.1", features = ["retain"] }
 serde = "1.0.217"
 thiserror = "2.0.9"

--- a/data-plane/python-bindings/Cargo.toml
+++ b/data-plane/python-bindings/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 agp-config = { path = "../gateway/config", version = "0.1.5" }
-agp-datapath = { path = "../gateway/datapath", version = "0.4.0" }
-agp-service = { path = "../gateway/service", version = "0.1.8" }
+agp-datapath = { path = "../gateway/datapath", version = "0.4.1" }
+agp-service = { path = "../gateway/service", version = "0.2.0" }
 agp-tracing = { path = "../gateway/tracing", version = "0.1.3" }
 pyo3 = "0.23.3"
 pyo3-async-runtimes = { version = "0.23.0", features = ["tokio-runtime"] }

--- a/data-plane/testing/Cargo.toml
+++ b/data-plane/testing/Cargo.toml
@@ -18,8 +18,8 @@ path = "src/bin/publisher.rs"
 
 [dependencies]
 agp-config = { path = "../gateway/config", version = "0.1.5" }
-agp-datapath = { path = "../gateway/datapath", version = "0.4.0" }
-agp-gw = { path = "../gateway/gateway", version = "0.3.8" }
+agp-datapath = { path = "../gateway/datapath", version = "0.4.1" }
+agp-gw = { path = "../gateway/gateway", version = "0.3.9" }
 clap = { version = "4.5", features = ["derive"] }
 indicatif = "0.17.11"
 parking_lot = "0.12"


### PR DESCRIPTION



## 🤖 New release

* `agp-datapath`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `agp-service`: 0.1.8 -> 0.2.0 (⚠ API breaking changes)
* `agp-gw`: 0.3.8 -> 0.3.9

### ⚠ `agp-service` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/inherent_method_missing.ron

Failed in:
  Service::send_msg, previously in file /tmp/.tmpyVo0AA/agp-service/src/lib.rs:440
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `agp-datapath`

<blockquote>

## [0.4.1](https://github.com/agntcy/agp/compare/agp-datapath-v0.4.0...agp-datapath-v0.4.1) - 2025-03-19

### Added

- *(tables)* do not require Default/Clone traits for elements stored in pool ([#97](https://github.com/agntcy/agp/pull/97))

### Other

- use same API for send_to and publish ([#89](https://github.com/agntcy/agp/pull/89))
</blockquote>

## `agp-service`

<blockquote>

## [0.2.0](https://github.com/agntcy/agp/compare/agp-service-v0.1.8...agp-service-v0.2.0) - 2025-03-19

### Other

- use same API for send_to and publish ([#89](https://github.com/agntcy/agp/pull/89))
</blockquote>

## `agp-gw`

<blockquote>

## [0.3.9](https://github.com/agntcy/agp/compare/agp-gw-v0.3.8...agp-gw-v0.3.9) - 2025-03-19

### Other

- updated the following local packages: agp-service
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).