### PR TITLE
chore: release

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "agp-datapath"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "agp-config",
  "agp-tracing",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "agp-service"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "agp-config",
  "agp-datapath",

--- a/data-plane/examples/Cargo.toml
+++ b/data-plane/examples/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/sdk-mock/main.rs"
 
 [dependencies]
 agp-config = { path = "../gateway/config", version = "0.1.5" }
-agp-datapath = { path = "../gateway/datapath", version = "0.4.1" }
+agp-datapath = { path = "../gateway/datapath", version = "0.4.2" }
 agp-gw = { path = "../gateway/gateway", version = "0.3.9" }
 clap = "4.5"
 tokio = "1"

--- a/data-plane/gateway/datapath/CHANGELOG.md
+++ b/data-plane/gateway/datapath/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/agntcy/agp/compare/agp-datapath-v0.4.1...agp-datapath-v0.4.2) - 2025-03-19
+
+### Added
+
+- improve message processing file ([#101](https://github.com/agntcy/agp/pull/101))
+
 ## [0.4.1](https://github.com/agntcy/agp/compare/agp-datapath-v0.4.0...agp-datapath-v0.4.1) - 2025-03-19
 
 ### Added

--- a/data-plane/gateway/datapath/Cargo.toml
+++ b/data-plane/gateway/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agp-datapath"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 license = { workspace = true }
 description = "Core data plane functionality for AGP"

--- a/data-plane/gateway/gateway/Cargo.toml
+++ b/data-plane/gateway/gateway/Cargo.toml
@@ -15,7 +15,7 @@ multicore = ["tokio/rt-multi-thread", "num_cpus"]
 
 [dependencies]
 agp-config = { path = "../config", version = "0.1.5" }
-agp-service = { path = "../service", version = "0.2.0" }
+agp-service = { path = "../service", version = "0.2.1" }
 agp-signal = { path = "../signal", version = "0.1.0" }
 agp-tracing = { path = "../tracing", version = "0.1.3" }
 clap = { version = "4.5.23", features = ["derive", "env"] }

--- a/data-plane/gateway/service/CHANGELOG.md
+++ b/data-plane/gateway/service/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/agntcy/agp/compare/agp-service-v0.2.0...agp-service-v0.2.1) - 2025-03-19
+
+### Other
+
+- updated the following local packages: agp-datapath
+
 ## [0.2.0](https://github.com/agntcy/agp/compare/agp-service-v0.1.8...agp-service-v0.2.0) - 2025-03-19
 
 ### Other

--- a/data-plane/gateway/service/Cargo.toml
+++ b/data-plane/gateway/service/Cargo.toml
@@ -2,12 +2,12 @@
 name = "agp-service"
 edition = "2021"
 license = { workspace = true }
-version = "0.2.0"
+version = "0.2.1"
 description = "Main service and public API to interact with AGP data plane."
 
 [dependencies]
 agp-config = { path = "../config", version = "0.1.5" }
-agp-datapath = { path = "../datapath", version = "0.4.1" }
+agp-datapath = { path = "../datapath", version = "0.4.2" }
 drain = { version = "0.1", features = ["retain"] }
 serde = "1.0.217"
 thiserror = "2.0.9"

--- a/data-plane/python-bindings/Cargo.toml
+++ b/data-plane/python-bindings/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 agp-config = { path = "../gateway/config", version = "0.1.5" }
-agp-datapath = { path = "../gateway/datapath", version = "0.4.1" }
-agp-service = { path = "../gateway/service", version = "0.2.0" }
+agp-datapath = { path = "../gateway/datapath", version = "0.4.2" }
+agp-service = { path = "../gateway/service", version = "0.2.1" }
 agp-tracing = { path = "../gateway/tracing", version = "0.1.3" }
 pyo3 = "0.23.3"
 pyo3-async-runtimes = { version = "0.23.0", features = ["tokio-runtime"] }

--- a/data-plane/testing/Cargo.toml
+++ b/data-plane/testing/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/bin/publisher.rs"
 
 [dependencies]
 agp-config = { path = "../gateway/config", version = "0.1.5" }
-agp-datapath = { path = "../gateway/datapath", version = "0.4.1" }
+agp-datapath = { path = "../gateway/datapath", version = "0.4.2" }
 agp-gw = { path = "../gateway/gateway", version = "0.3.9" }
 clap = { version = "4.5", features = ["derive"] }
 indicatif = "0.17.11"


### PR DESCRIPTION



## 🤖 New release

* `agp-datapath`: 0.4.1 -> 0.4.2 (✓ API compatible changes)
* `agp-service`: 0.2.0 -> 0.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `agp-datapath`

<blockquote>

## [0.4.2](https://github.com/agntcy/agp/compare/agp-datapath-v0.4.1...agp-datapath-v0.4.2) - 2025-03-19

### Added

- improve message processing file ([#101](https://github.com/agntcy/agp/pull/101))
</blockquote>

## `agp-service`

<blockquote>

## [0.2.1](https://github.com/agntcy/agp/compare/agp-service-v0.2.0...agp-service-v0.2.1) - 2025-03-19

### Other

- updated the following local packages: agp-datapath
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).