### PR TITLE
perf: improve connection pool performance

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -73,6 +73,7 @@ dependencies = [
  "agp-tracing",
  "bit-vec",
  "bytes",
+ "criterion",
  "drain",
  "h2",
  "opentelemetry",
@@ -202,6 +203,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -457,6 +464,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,6 +507,33 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-targets",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -590,6 +630,73 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "deranged"
@@ -846,6 +953,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7db2ff139bba50379da6aa0766b52fdcb62cb5b263009b09ed58ba604e14bbd1"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,6 +985,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
 
 [[package]]
 name = "home"
@@ -1233,10 +1356,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi 0.5.0",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1538,7 +1681,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
@@ -1577,6 +1720,12 @@ name = "once_cell"
 version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl-probe"
@@ -1769,6 +1918,34 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -2123,6 +2300,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2325,6 +2522,15 @@ name = "ryu"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -2622,6 +2828,16 @@ checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3044,6 +3260,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3198,6 +3424,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/data-plane/gateway/datapath/Cargo.toml
+++ b/data-plane/gateway/datapath/Cargo.toml
@@ -26,7 +26,12 @@ tracing-opentelemetry = "0.29.0"
 
 [dev-dependencies]
 tracing-test = { version = "0.2.5", features = ["no-env-filter"] }
+criterion = { version = "0.5", features = ["html_reports"] }
 
 [build-dependencies]
 protoc-bin-vendored = "3.1.0"
 tonic-build = { version = "0.12.3", features = ["prost"] }
+
+[[bench]]
+name = "pool_benchmark"
+harness = false

--- a/data-plane/gateway/datapath/Cargo.toml
+++ b/data-plane/gateway/datapath/Cargo.toml
@@ -25,8 +25,8 @@ tracing = "0.1.41"
 tracing-opentelemetry = "0.29.0"
 
 [dev-dependencies]
-tracing-test = { version = "0.2.5", features = ["no-env-filter"] }
 criterion = { version = "0.5", features = ["html_reports"] }
+tracing-test = { version = "0.2.5", features = ["no-env-filter"] }
 
 [build-dependencies]
 protoc-bin-vendored = "3.1.0"

--- a/data-plane/gateway/datapath/benches/pool_benchmark.rs
+++ b/data-plane/gateway/datapath/benches/pool_benchmark.rs
@@ -1,7 +1,7 @@
-use std::mem::MaybeUninit;
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use bit_vec::BitVec;
 use agp_datapath::tables::pool::Pool;
+use bit_vec::BitVec;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::mem::MaybeUninit;
 
 fn bench_lookup(c: &mut Criterion) {
     let mut pool = Pool::with_capacity(1024);

--- a/data-plane/gateway/datapath/benches/pool_benchmark.rs
+++ b/data-plane/gateway/datapath/benches/pool_benchmark.rs
@@ -1,0 +1,92 @@
+use std::mem::MaybeUninit;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use bit_vec::BitVec;
+use agp_datapath::tables::pool::Pool;
+
+fn bench_lookup(c: &mut Criterion) {
+    let mut pool = Pool::with_capacity(1024);
+    for i in 0..1024 {
+        pool.insert(i);
+    }
+
+    c.bench_function("pool lookup", |b| {
+        b.iter(|| {
+            for i in 0..1024 {
+                black_box(pool.get(i));
+            }
+        })
+    });
+}
+
+fn bench_bitvec_lookup(c: &mut Criterion) {
+    let size = 1024;
+    let bitvec = BitVec::from_elem(size, true);
+
+    c.bench_function("bitvec lookup", |b| {
+        b.iter(|| {
+            for i in 0..size {
+                black_box(bitvec.get(i));
+            }
+        })
+    });
+}
+
+fn bench_assume_init_ref(c: &mut Criterion) {
+    let size = 1024;
+    let pool: Vec<MaybeUninit<i32>> = {
+        let mut v = Vec::with_capacity(size);
+        v.resize_with(size, || MaybeUninit::new(42));
+        v
+    };
+
+    c.bench_function("assume_init_ref only", |b| {
+        b.iter(|| {
+            for i in 0..size {
+                let _ = black_box(unsafe { pool[i].assume_init_ref() });
+            }
+        })
+    });
+}
+
+fn bench_insert(c: &mut Criterion) {
+    c.bench_function("pool insert", |b| {
+        b.iter(|| {
+            let mut pool = Pool::with_capacity(1024);
+            for i in 0..1024 {
+                pool.insert(i);
+            }
+        })
+    });
+}
+
+fn bench_grow(c: &mut Criterion) {
+    c.bench_function("pool grow", |b| {
+        b.iter(|| {
+            let mut pool = Pool::with_capacity(16);
+            for i in 0..1024 {
+                pool.insert(i);
+            }
+        })
+    });
+}
+
+fn bench_capacity(c: &mut Criterion) {
+    c.bench_function("pool capacity", |b| {
+        b.iter(|| {
+            let pool: Pool<i32> = Pool::with_capacity(1024);
+            let _ = pool.capacity();
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_lookup,
+    bench_bitvec_lookup,
+    bench_assume_init_ref,
+    bench_insert,
+    bench_grow,
+    bench_capacity,
+);
+
+criterion_main!(benches);

--- a/data-plane/gateway/datapath/src/tables/pool.rs
+++ b/data-plane/gateway/datapath/src/tables/pool.rs
@@ -1,8 +1,6 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
-use std::mem::MaybeUninit;
-
 use bit_vec::BitVec;
 
 use tracing::trace;
@@ -13,7 +11,7 @@ pub struct Pool<T> {
     bitmap: BitVec,
 
     /// the pool of elements
-    pool: Vec<MaybeUninit<T>>,
+    pool: Vec<Option<T>>,
 
     /// the number of elements in the pool
     len: usize,
@@ -29,7 +27,7 @@ impl<T> Pool<T> {
     /// Create a new pool with a given capacity
     pub fn with_capacity(capacity: usize) -> Self {
         let mut pool = Vec::with_capacity(capacity);
-        pool.resize_with(capacity, || MaybeUninit::uninit());
+        pool.resize_with(capacity, || None);
 
         Pool {
             bitmap: BitVec::from_elem(capacity, false),
@@ -61,23 +59,14 @@ impl<T> Pool<T> {
     }
 
     /// Get an element from the pool
+    #[inline(always)]
     pub fn get(&self, index: usize) -> Option<&T> {
-        if self.bitmap.get(index).unwrap_or(false) {
-            // Safety: The element is initialized
-            Some(unsafe { self.pool[index].assume_init_ref() })
-        } else {
-            None
-        }
+        self.pool.get(index).and_then(|slot| slot.as_ref())
     }
 
     /// Get a mutable reference to an element in the pool
     pub fn get_mut(&mut self, index: usize) -> Option<&mut T> {
-        if self.bitmap.get(index).unwrap_or(false) {
-            // Safety: The element is initialized
-            Some(unsafe { self.pool[index].assume_init_mut() })
-        } else {
-            None
-        }
+        self.pool.get_mut(index).and_then(|slot| slot.as_mut())
     }
 
     /// Insert an element into the pool
@@ -86,7 +75,7 @@ impl<T> Pool<T> {
         if self.len == self.capacity {
             // Resize the pool
             self.pool
-                .resize_with(2 * self.capacity, || MaybeUninit::uninit());
+                .resize_with(2 * self.capacity, || None);
             self.bitmap.grow(self.capacity, false);
             self.capacity *= 2;
 
@@ -123,26 +112,16 @@ impl<T> Pool<T> {
             return false;
         }
 
-        // put T at position index
-        unsafe {
-            // we can safely unwrap because self.capacity < index
-            if !self.bitmap.get(index).unwrap_unchecked() {
-                // if the bit is not set, increase len
-                self.len += 1;
-            } else {
-                // If the bit is set we are replacing an element
-                // so we do not need to increase len, but we still need to
-                // call the in-place destructor first. This is safe because
-                // we are calling the destructor on an initialized element.
-                self.pool[index].assume_init_drop();
-            }
+        if !self.bitmap.get(index).unwrap_or(false) {
+            // if the bit is not set, increase len
+            self.len += 1;
         }
 
         // Mark the bit as set
         self.bitmap.set(index, true);
 
         // Store the new element in the pool
-        self.pool[index] = MaybeUninit::new(element);
+        self.pool[index] = Some(element);
 
         // If the index is greater than the max_set, update max_set
         if index > self.max_set {
@@ -158,13 +137,8 @@ impl<T> Pool<T> {
         if self.bitmap.get(index).unwrap_or(false) {
             self.bitmap.set(index, false);
 
-            // Drop existing element. This is safe, as we know the element is initialized.
-            unsafe {
-                self.pool[index].assume_init_drop();
-            };
-
-            // Store an uninit value in the pool
-            self.pool[index] = MaybeUninit::uninit();
+            // Remove element from the pool
+            self.pool[index] = None;
 
             // Decrease the length of the pool
             self.len -= 1;
@@ -183,21 +157,6 @@ impl<T> Pool<T> {
             true
         } else {
             false
-        }
-    }
-}
-
-impl<T> Drop for Pool<T> {
-    fn drop(&mut self) {
-        for i in 0..self.capacity {
-            if self.bitmap.get(i).unwrap_or(false) {
-                // Call the in-place destructor for active elements.
-                // Elements not mapped in the bitmap are not initialized, so
-                // we do not need to call the destructor for them.
-                unsafe {
-                    self.pool[i].assume_init_drop();
-                }
-            }
         }
     }
 }

--- a/data-plane/gateway/datapath/src/tables/pool.rs
+++ b/data-plane/gateway/datapath/src/tables/pool.rs
@@ -59,7 +59,6 @@ impl<T> Pool<T> {
     }
 
     /// Get an element from the pool
-    #[inline(always)]
     pub fn get(&self, index: usize) -> Option<&T> {
         self.pool.get(index).and_then(|slot| slot.as_ref())
     }

--- a/data-plane/gateway/datapath/src/tables/pool.rs
+++ b/data-plane/gateway/datapath/src/tables/pool.rs
@@ -73,8 +73,7 @@ impl<T> Pool<T> {
         // If length is equal to capacity, resize the pool
         if self.len == self.capacity {
             // Resize the pool
-            self.pool
-                .resize_with(2 * self.capacity, || None);
+            self.pool.resize_with(2 * self.capacity, || None);
             self.bitmap.grow(self.capacity, false);
             self.capacity *= 2;
 


### PR DESCRIPTION
## Motivation

The goal was to measure the performance of the connection pool, and address the potential performance issues.

## Solution

Baseline performance test:

```
pool insert             time:   [334.62 µs 335.07 µs 335.63 µs]
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe

pool lookup             time:   [1.0598 µs 1.0604 µs 1.0610 µs]
Found 12 outliers among 100 measurements (12.00%)
  5 (5.00%) high mild
  7 (7.00%) high severe

pool grow               time:   [336.44 µs 337.22 µs 338.02 µs]
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild

pool capacity           time:   [898.70 ns 899.33 ns 900.28 ns]
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe 
```

It turned out that the machine level code for `MaybeUninit::assume_init` produced by the LLVM optimizer is suboptimal, that led to a 200-300 ns overhead for the lookup operation:

https://github.com/rust-lang/rust/issues/74267

The implementation was changed to use `Option` type instead of `MaybeUninit`, as a result we were able to
- address the performance degradation caused by the poorly optimized code
- get rid of the unsafe code.

The use of `Option` type also made it possible to remove the bitmap lookup operation from the `get` and `get_mut` methods, resulting in an additional ~200ns performance improvement.

```
pool insert             time:   [257.49 µs 258.16 µs 258.79 µs]
                        change: [-12.161% -7.0263% -2.8698%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

pool lookup             time:   [486.44 ns 489.29 ns 493.89 ns]
                        change: [-7.1040% -3.9066% -1.2306%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe

pool grow               time:   [253.72 µs 254.16 µs 254.63 µs]
                        change: [-2.3813% -1.3961% -0.6362%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

pool capacity           time:   [311.65 ps 312.07 ps 312.56 ps]
                        change: [-0.0158% +0.3079% +0.6408%] (p = 0.06 > 0.05)
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
```

