### PR TITLE
feat: request/reply session type

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -141,6 +141,7 @@ version = "0.2.1"
 dependencies = [
  "agp-config",
  "agp-datapath",
+ "async-trait",
  "drain",
  "parking_lot",
  "rand 0.9.0",
@@ -289,9 +290,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.86"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/data-plane/examples/src/sdk-mock/main.rs
+++ b/data-plane/examples/src/sdk-mock/main.rs
@@ -7,7 +7,7 @@ use tracing::info;
 
 use agp_datapath::messages::encoder::{encode_agent, encode_agent_type};
 use agp_gw::config;
-use agp_service::session::SessionType;
+use agp_service::session::SessionConfig;
 
 mod args;
 
@@ -75,7 +75,7 @@ async fn main() {
     if let Some(msg) = message {
         // create a fire and forget session
         let res = svc
-            .create_session(&agent_name, SessionType::FireAndForget)
+            .create_session(&agent_name, SessionConfig::FireAndForget)
             .await;
         if res.is_err() {
             panic!("error creating fire and forget session");

--- a/data-plane/examples/src/sdk-mock/main.rs
+++ b/data-plane/examples/src/sdk-mock/main.rs
@@ -7,7 +7,10 @@ use tracing::info;
 
 use agp_datapath::messages::encoder::{encode_agent, encode_agent_type};
 use agp_gw::config;
-use agp_service::session::SessionConfig;
+use agp_service::{
+    session::{self, SessionConfig},
+    FireAndForgetConfiguration,
+};
 
 mod args;
 
@@ -69,20 +72,21 @@ async fn main() {
     // wait for the connection to be established
     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
-    let mut session = u32::MAX;
-
     // check what to do with the message
     if let Some(msg) = message {
         // create a fire and forget session
         let res = svc
-            .create_session(&agent_name, SessionConfig::FireAndForget)
+            .create_session(
+                &agent_name,
+                SessionConfig::FireAndForget(FireAndForgetConfiguration {}),
+            )
             .await;
         if res.is_err() {
             panic!("error creating fire and forget session");
         }
 
         // get the session
-        session = res.unwrap();
+        let session = res.unwrap();
 
         // publish message
         svc.publish(&agent_name, session, &route, None, 1, msg.into())
@@ -91,7 +95,7 @@ async fn main() {
     }
 
     // wait for messages
-    let mut messages = std::collections::VecDeque::<String>::new();
+    let mut messages = std::collections::VecDeque::<(String, session::Info)>::new();
     loop {
         tokio::select! {
             _ = agp_signal::shutdown() => {
@@ -102,7 +106,7 @@ async fn main() {
                 // send a message back
                 let msg = messages.pop_front();
                 if let Some(msg) = msg {
-                    svc.publish(&agent_name, session, &route, None, 1, msg.into())
+                    svc.publish(&agent_name, msg.1, &route, None, 1, msg.0.into())
                         .await
                         .unwrap();
                 }
@@ -112,16 +116,9 @@ async fn main() {
                     break;
                 }
 
-                let (msg, session_info) = next.unwrap();
+                let session_msg = next.unwrap().expect("error");
 
-                // make sure the session is the same
-                if session != u32::MAX && session_info.id != session {
-                    panic!("wrong session id {}", session_info.id);
-                } else {
-                    session = session_info.id;
-                }
-
-                match &msg.message_type.unwrap() {
+                match &session_msg.message.message_type.unwrap() {
                     agp_datapath::pubsub::ProtoPublishType(msg) => {
                         let payload = agp_datapath::messages::utils::get_payload(msg);
                         info!(
@@ -136,7 +133,7 @@ async fn main() {
                 }
 
                 let msg = format!("hello from the {}", local_agent);
-                messages.push_back(msg);
+                messages.push_back((msg, session_msg.info));
             }
         }
     }

--- a/data-plane/gateway/datapath/src/forwarder.rs
+++ b/data-plane/gateway/datapath/src/forwarder.rs
@@ -98,14 +98,12 @@ where
 
     pub fn on_forwarded_subscription(
         &self,
-        source_type: AgentType,
-        source_agent_id: Option<u64>,
+        source: Agent,
         name_type: AgentType,
         name_agent_id: Option<u64>,
         conn_index: u64,
         add: bool,
     ) {
-        let source = Agent::new(source_type, source_agent_id.unwrap_or(DEFAULT_AGENT_ID));
         let name = Agent::new(name_type, name_agent_id.unwrap_or(DEFAULT_AGENT_ID));
         if add {
             self.remote_subscription_table

--- a/data-plane/gateway/datapath/src/message_processing.rs
+++ b/data-plane/gateway/datapath/src/message_processing.rs
@@ -494,8 +494,8 @@ impl MessageProcessor {
                     debug!("forward subscription (add = {}) to {:?}", add, forward);
                     let out_conn = forward.unwrap();
 
-                    let (source_type, source_id) = match get_source(&msg) {
-                        Ok((c, f)) => (c, f),
+                    let source_agent = match get_source(&msg) {
+                        Ok(src) => src,
                         Err(e) => {
                             error!(
                                 "error processing subscription (add = {}) source: {:?}",
@@ -507,8 +507,7 @@ impl MessageProcessor {
                     match self.send_msg(msg, out_conn).await {
                         Ok(_) => {
                             self.forwarder().on_forwarded_subscription(
-                                source_type,
-                                source_id,
+                                source_agent,
                                 agent_type,
                                 agent_id,
                                 out_conn,

--- a/data-plane/gateway/datapath/src/messages/encoder.rs
+++ b/data-plane/gateway/datapath/src/messages/encoder.rs
@@ -3,6 +3,8 @@
 
 use std::hash::{DefaultHasher, Hash, Hasher};
 
+use crate::pubsub::ProtoAgent;
+
 pub const DEFAULT_AGENT_ID: u64 = u64::MAX;
 
 #[derive(Hash, Eq, PartialEq, Debug, Clone, Default)]
@@ -19,6 +21,16 @@ impl std::fmt::Display for AgentType {
             "{:x}/{:x}/{:x}",
             self.organization, self.namespace, self.agent_type
         )
+    }
+}
+
+impl From<&ProtoAgent> for AgentType {
+    fn from(agent: &ProtoAgent) -> Self {
+        Self {
+            organization: agent.organization,
+            namespace: agent.namespace,
+            agent_type: agent.agent_type,
+        }
     }
 }
 
@@ -79,6 +91,15 @@ impl std::fmt::Display for Agent {
     }
 }
 
+impl From<&ProtoAgent> for Agent {
+    fn from(agent: &ProtoAgent) -> Self {
+        Self {
+            agent_type: AgentType::from(agent),
+            agent_id: agent.agent_id.expect("agent id not found"),
+        }
+    }
+}
+
 impl Agent {
     /// Create a new Agent
     pub fn new(agent_type: AgentType, agent_id: u64) -> Self {
@@ -100,8 +121,8 @@ impl Agent {
         &self.agent_type
     }
 
-    pub fn agent_id(&self) -> &u64 {
-        &self.agent_id
+    pub fn agent_id(&self) -> u64 {
+        self.agent_id
     }
 
     pub fn agent_id_option(&self) -> Option<u64> {

--- a/data-plane/gateway/datapath/src/messages/utils.rs
+++ b/data-plane/gateway/datapath/src/messages/utils.rs
@@ -177,9 +177,13 @@ pub fn get_source(msg: &ProtoMessage) -> Result<Agent, MessageError> {
     match get_agp_header(msg) {
         Some(header) => match header.source {
             Some(source) => {
-                let agent_type =
-                    AgentType::new(source.organization, source.namespace, source.agent_type);
-                Ok((agent_type, source.agent_id))
+                let id =  match source.agent_id {
+                    Some(id) => id,
+                    None => return Err(MessageError::SourceNotFound),
+                };
+
+                let agent = Agent::new(AgentType::new(source.organization, source.namespace, source.agent_type), id);
+                Ok(agent)
             }
             None => Err(MessageError::SourceNotFound),
         },
@@ -465,9 +469,7 @@ mod tests {
         assert_eq!(None, get_recv_from(&sub).unwrap());
         assert_eq!(None, get_forward_to(&sub).unwrap());
         assert_eq!(None, get_incoming_connection(&sub).unwrap());
-        let (got_source, got_source_id) = get_source(&sub).unwrap();
-        assert_eq!(*source.agent_type(), got_source);
-        assert_eq!(Some(1), got_source_id);
+        assert_eq!(source, get_source(&sub).unwrap());
         let (got_name, got_name_id) = get_name(&sub).unwrap();
         assert_eq!(name, got_name);
         assert_eq!(Some(2), got_name_id);
@@ -487,9 +489,7 @@ mod tests {
         assert_eq!(Some(50), get_recv_from(&sub_from).unwrap());
         assert_eq!(None, get_forward_to(&sub_from).unwrap());
         assert_eq!(None, get_incoming_connection(&sub_from).unwrap());
-        let (got_source, got_source_id) = get_source(&sub_from).unwrap();
-        assert_eq!(*Agent::default().agent_type(), got_source);
-        assert_eq!(Agent::default().agent_id_option(), got_source_id);
+        assert_eq!(source, get_source(&sub).unwrap());
         let (got_name, got_name_id) = get_name(&sub_from).unwrap();
         assert_eq!(name, got_name);
         assert_eq!(Some(2), got_name_id);
@@ -501,9 +501,7 @@ mod tests {
         assert_eq!(None, get_recv_from(&sub_fwd).unwrap());
         assert_eq!(Some(30), get_forward_to(&sub_fwd).unwrap());
         assert_eq!(None, get_incoming_connection(&sub_fwd).unwrap());
-        let (got_source, got_source_id) = get_source(&sub_fwd).unwrap();
-        assert_eq!(*source.agent_type(), got_source);
-        assert_eq!(Some(1), got_source_id);
+        assert_eq!(source, get_source(&sub).unwrap());
         let (got_name, got_name_id) = get_name(&sub_fwd).unwrap();
         assert_eq!(name, got_name);
         assert_eq!(None, got_name_id);
@@ -520,9 +518,7 @@ mod tests {
         assert_eq!(Some(50), get_recv_from(&unsub_from).unwrap());
         assert_eq!(None, get_forward_to(&unsub_from).unwrap());
         assert_eq!(None, get_incoming_connection(&sub_from).unwrap());
-        let (got_source, got_source_id) = get_source(&unsub_from).unwrap();
-        assert_eq!(*Agent::default().agent_type(), got_source);
-        assert_eq!(Agent::default().agent_id_option(), got_source_id);
+        assert_eq!(source, get_source(&sub).unwrap());
         let (got_name, got_name_id) = get_name(&unsub_from).unwrap();
         assert_eq!(name, got_name);
         assert_eq!(Some(2), got_name_id);
@@ -533,9 +529,7 @@ mod tests {
         assert_eq!(None, get_recv_from(&unsub_fwd).unwrap());
         assert_eq!(Some(30), get_forward_to(&unsub_fwd).unwrap());
         assert_eq!(None, get_incoming_connection(&unsub_fwd).unwrap());
-        let (got_source, got_source_id) = get_source(&unsub_fwd).unwrap();
-        assert_eq!(*source.agent_type(), got_source);
-        assert_eq!(Some(1), got_source_id);
+        assert_eq!(source, get_source(&sub).unwrap());
         let (got_name, got_name_id) = get_name(&unsub_fwd).unwrap();
         assert_eq!(name, got_name);
         assert_eq!(None, got_name_id);
@@ -558,9 +552,7 @@ mod tests {
         assert_eq!(None, get_recv_from(&p).unwrap());
         assert_eq!(None, get_forward_to(&p).unwrap());
         assert_eq!(None, get_incoming_connection(&p).unwrap());
-        let (got_source, got_source_id) = get_source(&sub).unwrap();
-        assert_eq!(*source.agent_type(), got_source);
-        assert_eq!(Some(1), got_source_id);
+        assert_eq!(source, get_source(&sub).unwrap());
         let (got_name, got_name_id) = get_name(&sub).unwrap();
         assert_eq!(name, got_name);
         assert_eq!(Some(2), got_name_id);

--- a/data-plane/gateway/datapath/src/messages/utils.rs
+++ b/data-plane/gateway/datapath/src/messages/utils.rs
@@ -173,7 +173,7 @@ pub fn get_error(msg: &ProtoMessage) -> Result<Option<bool>, MessageError> {
     }
 }
 
-pub fn get_source(msg: &ProtoMessage) -> Result<(AgentType, Option<u64>), MessageError> {
+pub fn get_source(msg: &ProtoMessage) -> Result<Agent, MessageError> {
     match get_agp_header(msg) {
         Some(header) => match header.source {
             Some(source) => {

--- a/data-plane/gateway/datapath/src/tables/subscription_table.rs
+++ b/data-plane/gateway/datapath/src/tables/subscription_table.rs
@@ -398,7 +398,7 @@ fn add_subscription_to_sub_table(
 ) {
     match table.get_mut(agent.agent_type()) {
         None => {
-            let uid = *agent.agent_id();
+            let uid = agent.agent_id();
             debug!(
                 "subscription table: add first subscription for type {:?}, agent_id {:?} on connection {}",
                 agent.agent_type(), uid, conn,
@@ -411,7 +411,7 @@ fn add_subscription_to_sub_table(
             table.insert(agent.agent_type().clone(), state);
         }
         Some(state) => {
-            state.insert(*agent.agent_id(), conn, is_local);
+            state.insert(agent.agent_id(), conn, is_local);
         }
     }
 }
@@ -465,7 +465,7 @@ fn remove_subscription_from_sub_table(
             Err(SubscriptionTableError::SubscriptionNotFound)
         }
         Some(state) => {
-            state.remove(agent.agent_id(), conn_index, is_local)?;
+            state.remove(&agent.agent_id(), conn_index, is_local)?;
             // we may need to remove the state
             if state.ids.is_empty() {
                 table.remove(agent.agent_type());

--- a/data-plane/gateway/service/Cargo.toml
+++ b/data-plane/gateway/service/Cargo.toml
@@ -8,6 +8,7 @@ description = "Main service and public API to interact with AGP data plane."
 [dependencies]
 agp-config = { path = "../config", version = "0.1.5" }
 agp-datapath = { path = "../datapath", version = "0.4.2" }
+async-trait = "0.1.88"
 drain = { version = "0.1", features = ["retain"] }
 parking_lot = "0.12.3"
 rand = "0.9.0"

--- a/data-plane/gateway/service/src/errors.rs
+++ b/data-plane/gateway/service/src/errors.rs
@@ -66,4 +66,6 @@ pub enum SessionError {
         error: String,
         message: Box<SessionMessage>,
     },
+    #[error("configuration error: {0}")]
+    ConfigurationError(String),
 }

--- a/data-plane/gateway/service/src/errors.rs
+++ b/data-plane/gateway/service/src/errors.rs
@@ -3,7 +3,7 @@
 
 use thiserror::Error;
 
-use agp_datapath::pubsub::proto::pubsub::v1::Message;
+use crate::session::SessionMessage;
 
 #[derive(Error, Debug)]
 pub enum ServiceError {
@@ -64,6 +64,6 @@ pub enum SessionError {
     #[error("timeout for message: {error}")]
     Timeout {
         error: String,
-        message: Message
+        message: Box<SessionMessage>,
     },
 }

--- a/data-plane/gateway/service/src/errors.rs
+++ b/data-plane/gateway/service/src/errors.rs
@@ -3,6 +3,8 @@
 
 use thiserror::Error;
 
+use agp_datapath::pubsub::proto::pubsub::v1::Message;
+
 #[derive(Error, Debug)]
 pub enum ServiceError {
     #[error("configuration error {0}")]
@@ -29,12 +31,39 @@ pub enum ServiceError {
     ReceiveError(String),
     #[error("session not found: {0}")]
     SessionNotFound(String),
-    #[error("error creating session: {0}")]
-    SessionCreationError(String),
-    #[error("error creating the session: {0}")]
-    SessionDeletionError(String),
-    #[error("error deleting the session: {0}")]
-    SessionSendError(String),
+    #[error("error in session session: {0}")]
+    SessionError(String),
     #[error("unknown error")]
     Unknown,
+}
+
+#[derive(Error, Debug, PartialEq)]
+pub enum SessionError {
+    #[error("error receiving message from gateway: {0}")]
+    GatewayReception(String),
+    #[error("error sending message to gateway: {0}")]
+    GatewayTransmission(String),
+    #[error("error receiving message from app: {0}")]
+    AppReception(String),
+    #[error("error sending message to app: {0}")]
+    AppTransmission(String),
+    #[error("error processing message: {0}")]
+    Processing(String),
+    #[error("session id already used: {0}")]
+    SessionIdAlreadyUsed(String),
+    #[error("missing AGP header: {0}")]
+    MissingAgpHeader(String),
+    #[error("missing session header")]
+    MissingSessionHeader,
+    #[error("session unknown: {0}")]
+    SessionUnknown(String),
+    #[error("session not found: {0}")]
+    SessionNotFound(String),
+    #[error("missing session id: {0}")]
+    MissingSessionId(String),
+    #[error("timeout for message: {error}")]
+    Timeout {
+        error: String,
+        message: Message
+    },
 }

--- a/data-plane/gateway/service/src/lib.rs
+++ b/data-plane/gateway/service/src/lib.rs
@@ -4,17 +4,22 @@
 pub mod errors;
 pub mod producer_buffer;
 pub mod receiver_buffer;
+#[macro_use]
 pub mod session;
 pub mod timer;
 
 mod fire_and_forget;
+mod request_response;
 mod session_layer;
+
+pub use fire_and_forget::FireAndForgetConfiguration;
+pub use request_response::RequestResponseConfiguration;
 
 use agp_datapath::messages::utils;
 use agp_datapath::messages::{Agent, AgentType};
 use agp_datapath::pubsub::MessageType;
 use serde::Deserialize;
-use session::MessageDirection;
+use session::{AppChannelReceiver, MessageDirection};
 use session_layer::SessionLayer;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -179,10 +184,7 @@ impl Service {
     }
 
     // APP APIs
-    pub fn create_agent(
-        &mut self,
-        agent_name: &Agent,
-    ) -> Result<mpsc::Receiver<(Message, session::Info)>, ServiceError> {
+    pub fn create_agent(&mut self, agent_name: &Agent) -> Result<AppChannelReceiver, ServiceError> {
         // make sure the agent is not already registered
         if self.session_layers.contains_key(agent_name) {
             error!("agent {:?} already exists", agent_name);
@@ -365,7 +367,7 @@ impl Service {
                 .await
                 .map_err(|e| {
                     error!("error sending the message to session {}: {}", id, e);
-                    ServiceError::SessionSendError(e.to_string())
+                    ServiceError::SessionError(e.to_string())
                 }),
             None => session.tx_gw().send(Ok(msg)).await.map_err(|e| {
                 error!("error sending the subscription {}", e);
@@ -540,7 +542,7 @@ impl Service {
     pub async fn create_session(
         &self,
         agent: &Agent,
-        session_type: session::SessionType,
+        session_config: session::SessionConfig,
     ) -> Result<session::Id, ServiceError> {
         // check if agent was registered
         let layer = self.session_layers.get(agent);
@@ -553,10 +555,40 @@ impl Service {
         let layer = layer.unwrap();
 
         // create a new fire and forget session
-        layer.create_session(session_type, None).await.map_err(|e| {
-            error!("error creating session: {}", e);
-            ServiceError::SessionCreationError(e.to_string())
-        })
+        layer
+            .create_session(session_config, None)
+            .await
+            .map_err(|e| {
+                error!("error creating session: {}", e);
+                ServiceError::SessionError(e.to_string())
+            })
+    }
+
+    /// Set config for a session
+    pub async fn set_session_config(
+        &self,
+        agent: &Agent,
+        session_id: session::Id,
+        session_config: &session::SessionConfig,
+    ) -> Result<(), ServiceError> {
+        // check if agent was registered
+        let layer = self.session_layers.get(agent);
+
+        if layer.is_none() {
+            error!("agent {} not found", agent);
+            return Err(ServiceError::AgentNotFound(agent.to_string()));
+        }
+
+        let layer = layer.unwrap();
+
+        // set the session config
+        layer
+            .set_session_config(session_id, &session_config)
+            .await
+            .map_err(|e| {
+                error!("error setting session config: {}", e);
+                ServiceError::SessionError(e.to_string())
+            })
     }
 
     /// delete a session
@@ -580,7 +612,7 @@ impl Service {
             true => Ok(()),
             false => {
                 error!("error deleting session");
-                Err(ServiceError::SessionDeletionError("unknown".to_string()))
+                Err(ServiceError::SessionError("unknown".to_string()))
             }
         }
     }
@@ -650,7 +682,7 @@ impl ComponentBuilder for ServiceBuilder {
 // tests
 #[cfg(test)]
 mod tests {
-    use crate::session::SessionType;
+    use crate::session::SessionConfig;
 
     use super::*;
     use agp_config::grpc::server::ServerConfig;
@@ -734,7 +766,10 @@ mod tests {
 
         // create a fire and forget session
         let session_id = service
-            .create_session(&publisher_agent, SessionType::FireAndForget)
+            .create_session(
+                &publisher_agent,
+                SessionConfig::FireAndForget(FireAndForgetConfiguration::default()),
+            )
             .await
             .unwrap();
 
@@ -753,7 +788,11 @@ mod tests {
             .unwrap();
 
         // wait for the message to arrive
-        let (msg, info) = sub_rx.recv().await.unwrap();
+        let (msg, info) = sub_rx
+            .recv()
+            .await
+            .expect("no message received")
+            .expect("error");
 
         // make sure message is a publication
         assert!(msg.message_type.is_some());

--- a/data-plane/gateway/service/src/lib.rs
+++ b/data-plane/gateway/service/src/lib.rs
@@ -14,6 +14,7 @@ mod session_layer;
 
 pub use fire_and_forget::FireAndForgetConfiguration;
 pub use request_response::RequestResponseConfiguration;
+pub use session::SessionMessage;
 
 use agp_datapath::messages::utils;
 use agp_datapath::messages::{Agent, AgentType};
@@ -350,8 +351,8 @@ impl Service {
     async fn send_message(
         &self,
         agent: &Agent,
-        session_id: Option<session::Id>,
         msg: Message,
+        info: Option<session::Info>,
     ) -> Result<(), ServiceError> {
         let session = match self.session_layers.get(agent) {
             None => {
@@ -361,14 +362,18 @@ impl Service {
             Some(layer) => layer,
         };
 
-        match session_id {
-            Some(id) => session
-                .handle_message(msg, MessageDirection::South, Some(id))
-                .await
-                .map_err(|e| {
-                    error!("error sending the message to session {}: {}", id, e);
-                    ServiceError::SessionError(e.to_string())
-                }),
+        // save session id for later use
+        match info {
+            Some(info) => {
+                let id = info.id;
+                session
+                    .handle_message(SessionMessage::from((msg, info)), MessageDirection::South)
+                    .await
+                    .map_err(|e| {
+                        error!("error sending the message to session {}: {}", id, e);
+                        ServiceError::SessionError(e.to_string())
+                    })
+            }
             None => session.tx_gw().send(Ok(msg)).await.map_err(|e| {
                 error!("error sending the subscription {}", e);
                 ServiceError::SubscriptionError(e.to_string())
@@ -386,7 +391,7 @@ impl Service {
         debug!("subscribe to {}/{:?}", agent_type, agent_id);
 
         let msg = utils::create_subscription(local_agent, agent_type, agent_id, None, conn);
-        self.send_message(local_agent, None, msg).await
+        self.send_message(local_agent, msg, None).await
     }
 
     pub async fn unsubscribe(
@@ -399,7 +404,7 @@ impl Service {
         debug!("unsubscribe from {}/{:?}", agent_type, agent_id);
 
         let msg = utils::create_unsubscription(local_agent, agent_type, agent_id, None, conn);
-        self.send_message(local_agent, None, msg).await
+        self.send_message(local_agent, msg, None).await
     }
 
     pub async fn set_route(
@@ -413,7 +418,7 @@ impl Service {
 
         // send a message with subscription from
         let msg = utils::create_subscription(local_agent, agent_type, agent_id, Some(conn), None);
-        self.send_message(local_agent, None, msg).await
+        self.send_message(local_agent, msg, None).await
     }
 
     pub async fn remove_route(
@@ -427,27 +432,35 @@ impl Service {
 
         //  send a message with unsubscription from
         let msg = utils::create_unsubscription(local_agent, agent_type, agent_id, Some(conn), None);
-        self.send_message(local_agent, None, msg).await
+        self.send_message(local_agent, msg, None).await
     }
 
     pub async fn publish(
         &self,
         source: &Agent,
-        session_id: session::Id,
+        session_info: session::Info,
         agent_type: &AgentType,
         agent_id: Option<u64>,
         fanout: u32,
         blob: Vec<u8>,
     ) -> Result<(), ServiceError> {
-        self.publish_to(source, session_id, agent_type, agent_id, fanout, blob, None)
-            .await
+        self.publish_to(
+            source,
+            session_info,
+            agent_type,
+            agent_id,
+            fanout,
+            blob,
+            None,
+        )
+        .await
     }
 
     #[allow(clippy::too_many_arguments)]
     pub async fn publish_to(
         &self,
         source: &Agent,
-        session_id: session::Id,
+        session_info: session::Info,
         agent_type: &AgentType,
         agent_id: Option<u64>,
         fanout: u32,
@@ -460,7 +473,7 @@ impl Service {
             source, agent_type, agent_id, None, out_conn, fanout, "msg", blob,
         );
 
-        self.send_message(source, Some(session_id), msg).await
+        self.send_message(source, msg, Some(session_info)).await
     }
 
     /// Receive messages from gateway and forward them to the appropriate session
@@ -480,7 +493,7 @@ impl Service {
             let subscribe_msg = utils::create_subscription(
                 &agent,
                 agent.agent_type(),
-                Some(*agent.agent_id()),
+                Some(agent.agent_id()),
                 None,
                 None,
             );
@@ -515,7 +528,7 @@ impl Service {
 
                                         // Handle the message
                                         let res = session_layer
-                                            .handle_message(msg, MessageDirection::North, None)
+                                            .handle_message(SessionMessage::from(msg), MessageDirection::North)
                                             .await;
 
                                         if let Err(e) = res {
@@ -543,7 +556,7 @@ impl Service {
         &self,
         agent: &Agent,
         session_config: session::SessionConfig,
-    ) -> Result<session::Id, ServiceError> {
+    ) -> Result<session::Info, ServiceError> {
         // check if agent was registered
         let layer = self.session_layers.get(agent);
 
@@ -583,7 +596,7 @@ impl Service {
 
         // set the session config
         layer
-            .set_session_config(session_id, &session_config)
+            .set_session_config(session_id, session_config)
             .await
             .map_err(|e| {
                 error!("error setting session config: {}", e);
@@ -765,7 +778,7 @@ mod tests {
         // subscription is done automatically.
 
         // create a fire and forget session
-        let session_id = service
+        let session_info = service
             .create_session(
                 &publisher_agent,
                 SessionConfig::FireAndForget(FireAndForgetConfiguration::default()),
@@ -778,9 +791,9 @@ mod tests {
         service
             .publish(
                 &publisher_agent,
-                session_id,
+                session_info.clone(),
                 &subscriber_agent.agent_type(),
-                Some(*subscriber_agent.agent_id()),
+                Some(subscriber_agent.agent_id()),
                 1,
                 message_blob.clone(),
             )
@@ -788,15 +801,15 @@ mod tests {
             .unwrap();
 
         // wait for the message to arrive
-        let (msg, info) = sub_rx
+        let msg = sub_rx
             .recv()
             .await
             .expect("no message received")
             .expect("error");
 
         // make sure message is a publication
-        assert!(msg.message_type.is_some());
-        let publ = match msg.message_type.unwrap() {
+        assert!(msg.message.message_type.is_some());
+        let publ = match msg.message.message_type.unwrap() {
             MessageType::Publish(p) => p,
             _ => panic!("expected a publication"),
         };
@@ -805,15 +818,15 @@ mod tests {
         assert_eq!(utils::get_payload(&publ), message_blob);
 
         // make also sure the session ids correspond
-        assert_eq!(session_id, info.id);
+        assert_eq!(session_info.id, msg.info.id);
 
         // Now remove the session from the 2 agents
         service
-            .delete_session(&publisher_agent, session_id)
+            .delete_session(&publisher_agent, session_info.id)
             .await
             .unwrap();
         service
-            .delete_session(&subscriber_agent, session_id)
+            .delete_session(&subscriber_agent, session_info.id)
             .await
             .unwrap();
 

--- a/data-plane/gateway/service/src/request_response.rs
+++ b/data-plane/gateway/service/src/request_response.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
+use std::num::TryFromIntError;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -119,8 +120,31 @@ impl RequestResponse {
         // get message id
         let message_id = message.info.message_id.expect("message id not found");
 
+        // get session config
+        let session_config = match self.session_config() {
+            SessionConfig::RequestResponse(config) => config,
+            _ => {
+                return Err(SessionError::AppTransmission(
+                    "invalid session config".to_string(),
+                ))
+            }
+        };
+
+        // get duration from configuration
+        let duration =
+            session_config
+                .timeout
+                .as_millis()
+                .try_into()
+                .map_err(|e: TryFromIntError| {
+                    SessionError::ConfigurationError(format!(
+                        "timeout duration is too large: {}",
+                        e
+                    ))
+                })?;
+
         // create new timer
-        let timer = timer::Timer::new(message_id, 1000, 0);
+        let timer = timer::Timer::new(message_id, duration, session_config.max_retries);
 
         // send message
         self.internal

--- a/data-plane/gateway/service/src/request_response.rs
+++ b/data-plane/gateway/service/src/request_response.rs
@@ -1,0 +1,318 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+use core::fmt;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use parking_lot::RwLock;
+use rand::Rng;
+use tracing::{debug, warn};
+
+use crate::errors::SessionError;
+use crate::session::{AppChannelSender, GwChannelSender, SessionConfig};
+use crate::session::{
+    Common, CommonSession, Id, Info, MessageDirection, Session, SessionDirection, State,
+};
+use crate::timer;
+use agp_datapath::messages::utils;
+use agp_datapath::pubsub::proto::pubsub::v1::Message;
+use agp_datapath::pubsub::proto::pubsub::v1::SessionHeaderType;
+
+/// Configuration for the Request Response session
+/// This configuration is used to set the maximum number of retries and the timeout
+#[derive(Debug, Clone, PartialEq)]
+pub struct RequestResponseConfiguration {
+    pub max_retries: u32,
+    pub timeout: std::time::Duration,
+}
+
+impl Default for RequestResponseConfiguration {
+    fn default() -> Self {
+        RequestResponseConfiguration {
+            max_retries: 0,
+            timeout: std::time::Duration::from_millis(1000),
+        }
+    }
+}
+
+impl std::fmt::Display for RequestResponseConfiguration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "RequestResponseConfiguration: max_retries: {}, timeout: {} ms",
+            self.max_retries,
+            self.timeout.as_millis()
+        )
+    }
+}
+
+/// Internal state of the Request Response session
+struct RequestResponseInternal {
+    common: Common,
+    timers: RwLock<HashMap<u32, (timer::Timer, Message)>>,
+}
+
+#[async_trait]
+impl timer::TimerObserver for RequestResponseInternal {
+    async fn on_timeout(&self, _message_id: u32, _timeouts: u32) {
+        panic!("this should never happen");
+    }
+
+    async fn on_failure(&self, message_id: u32, timeouts: u32) {
+        debug_assert!(timeouts == 1);
+
+        // get message
+        let (_timer, message) = self
+            .timers
+            .write()
+            .remove(&message_id)
+            .expect("timer not found");
+
+        let _ = self
+            .common
+            .tx_app_ref()
+            .send(Err(SessionError::Timeout {
+                error: message_id.to_string(),
+                message,
+            }))
+            .await
+            .map_err(|e| SessionError::AppTransmission(e.to_string()));
+    }
+
+    async fn on_stop(&self, message_id: u32) {
+        debug!("timer stopped: {}", message_id);
+    }
+}
+
+/// Request Response session
+pub(crate) struct RequestResponse {
+    internal: Arc<RequestResponseInternal>,
+}
+
+impl RequestResponse {
+    pub(crate) fn new(
+        id: Id,
+        session_config: RequestResponseConfiguration,
+        session_direction: SessionDirection,
+        tx_gw: GwChannelSender,
+        tx_app: AppChannelSender,
+    ) -> RequestResponse {
+        let internal = RequestResponseInternal {
+            common: Common::new(
+                id,
+                session_direction,
+                SessionConfig::RequestResponse(session_config),
+                tx_gw,
+                tx_app,
+            ),
+            timers: RwLock::new(HashMap::new()),
+        };
+
+        RequestResponse {
+            internal: Arc::new(internal),
+        }
+    }
+
+    pub(crate) async fn send_message_with_timer(
+        &self,
+        message: Message,
+        message_id: u32,
+    ) -> Result<(), SessionError> {
+        // create new timer
+        let timer = timer::Timer::new(message_id, 1000, 0);
+
+        // send message
+        self.internal
+            .common
+            .tx_gw_ref()
+            .send(Ok(message.clone()))
+            .await
+            .map_err(|e| SessionError::GatewayTransmission(e.to_string()))?;
+
+        // start timer
+        timer.start(self.internal.clone());
+
+        // store timer and message
+        self.internal
+            .timers
+            .write()
+            .insert(message_id, (timer, message));
+
+        // we are good
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Session for RequestResponse {
+    async fn on_message(
+        &self,
+        mut message: Message,
+        direction: MessageDirection,
+    ) -> Result<(), SessionError> {
+        // set the session type
+        let header = utils::get_session_header_as_mut(&mut message);
+        if header.is_none() {
+            return Err(SessionError::AppTransmission("missing header".to_string()));
+        }
+
+        let header = header.unwrap();
+
+        // clone tx
+        match direction {
+            MessageDirection::North => {
+                // message for the app - check if request or response
+                let session_type = match utils::int_to_service_type(header.header_type) {
+                    Some(t) => t,
+                    None => Err(SessionError::AppTransmission(
+                        "unknown session type".to_string(),
+                    ))?,
+                };
+
+                match session_type {
+                    SessionHeaderType::Reply => {
+                        // this is a reply - remove the timer
+                        let message_id = header.message_id;
+                        match self.internal.timers.write().remove(&message_id) {
+                            Some((timer, _message)) => {
+                                // stop the timer
+                                timer.stop();
+                            }
+                            None => {
+                                return Err(SessionError::AppTransmission(format!(
+                                    "timer not found for message id {}",
+                                    message_id
+                                )))
+                            }
+                        }
+                    }
+                    SessionHeaderType::Request => {
+                        // this is a request - send it to app
+                    }
+                    _ => Err(SessionError::AppTransmission(format!(
+                        "request/reply session: unsupported session type: {:?}",
+                        session_type
+                    )))?,
+                }
+
+                // create info
+                let info = Info::new(self.id(), self.state().clone());
+
+                self.internal
+                    .common
+                    .tx_app_ref()
+                    .send(Ok((message, info)))
+                    .await
+                    .map_err(|e| SessionError::AppTransmission(e.to_string()))
+            }
+            MessageDirection::South => {
+                // Send message with timer
+                let message_id = rand::rng().random();
+                header.message_id = message_id;
+
+                self.send_message_with_timer(message, message_id).await
+            }
+        }
+    }
+}
+
+delegate_common_behavior!(RequestResponse, internal, common);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use agp_datapath::messages::encoder;
+
+    #[tokio::test]
+    async fn test_rr_create() {
+        let (tx_gw, _) = tokio::sync::mpsc::channel(1);
+        let (tx_app, _) = tokio::sync::mpsc::channel(1);
+
+        let session_config = RequestResponseConfiguration {
+            max_retries: 0,
+            timeout: std::time::Duration::from_millis(1000),
+        };
+
+        let session = RequestResponse::new(
+            0,
+            session_config.clone(),
+            SessionDirection::Bidirectional,
+            tx_gw,
+            tx_app,
+        );
+
+        assert_eq!(session.id(), 0);
+        assert_eq!(session.state(), &State::Active);
+        assert_eq!(
+            session.session_config(),
+            SessionConfig::RequestResponse(session_config)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fire_and_forget_on_message() {
+        let (tx_gw, _rx_gw) = tokio::sync::mpsc::channel(1);
+        let (tx_app, mut rx_app) = tokio::sync::mpsc::channel(1);
+
+        let session_config = RequestResponseConfiguration {
+            max_retries: 0,
+            timeout: std::time::Duration::from_millis(1000),
+        };
+
+        let session = RequestResponse::new(
+            0,
+            session_config,
+            SessionDirection::Bidirectional,
+            tx_gw,
+            tx_app,
+        );
+
+        let payload = vec![0x1, 0x2, 0x3, 0x4];
+
+        let mut msg = utils::create_publication(
+            &encoder::encode_agent("cisco", "default", "local_agent", 0),
+            &encoder::encode_agent_type("cisco", "default", "remote_agent"),
+            Some(0),
+            None,
+            None,
+            1,
+            "msg",
+            payload.clone(),
+        );
+
+        // set the session id in the message
+        let header = utils::get_session_header_as_mut(&mut msg).unwrap();
+        header.session_id = 1;
+
+        // Send a message to the underlying gateway
+        let res = session
+            .on_message(msg.clone(), MessageDirection::South)
+            .await;
+        assert!(res.is_ok());
+
+        // we will wait for a response, but as no one is reply, we will get a timeout
+        let res = rx_app.recv().await.expect("no message received");
+        assert!(res.is_err());
+
+        // We also should get the message back in the error
+        let err = res.unwrap_err();
+        match err {
+            SessionError::Timeout {
+                error: _error,
+                message,
+            } => {
+                let blob = utils::get_message_as_publish(&message)
+                    .expect("error getting message")
+                    .msg
+                    .as_ref()
+                    .expect("error getting message")
+                    .blob
+                    .clone();
+                assert_eq!(blob, payload);
+            }
+            _ => panic!("unexpected error"),
+        }
+    }
+}

--- a/data-plane/gateway/service/src/session.rs
+++ b/data-plane/gateway/service/src/session.rs
@@ -2,62 +2,58 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
-use thiserror::Error;
+use parking_lot::RwLock;
 use tonic::Status;
 
+use crate::errors::SessionError;
+use crate::fire_and_forget::FireAndForgetConfiguration;
+use crate::request_response::RequestResponseConfiguration;
+use agp_datapath::messages::encoder::Agent;
+use agp_datapath::messages::utils;
 use agp_datapath::pubsub::proto::pubsub::v1::Message;
-
-#[derive(Error, Debug)]
-pub(crate) enum Error {
-    #[error("error receiving message from gateway {0}")]
-    #[allow(dead_code)]
-    GatewayReception(String),
-    #[error("error sending message to gateway {0}")]
-    GatewayTransmission(String),
-    #[error("error receiving message from app {0}")]
-    #[allow(dead_code)]
-    AppReception(String),
-    #[error("error sending message to app {0}")]
-    AppTransmission(String),
-    #[error("error processing message {0}")]
-    #[allow(dead_code)]
-    Processing(String),
-    #[error("session id already used {0}")]
-    SessionIdAlreadyUsed(String),
-    #[error("missing AGP header {0}")]
-    MissingAgpHeader(String),
-    #[error("missing session header")]
-    MissingSessionHeader,
-    #[error("session unknown: {0}")]
-    SessionUnknown(String),
-    #[error("session not found: {0}")]
-    SessionNotFound(String),
-    #[error("missing session id: {0}")]
-    MissingSessionId(String),
-}
 
 /// Session ID
 pub type Id = u32;
 
+/// Channel used in the path service -> app
+pub type AppChannelSender = tokio::sync::mpsc::Sender<Result<(Message, Info), SessionError>>;
+/// Channel used in the path app -> service
+pub type AppChannelReceiver = tokio::sync::mpsc::Receiver<Result<(Message, Info), SessionError>>;
+/// Channel used in the path service -> gw
+pub type GwChannelSender = tokio::sync::mpsc::Sender<Result<Message, Status>>;
+/// Channel used in the path gw -> service
+pub type GwChannelReceiver = tokio::sync::mpsc::Receiver<Result<Message, Status>>;
+
 /// Session Info
 #[derive(Clone, PartialEq, Debug)]
 pub struct Info {
+    /// The id of the session
     pub id: Id,
-    pub session_type: SessionType,
-    pub state: State,
-
-    pub message_nonce: u32,
-    pub message_count: u32,
+    /// The message nonce used to identify the message
+    pub message_id: u32,
+    /// The identifier of the agent that sent the message
+    pub message_source: Agent,
+    /// The input connection id
+    pub input_connection: u64,
 }
 
-impl Info {
-    pub fn new(id: Id, session_type: SessionType, state: State) -> Info {
+impl From<&Message> for Info {
+    fn from(message: &Message) -> Self {
+        let session_header = utils::get_session_header(&message).expect("session header not found");
+        let agp_header = utils::get_agp_header(&message).expect("AGP header not found");
+
+        let id = session_header.session_id;
+        let message_id = session_header.message_id;
+        let message_source = utils::get_source(&msg);
+        let input_connection = agp_header
+            .incoming_conn
+            .expect("input connection not found");
+
         Info {
             id,
-            session_type,
-            state,
-            message_nonce: 0,
-            message_count: 0,
+            message_id,
+            message_source,
+            input_connection,
         }
     }
 }
@@ -86,26 +82,21 @@ pub(crate) enum MessageDirection {
 }
 
 #[derive(Clone, PartialEq, Debug)]
-pub enum SessionType {
-    FireAndForget,
-    RequestResponse,
-    PublishSubscribe,
-    Streaming,
+pub enum SessionConfig {
+    FireAndForget(FireAndForgetConfiguration),
+    RequestResponse(RequestResponseConfiguration),
 }
 
-impl std::fmt::Display for SessionType {
+impl std::fmt::Display for SessionConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            SessionType::FireAndForget => write!(f, "FireAndForget"),
-            SessionType::RequestResponse => write!(f, "RequestResponse"),
-            SessionType::PublishSubscribe => write!(f, "PublishSubscribe"),
-            SessionType::Streaming => write!(f, "Streaming"),
+            SessionConfig::FireAndForget(ff) => write!(f, "{}", ff),
+            SessionConfig::RequestResponse(rr) => write!(f, "{}", rr),
         }
     }
 }
 
-#[async_trait]
-pub(crate) trait Session {
+pub(crate) trait CommonSession {
     // Session ID
     #[allow(dead_code)]
     fn id(&self) -> Id;
@@ -114,12 +105,23 @@ pub(crate) trait Session {
     #[allow(dead_code)]
     fn state(&self) -> &State;
 
-    // get the session type
+    // get the session config
     #[allow(dead_code)]
-    fn session_type(&self) -> SessionType;
+    fn session_config(&self) -> SessionConfig;
 
+    // set the session config
+    #[allow(dead_code)]
+    fn set_session_config(&self, session_config: &SessionConfig) -> Result<(), SessionError>;
+}
+
+#[async_trait]
+pub(crate) trait Session: CommonSession {
     // publish a message as part of the session
-    async fn on_message(&self, message: Message, direction: MessageDirection) -> Result<(), Error>;
+    async fn on_message(
+        &self,
+        message: Message,
+        direction: MessageDirection,
+    ) -> Result<(), SessionError>;
 }
 
 /// Common session data
@@ -130,58 +132,98 @@ pub(crate) struct Common {
     /// Session state
     state: State,
 
+    /// Session type
+    session_config: RwLock<SessionConfig>,
+
     /// Session direction
     #[allow(dead_code)]
     session_direction: SessionDirection,
 
     /// Sender for messages to gw
-    tx_gw: tokio::sync::mpsc::Sender<Result<Message, Status>>,
+    tx_gw: GwChannelSender,
 
     /// Sender for messages to app
-    tx_app: tokio::sync::mpsc::Sender<(Message, Info)>,
+    tx_app: AppChannelSender,
+}
+
+impl CommonSession for Common {
+    fn id(&self) -> Id {
+        self.id
+    }
+
+    fn state(&self) -> &State {
+        &self.state
+    }
+
+    fn session_config(&self) -> SessionConfig {
+        self.session_config.read().clone()
+    }
+
+    fn set_session_config(&self, session_config: &SessionConfig) -> Result<(), SessionError> {
+        let mut conf = self.session_config.write();
+
+        *conf = session_config.clone();
+        Ok(())
+    }
 }
 
 impl Common {
     pub(crate) fn new(
         id: Id,
         session_direction: SessionDirection,
-        tx_gw: tokio::sync::mpsc::Sender<Result<Message, Status>>,
-        tx_app: tokio::sync::mpsc::Sender<(Message, Info)>,
+        session_type: SessionConfig,
+        tx_gw: GwChannelSender,
+        tx_app: AppChannelSender,
     ) -> Common {
         Common {
             id,
             state: State::Active,
             session_direction,
+            session_config: RwLock::new(session_type),
             tx_gw,
             tx_app,
         }
     }
 
-    /// get the session ID
-    pub(crate) fn id(&self) -> Id {
-        self.id
-    }
-
-    /// get the session state
-    pub(crate) fn state(&self) -> &State {
-        &self.state
-    }
-
     #[allow(dead_code)]
-    pub(crate) fn tx_gw(&self) -> tokio::sync::mpsc::Sender<Result<Message, Status>> {
+    pub(crate) fn tx_gw(&self) -> GwChannelSender {
         self.tx_gw.clone()
     }
 
+    pub(crate) fn tx_gw_ref(&self) -> &GwChannelSender {
+        &self.tx_gw
+    }
+
     #[allow(dead_code)]
-    pub(crate) fn tx_app(&self) -> tokio::sync::mpsc::Sender<(Message, Info)> {
+    pub(crate) fn tx_app(&self) -> AppChannelSender {
         self.tx_app.clone()
     }
 
-    pub(crate) fn tx_app_ref(&self) -> &tokio::sync::mpsc::Sender<(Message, Info)> {
+    pub(crate) fn tx_app_ref(&self) -> &AppChannelSender {
         &self.tx_app
     }
+}
 
-    pub(crate) fn tx_gw_ref(&self) -> &tokio::sync::mpsc::Sender<Result<Message, Status>> {
-        &self.tx_gw
-    }
+// Define a macro to delegate trait implementation
+macro_rules! delegate_common_behavior {
+    ($parent:ident, $($tokens:ident),+) => {
+        impl CommonSession for $parent {
+            fn id(&self) -> Id {
+                // concat the token stream
+                self.$($tokens).+.id()
+            }
+
+            fn state(&self) -> &State {
+                self.$($tokens).+.state()
+            }
+
+            fn session_config(&self) -> SessionConfig {
+                self.$($tokens).+.session_config()
+            }
+
+            fn set_session_config(&self, session_config: &SessionConfig) -> Result<(), SessionError> {
+                self.$($tokens).+.set_session_config(session_config)
+            }
+        }
+    };
 }

--- a/data-plane/gateway/service/src/session.rs
+++ b/data-plane/gateway/service/src/session.rs
@@ -44,7 +44,7 @@ impl From<&Message> for Info {
 
         let id = session_header.session_id;
         let message_id = session_header.message_id;
-        let message_source = utils::get_source(&msg);
+        let message_source = utils::get_source(&message).expect("message source not found");
         let input_connection = agp_header
             .incoming_conn
             .expect("input connection not found");

--- a/data-plane/gateway/service/src/session.rs
+++ b/data-plane/gateway/service/src/session.rs
@@ -15,10 +15,48 @@ use agp_datapath::pubsub::proto::pubsub::v1::Message;
 /// Session ID
 pub type Id = u32;
 
+/// Message wrapper
+#[derive(Clone, PartialEq, Debug)]
+pub struct SessionMessage {
+    /// The message to be sent
+    pub message: Message,
+    /// The optional session info
+    pub info: Info,
+}
+
+impl SessionMessage {
+    /// Create a new session message
+    pub fn new(message: Message, info: Info) -> Self {
+        SessionMessage { message, info }
+    }
+}
+
+impl From<(Message, Info)> for SessionMessage {
+    fn from(tuple: (Message, Info)) -> Self {
+        SessionMessage {
+            message: tuple.0,
+            info: tuple.1,
+        }
+    }
+}
+
+impl From<Message> for SessionMessage {
+    fn from(message: Message) -> Self {
+        let info = Info::from(&message);
+        SessionMessage { message, info }
+    }
+}
+
+impl From<SessionMessage> for Message {
+    fn from(session_message: SessionMessage) -> Self {
+        session_message.message
+    }
+}
+
 /// Channel used in the path service -> app
-pub type AppChannelSender = tokio::sync::mpsc::Sender<Result<(Message, Info), SessionError>>;
+pub type AppChannelSender = tokio::sync::mpsc::Sender<Result<SessionMessage, SessionError>>;
 /// Channel used in the path app -> service
-pub type AppChannelReceiver = tokio::sync::mpsc::Receiver<Result<(Message, Info), SessionError>>;
+pub type AppChannelReceiver = tokio::sync::mpsc::Receiver<Result<SessionMessage, SessionError>>;
 /// Channel used in the path service -> gw
 pub type GwChannelSender = tokio::sync::mpsc::Sender<Result<Message, Status>>;
 /// Channel used in the path gw -> service
@@ -30,29 +68,39 @@ pub struct Info {
     /// The id of the session
     pub id: Id,
     /// The message nonce used to identify the message
-    pub message_id: u32,
+    pub message_id: Option<u32>,
     /// The identifier of the agent that sent the message
-    pub message_source: Agent,
+    pub message_source: Option<Agent>,
     /// The input connection id
-    pub input_connection: u64,
+    pub input_connection: Option<u64>,
+}
+
+impl Info {
+    /// Create a new session info
+    pub fn new(id: Id) -> Self {
+        Info {
+            id,
+            message_id: None,
+            message_source: None,
+            input_connection: None,
+        }
+    }
 }
 
 impl From<&Message> for Info {
     fn from(message: &Message) -> Self {
-        let session_header = utils::get_session_header(&message).expect("session header not found");
-        let agp_header = utils::get_agp_header(&message).expect("AGP header not found");
+        let session_header = utils::get_session_header(message).expect("session header not found");
+        let agp_header = utils::get_agp_header(message).expect("AGP header not found");
 
         let id = session_header.session_id;
         let message_id = session_header.message_id;
-        let message_source = utils::get_source(&message).expect("message source not found");
-        let input_connection = agp_header
-            .incoming_conn
-            .expect("input connection not found");
+        let message_source = utils::get_source(message).expect("message source not found");
+        let input_connection = agp_header.incoming_conn;
 
         Info {
             id,
-            message_id,
-            message_source,
+            message_id: Some(message_id),
+            message_source: Some(message_source),
             input_connection,
         }
     }
@@ -119,7 +167,7 @@ pub(crate) trait Session: CommonSession {
     // publish a message as part of the session
     async fn on_message(
         &self,
-        message: Message,
+        message: SessionMessage,
         direction: MessageDirection,
     ) -> Result<(), SessionError>;
 }
@@ -127,9 +175,11 @@ pub(crate) trait Session: CommonSession {
 /// Common session data
 pub(crate) struct Common {
     /// Session ID - unique identifier for the session
+    #[allow(dead_code)]
     id: Id,
 
     /// Session state
+    #[allow(dead_code)]
     state: State,
 
     /// Session type

--- a/data-plane/gateway/service/src/session.rs
+++ b/data-plane/gateway/service/src/session.rs
@@ -1,9 +1,7 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
-use std::future::Future;
-use std::pin::Pin;
-
+use async_trait::async_trait;
 use thiserror::Error;
 use tonic::Status;
 
@@ -106,6 +104,7 @@ impl std::fmt::Display for SessionType {
     }
 }
 
+#[async_trait]
 pub(crate) trait Session {
     // Session ID
     #[allow(dead_code)]
@@ -120,11 +119,7 @@ pub(crate) trait Session {
     fn session_type(&self) -> SessionType;
 
     // publish a message as part of the session
-    fn on_message(
-        &self,
-        message: Message,
-        direction: MessageDirection,
-    ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'static>>;
+    async fn on_message(&self, message: Message, direction: MessageDirection) -> Result<(), Error>;
 }
 
 /// Common session data
@@ -172,11 +167,21 @@ impl Common {
         &self.state
     }
 
+    #[allow(dead_code)]
     pub(crate) fn tx_gw(&self) -> tokio::sync::mpsc::Sender<Result<Message, Status>> {
         self.tx_gw.clone()
     }
 
+    #[allow(dead_code)]
     pub(crate) fn tx_app(&self) -> tokio::sync::mpsc::Sender<(Message, Info)> {
         self.tx_app.clone()
+    }
+
+    pub(crate) fn tx_app_ref(&self) -> &tokio::sync::mpsc::Sender<(Message, Info)> {
+        &self.tx_app
+    }
+
+    pub(crate) fn tx_gw_ref(&self) -> &tokio::sync::mpsc::Sender<Result<Message, Status>> {
+        &self.tx_gw
     }
 }

--- a/data-plane/gateway/service/src/timer.rs
+++ b/data-plane/gateway/service/src/timer.rs
@@ -23,7 +23,7 @@ pub struct Timer {
 
 #[allow(dead_code)]
 impl Timer {
-    fn new(timer_id: u32, duration: u32, max_retries: u32) -> Self {
+    pub fn new(timer_id: u32, duration: u32, max_retries: u32) -> Self {
         Timer {
             timer_id,
             duration,
@@ -32,7 +32,7 @@ impl Timer {
         }
     }
 
-    fn start<T: TimerObserver + Send + Sync + 'static>(&self, observer: Arc<T>) {
+    pub fn start<T: TimerObserver + Send + Sync + 'static>(&self, observer: Arc<T>) {
         let timer_id = self.timer_id;
         let duration = self.duration;
         let max_retries = self.max_retries;
@@ -66,7 +66,7 @@ impl Timer {
         });
     }
 
-    fn stop(&self) {
+    pub fn stop(&self) {
         self.cancellation_token.cancel();
     }
 }

--- a/data-plane/python-bindings/agp_bindings/__init__.py
+++ b/data-plane/python-bindings/agp_bindings/__init__.py
@@ -6,10 +6,10 @@ from typing import Optional, Tuple
 from ._agp_bindings import (
     PyGatewayConfig as GatewayConfig,
     PyService,
-    PyAgentClass,
-    PySessionType,
+    PyAgentType,
     PySessionInfo,
-    create_session,
+    PyFireAndForgetConfiguration,
+    create_ff_session,
     create_agent,
     connect,
     disconnect,
@@ -72,7 +72,9 @@ class Gateway:
 
         return await create_agent(self.svc, organization, namespace, agent, id)
 
-    async def create_session(self, session_type: PySessionType) -> int:
+    async def create_ff_session(
+        self, session_config: PyFireAndForgetConfiguration
+    ) -> int:
         """
         Create a new session.
 
@@ -83,7 +85,7 @@ class Gateway:
             ID of the session
         """
 
-        return await create_session(self.svc, session_type)
+        return await create_ff_session(self.svc, session_config)
 
     async def serve(self):
         """
@@ -153,7 +155,7 @@ class Gateway:
             None
         """
 
-        name = PyAgentClass(organization, namespace, agent)
+        name = PyAgentType(organization, namespace, agent)
         await set_route(self.svc, self.conn_id, name, id)
 
     async def remove_route(
@@ -171,7 +173,7 @@ class Gateway:
             None
         """
 
-        name = PyAgentClass(organization, namespace, agent)
+        name = PyAgentType(organization, namespace, agent)
         await remove_route(self.svc, self.conn_id, name, id)
 
     async def subscribe(self, organization, namespace, agent, id=None):
@@ -188,7 +190,7 @@ class Gateway:
             None
         """
 
-        sub = PyAgentClass(organization, namespace, agent)
+        sub = PyAgentType(organization, namespace, agent)
         await subscribe(self.svc, self.conn_id, sub, id)
 
     async def unsubscribe(self, organization, namespace, agent, id=None):
@@ -204,7 +206,7 @@ class Gateway:
         Returns:
             None
         """
-        unsub = PyAgentClass(organization, namespace, agent)
+        unsub = PyAgentType(organization, namespace, agent)
         await unsubscribe(self.svc, self.conn_id, unsub, id)
 
     async def publish(self, session, msg, organization, namespace, agent):
@@ -221,10 +223,10 @@ class Gateway:
             None
         """
 
-        dest = PyAgentClass(organization, namespace, agent)
+        dest = PyAgentType(organization, namespace, agent)
         await publish(self.svc, session, 1, msg, dest, None)
 
-    async def publish_to(self, session, msg, agent):
+    async def publish_to(self, session, msg):
         """
         Publish a message to an agent via the connected gateway.
 
@@ -236,9 +238,9 @@ class Gateway:
             None
         """
 
-        await publish(self.svc, session, 1, msg, agent=agent)
+        await publish(self.svc, session, 1, msg)
 
-    async def receive(self) -> Tuple[PySessionInfo, any, bytes]:
+    async def receive(self) -> Tuple[PySessionInfo, bytes]:
         """
         Receive a message from the connected gateway.
 

--- a/data-plane/python-bindings/agp_bindings/_agp_bindings.pyi
+++ b/data-plane/python-bindings/agp_bindings/_agp_bindings.pyi
@@ -5,7 +5,7 @@ import builtins
 import typing
 from enum import Enum, auto
 
-class PyAgentClass:
+class PyAgentType:
     r"""
     agent class
     """
@@ -64,24 +64,24 @@ def create_session(svc:PyService, session_type:PySessionType) -> typing.Any:
 def disconnect(svc:PyService, conn:builtins.int) -> typing.Any:
     ...
 
-def publish(svc:PyService, session_id:builtins.int, fanout:builtins.int, blob:typing.Sequence[builtins.int], name:typing.Optional[PyAgentClass]=None, id:typing.Optional[builtins.int]=None, agent:typing.Optional[PyAgentSource]=None) -> typing.Any:
+def publish(svc:PyService, session_id:builtins.int, fanout:builtins.int, blob:typing.Sequence[builtins.int], name:typing.Optional[PyAgentType]=None, id:typing.Optional[builtins.int]=None, agent:typing.Optional[PyAgentSource]=None) -> typing.Any:
     ...
 
 def receive(svc:PyService) -> typing.Any:
     ...
 
-def remove_route(svc:PyService, conn:builtins.int, name:PyAgentClass, id:typing.Optional[builtins.int]=None) -> typing.Any:
+def remove_route(svc:PyService, conn:builtins.int, name:PyAgentType, id:typing.Optional[builtins.int]=None) -> typing.Any:
     ...
 
 def serve(svc:PyService) -> typing.Any:
     ...
 
-def set_route(svc:PyService, conn:builtins.int, name:PyAgentClass, id:typing.Optional[builtins.int]=None) -> typing.Any:
+def set_route(svc:PyService, conn:builtins.int, name:PyAgentType, id:typing.Optional[builtins.int]=None) -> typing.Any:
     ...
 
-def subscribe(svc:PyService, conn:builtins.int, name:PyAgentClass, id:typing.Optional[builtins.int]=None) -> typing.Any:
+def subscribe(svc:PyService, conn:builtins.int, name:PyAgentType, id:typing.Optional[builtins.int]=None) -> typing.Any:
     ...
 
-def unsubscribe(svc:PyService, conn:builtins.int, name:PyAgentClass, id:typing.Optional[builtins.int]=None) -> typing.Any:
+def unsubscribe(svc:PyService, conn:builtins.int, name:PyAgentType, id:typing.Optional[builtins.int]=None) -> typing.Any:
     ...
 

--- a/data-plane/python-bindings/src/lib.rs
+++ b/data-plane/python-bindings/src/lib.rs
@@ -335,13 +335,13 @@ enum PySessionType {
     Streaming,
 }
 
-impl From<PySessionType> for session::SessionType {
+impl From<PySessionType> for session::SessionConfig {
     fn from(session_type: PySessionType) -> Self {
         match session_type {
-            PySessionType::FireAndForget => session::SessionType::FireAndForget,
-            PySessionType::RequestResponse => session::SessionType::RequestResponse,
-            PySessionType::PublishSubscribe => session::SessionType::PublishSubscribe,
-            PySessionType::Streaming => session::SessionType::Streaming,
+            PySessionType::FireAndForget => session::SessionConfig::FireAndForget,
+            PySessionType::RequestResponse => session::SessionConfig::RequestResponse,
+            PySessionType::PublishSubscribe => session::SessionConfig::PublishSubscribe,
+            PySessionType::Streaming => session::SessionConfig::Streaming,
         }
     }
 }
@@ -455,7 +455,7 @@ async fn create_session_impl(
     // create local agent
     let service = svc.sdk.write().await;
 
-    let session_type: session::SessionType = session_type.into();
+    let session_type: session::SessionConfig = session_type.into();
 
     match &service.agent {
         Some(agent) => service.service.create_session(agent, session_type).await,

--- a/data-plane/python-bindings/tests/test_bindings.py
+++ b/data-plane/python-bindings/tests/test_bindings.py
@@ -26,70 +26,70 @@ async def server():
     await asyncio.sleep(1)
 
 
-# @pytest.mark.asyncio
-# async def test_end_to_end(server):
-#     # create 2 clients, Alice and Bob
-#     svc_alice = agp_bindings.PyService("gateway/alice")
-#     svc_alice.configure(agp_bindings.GatewayConfig(endpoint="http://127.0.0.1:12345"))
+@pytest.mark.asyncio
+async def test_end_to_end(server):
+    # create 2 clients, Alice and Bob
+    svc_alice = agp_bindings.PyService("gateway/alice")
+    svc_alice.configure(agp_bindings.GatewayConfig(endpoint="http://127.0.0.1:12345"))
 
-#     svc_bob = agp_bindings.PyService("gateway/bob")
-#     svc_bob.configure(agp_bindings.GatewayConfig(endpoint="http://127.0.0.1:12345"))
+    svc_bob = agp_bindings.PyService("gateway/bob")
+    svc_bob.configure(agp_bindings.GatewayConfig(endpoint="http://127.0.0.1:12345"))
 
-#     # connect to the gateway server
-#     await agp_bindings.create_agent(svc_alice, "cisco", "default", "alice", 1234)
-#     await agp_bindings.create_agent(svc_bob, "cisco", "default", "bob", 1234)
+    # connect to the gateway server
+    await agp_bindings.create_agent(svc_alice, "cisco", "default", "alice", 1234)
+    await agp_bindings.create_agent(svc_bob, "cisco", "default", "bob", 1234)
 
-#     # connect to the service
-#     conn_id_alice = await agp_bindings.connect(svc_alice)
-#     conn_id_bob = await agp_bindings.connect(svc_bob)
+    # connect to the service
+    conn_id_alice = await agp_bindings.connect(svc_alice)
+    conn_id_bob = await agp_bindings.connect(svc_bob)
 
-#     # subscribe alice and bob
-#     alice_class = agp_bindings.PyAgentClass("cisco", "default", "alice")
-#     bob_class = agp_bindings.PyAgentClass("cisco", "default", "bob")
-#     await agp_bindings.subscribe(svc_alice, conn_id_alice, alice_class, 1234)
-#     await agp_bindings.subscribe(svc_bob, conn_id_bob, bob_class, None)
+    # subscribe alice and bob
+    alice_class = agp_bindings.PyAgentType("cisco", "default", "alice")
+    bob_class = agp_bindings.PyAgentType("cisco", "default", "bob")
+    await agp_bindings.subscribe(svc_alice, conn_id_alice, alice_class, 1234)
+    await agp_bindings.subscribe(svc_bob, conn_id_bob, bob_class, None)
 
-#     # set routes
-#     await agp_bindings.set_route(svc_alice, conn_id_alice, bob_class, None)
+    # set routes
+    await agp_bindings.set_route(svc_alice, conn_id_alice, bob_class, None)
 
-#     # create fire and forget session
-#     session_id = await agp_bindings.create_session(
-#         svc_alice, agp_bindings.PySessionType.FireAndForget
-#     )
+    # create fire and forget session
+    session_info = await agp_bindings.create_ff_session(
+        svc_alice, agp_bindings.PyFireAndForgetConfiguration()
+    )
 
-#     # wait for the routes to be set
-#     # TODO remove this sleep
-#     await asyncio.sleep(1)
+    # wait for the routes to be set
+    # TODO remove this sleep
+    await asyncio.sleep(1)
 
-#     # send msg from Alice to Bob
-#     msg = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-#     await agp_bindings.publish(svc_alice, session_id, 1, msg, bob_class, None)
+    # send msg from Alice to Bob
+    msg = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+    await agp_bindings.publish(svc_alice, session_info, 1, msg, bob_class, None)
 
-#     # receive message from Alice
-#     session_info, source, msg_rcv = await agp_bindings.receive(svc_bob)
+    # receive message from Alice
+    session_info_ret, msg_rcv = await agp_bindings.receive(svc_bob)
 
-#     # make seure the session id corresponds
-#     assert session_info.id == session_id
+    # make seure the session id corresponds
+    assert session_info_ret.id == session_info.id
 
-#     # check if the message is correct
-#     assert msg_rcv == bytes(msg)
+    # check if the message is correct
+    assert msg_rcv == bytes(msg)
 
-#     # reply to Alice
-#     await agp_bindings.publish(svc_bob, session_info.id, 1, msg_rcv, agent=source)
+    # reply to Alice
+    await agp_bindings.publish(svc_bob, session_info_ret, 1, msg_rcv)
 
-#     # wait for message
-#     _, source, msg_rcv = await agp_bindings.receive(svc_alice)
+    # wait for message
+    session_info_ret, msg_rcv = await agp_bindings.receive(svc_alice)
 
-#     print(msg_rcv)
+    print(msg_rcv)
 
-#     # check if the message is correct
-#     assert msg_rcv == bytes(msg)
+    # check if the message is correct
+    assert msg_rcv == bytes(msg)
 
-#     # disconnect alice
-#     await agp_bindings.disconnect(svc_alice, conn_id_alice)
+    # disconnect alice
+    await agp_bindings.disconnect(svc_alice, conn_id_alice)
 
-#     # disconnect bob
-#     await agp_bindings.disconnect(svc_bob, conn_id_bob)
+    # disconnect bob
+    await agp_bindings.disconnect(svc_bob, conn_id_bob)
 
 
 @pytest.mark.asyncio
@@ -131,34 +131,37 @@ async def test_gateway_wrapper(server):
     await gateway2.set_route("cisco", "default", agent1)
 
     # create session
-    session_id = await gateway2.create_session(agp_bindings.PySessionType.FireAndForget)
+    session_info = await gateway2.create_ff_session(
+        agp_bindings.PyFireAndForgetConfiguration()
+    )
 
     # TODO remove this sleep
     await asyncio.sleep(1)
 
     # publish message
     msg = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-    await gateway2.publish(session_id, msg, org, ns, agent1)
+    await gateway2.publish(session_info, msg, org, ns, agent1)
 
     await asyncio.sleep(1)
 
     # # receive message
-    session_info, source, msg_rcv = await gateway1.receive()
+    session_info_rec, msg_rcv = await gateway1.receive()
 
     # check if the message is correct
     assert msg_rcv == bytes(msg)
 
     # make sure the session info is correct
-    assert session_info.id == session_id
+    assert session_info.id == session_info_rec.id
 
     # reply to Alice
-    await gateway1.publish_to(session_info.id, msg_rcv, source)
+    await gateway1.publish_to(session_info_rec, msg_rcv)
 
     # wait for message
-    _, source, msg_rcv = await gateway2.receive()
+    _, msg_rcv = await gateway2.receive()
 
     # check if the message is correct
     assert msg_rcv == bytes(msg)
+
 
 @pytest.mark.asyncio
 async def test_auto_reconnect_after_server_restart():
@@ -171,97 +174,96 @@ async def test_auto_reconnect_after_server_restart():
 
     # setup two clients (Alice and Bob)
     svc_alice = agp_bindings.PyService("gateway/alice")
-    svc_alice.configure(agp_bindings.GatewayConfig(
-        endpoint="http://127.0.0.1:12346"
-    ))
+    svc_alice.configure(agp_bindings.GatewayConfig(endpoint="http://127.0.0.1:12346"))
     svc_bob = agp_bindings.PyService("gateway/bob")
-    svc_bob.configure(agp_bindings.GatewayConfig(
-        endpoint="http://127.0.0.1:12346"
-    ))
-    
+    svc_bob.configure(agp_bindings.GatewayConfig(endpoint="http://127.0.0.1:12346"))
+
     # create agents for Alice and Bob
     await agp_bindings.create_agent(svc_alice, "cisco", "default", "alice", 1234)
     await agp_bindings.create_agent(svc_bob, "cisco", "default", "bob", 1234)
-    
+
     # connect clients and subscribe for messages
     conn_id_alice = await agp_bindings.connect(svc_alice)
     conn_id_bob = await agp_bindings.connect(svc_bob)
-    
-    alice_class = agp_bindings.PyAgentClass("cisco", "default", "alice")
-    bob_class = agp_bindings.PyAgentClass("cisco", "default", "bob")
+
+    alice_class = agp_bindings.PyAgentType("cisco", "default", "alice")
+    bob_class = agp_bindings.PyAgentType("cisco", "default", "bob")
     await agp_bindings.subscribe(svc_alice, conn_id_alice, alice_class, 1234)
     await agp_bindings.subscribe(svc_bob, conn_id_bob, bob_class, 1234)
-    
+
     # set routing from Alice to Bob
     await agp_bindings.set_route(svc_alice, conn_id_alice, bob_class, None)
 
     # create fire and forget session
-    session_id = await agp_bindings.create_session(
-        svc_alice, agp_bindings.PySessionType.FireAndForget
+    session_info = await agp_bindings.create_ff_session(
+        svc_alice, agp_bindings.PyFireAndForgetConfiguration()
     )
-    
+
     # verify baseline message exchange before the simulated server restart
     baseline_msg = [1, 2, 3]
-    await agp_bindings.publish(svc_alice, session_id, 1, baseline_msg, bob_class, None)
-    
-    _, src, received = await agp_bindings.receive(svc_bob)
+    await agp_bindings.publish(
+        svc_alice, session_info, 1, baseline_msg, bob_class, None
+    )
+
+    _, received = await agp_bindings.receive(svc_bob)
     assert received == bytes(baseline_msg)
-    
+
     # restart the server
     await agp_bindings.stop(svc_server)
     await asyncio.sleep(3)  # allow time for the server to fully shut down
     await agp_bindings.serve(svc_server)
     await asyncio.sleep(2)  # allow time for automatic reconnection
-    
+
     # test that the message exchange resumes normally after the simulated restart
     test_msg = [4, 5, 6]
-    await agp_bindings.publish(svc_alice, session_id, 1, test_msg, bob_class, None)
-    _, src, received = await agp_bindings.receive(svc_bob)
+    await agp_bindings.publish(svc_alice, session_info, 1, test_msg, bob_class, None)
+    _, received = await agp_bindings.receive(svc_bob)
     assert received == bytes(test_msg)
-    
+
     # clean up
     await agp_bindings.disconnect(svc_alice, conn_id_alice)
     await agp_bindings.disconnect(svc_bob, conn_id_bob)
+
 
 @pytest.mark.asyncio
 async def test_error_on_nonexistent_subscription(server):
     # setup one client (Alice, but there is no Bob this time)
     svc_alice = agp_bindings.PyService("gateway/alice")
-    svc_alice.configure(agp_bindings.GatewayConfig(
-        endpoint="http://127.0.0.1:12345"
-    ))
+    svc_alice.configure(agp_bindings.GatewayConfig(endpoint="http://127.0.0.1:12345"))
 
     # create agent for Alice
     await agp_bindings.create_agent(svc_alice, "cisco", "default", "alice", 1234)
 
     # connect client and subscribe for messages
     conn_id_alice = await agp_bindings.connect(svc_alice)
-    alice_class = agp_bindings.PyAgentClass("cisco", "default", "alice")
+    alice_class = agp_bindings.PyAgentType("cisco", "default", "alice")
     await agp_bindings.subscribe(svc_alice, conn_id_alice, alice_class, 1234)
 
     # create fire and forget session
-    session_id = await agp_bindings.create_session(
-        svc_alice, agp_bindings.PySessionType.FireAndForget
+    session_info = await agp_bindings.create_ff_session(
+        svc_alice, agp_bindings.PyFireAndForgetConfiguration()
     )
 
     # create Bob's agent class, but do not instantiate or subscribe Bob
-    bob_class = agp_bindings.PyAgentClass("cisco", "default", "bob")
-    
+    bob_class = agp_bindings.PyAgentType("cisco", "default", "bob")
+
     # publish a message from Alice intended for Bob (who is not there)
     msg = [7, 8, 9]
-    await agp_bindings.publish(svc_alice, session_id, 1, msg, bob_class, None)
-    
+    await agp_bindings.publish(svc_alice, session_info, 1, msg, bob_class, None)
+
     # an exception should be raised on receive
     try:
-        _, src, received = await asyncio.wait_for(agp_bindings.receive(svc_alice), timeout=5)
+        _, src, received = await asyncio.wait_for(
+            agp_bindings.receive(svc_alice), timeout=5
+        )
     except asyncio.TimeoutError:
         pytest.fail("timed out waiting for error message on receive channel")
     except Exception as e:
-        assert "an error occurred processing a message" in str(e), (
-            f"Unexpected error message: {str(e)}"
-        )
+        assert "an error occurred processing a message" in str(
+            e
+        ), f"Unexpected error message: {str(e)}"
     else:
         pytest.fail(f"Expected an exception, but received message: {received}")
-    
+
     # clean up
     await agp_bindings.disconnect(svc_alice, conn_id_alice)

--- a/data-plane/testing/src/bin/publisher.rs
+++ b/data-plane/testing/src/bin/publisher.rs
@@ -195,7 +195,7 @@ async fn main() {
     let res = svc
         .create_session(
             &agent_name,
-            agp_service::session::SessionType::FireAndForget,
+            agp_service::session::SessionConfig::FireAndForget,
         )
         .await;
     if res.is_err() {

--- a/data-plane/testing/src/bin/publisher.rs
+++ b/data-plane/testing/src/bin/publisher.rs
@@ -195,7 +195,9 @@ async fn main() {
     let res = svc
         .create_session(
             &agent_name,
-            agp_service::session::SessionConfig::FireAndForget,
+            agp_service::session::SessionConfig::FireAndForget(
+                agp_service::FireAndForgetConfiguration {},
+            ),
         )
         .await;
     if res.is_err() {
@@ -203,7 +205,8 @@ async fn main() {
     }
 
     // get the session
-    let session_id = res.unwrap();
+    let session_info = res.unwrap();
+    let session_id = session_info.id;
 
     // start receiving loop
     let results_list = Arc::new(RwLock::new(HashMap::new()));
@@ -221,7 +224,13 @@ async fn main() {
                             break;
                         }
                         Some(msg_info) => {
-                            let (msg, session_info) = msg_info;
+                            if msg_info.is_err() {
+                                error!("error receiving message");
+                                continue;
+                            }
+
+                            let msg_info = msg_info.unwrap();
+                            let msg = msg_info.message;
 
                             // make sure the session matches
                             if session_info.id != session_id {
@@ -295,7 +304,7 @@ async fn main() {
         // send message
         // at the moment we have only one connection so we can use it to send all messages there
         // the match will be performed by the remote GW.
-        let agent_id = *p.1.agent_id();
+        let agent_id = p.1.agent_id();
         let name_id = if agent_id == 0 { None } else { Some(agent_id) };
 
         // for the moment we send the message in anycast
@@ -303,7 +312,7 @@ async fn main() {
         if svc
             .publish(
                 &agent_name,
-                session_id,
+                session_info.clone(),
                 p.1.agent_type(),
                 name_id,
                 1,

--- a/data-plane/testing/src/bin/workload-gen.rs
+++ b/data-plane/testing/src/bin/workload-gen.rs
@@ -182,7 +182,7 @@ fn main() {
 
             bar.inc(1);
 
-            type_state.insert(*sub.agent_id(), subscriber);
+            type_state.insert(sub.agent_id(), subscriber);
         }
 
         subscription_list.insert(agent_type, type_state);


### PR DESCRIPTION
## Motivation

Request/Response session type.

This is a first draft and requires extensive testing. Unit tests will be added in a second PR.

## Solution

Introduce the Request/Response session type:
 - in a request/reply session, if a reply is not received before the timeout, an error is returned to the application
 - application can now receive either messages or errors: an example of an error is a timeout on a request for which a reply was not received before the timeout
 - multiple messages can be sent in parallel - multiple timers will be set, one for each request
 - for each timeout that triggers, an error is sent to the application