### PR TITLE
chore: release

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agp-config"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "agp-tracing",
  "duration-str",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agp-datapath"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "agp-config",
  "agp-tracing",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "agp-gw"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "agp-config",
  "agp-service",
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "agp-service"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "agp-config",
  "agp-datapath",
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "agp-signal"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "tokio",
  "tracing",
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "agp-tracing"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "once_cell",
  "opentelemetry",

--- a/data-plane/examples/Cargo.toml
+++ b/data-plane/examples/Cargo.toml
@@ -9,11 +9,11 @@ name = "sdk-mock"
 path = "src/sdk-mock/main.rs"
 
 [dependencies]
-agp-config = { path = "../gateway/config", version = "0.1.5" }
-agp-datapath = { path = "../gateway/datapath", version = "0.4.2" }
-agp-gw = { path = "../gateway/gateway", version = "0.3.10" }
-agp-service = { path = "../gateway/service", version = "0.2.1" }
-agp-signal = { path = "../gateway/signal", version = "0.1.0" }
+agp-config = { path = "../gateway/config", version = "0.1.6" }
+agp-datapath = { path = "../gateway/datapath", version = "0.5.0" }
+agp-gw = { path = "../gateway/gateway", version = "0.3.11" }
+agp-service = { path = "../gateway/service", version = "0.3.0" }
+agp-signal = { path = "../gateway/signal", version = "0.1.1" }
 clap = "4.5"
 tokio = "1"
 tracing = "0.1.41"

--- a/data-plane/gateway/config/CHANGELOG.md
+++ b/data-plane/gateway/config/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/agntcy/agp/compare/agp-config-v0.1.5...agp-config-v0.1.6) - 2025-03-28
+
+### Other
+
+- update copyright ([#109](https://github.com/agntcy/agp/pull/109))
+
 ## [0.1.5](https://github.com/agntcy/agp/compare/agp-config-v0.1.4...agp-config-v0.1.5) - 2025-03-18
 
 ### Added

--- a/data-plane/gateway/config/Cargo.toml
+++ b/data-plane/gateway/config/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "agp-config"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 license = { workspace = true }
 description = "Configuration utilities"
 
 [dependencies]
-agp-tracing = { path = "../tracing", version = "0.1.3" }
+agp-tracing = { path = "../tracing", version = "0.1.4" }
 duration-str = "0.12.0"
 futures = "0.3.31"
 http = "1.2.0"

--- a/data-plane/gateway/datapath/CHANGELOG.md
+++ b/data-plane/gateway/datapath/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/agntcy/agp/compare/agp-datapath-v0.4.2...agp-datapath-v0.5.0) - 2025-03-28
+
+### Added
+
+- add timers for rtx ([#117](https://github.com/agntcy/agp/pull/117))
+- rename protobuf fields ([#116](https://github.com/agntcy/agp/pull/116))
+- add receiver buffer ([#107](https://github.com/agntcy/agp/pull/107))
+- producer buffer ([#105](https://github.com/agntcy/agp/pull/105))
+- *(data-plane/service)* [**breaking**] first draft of session layer ([#106](https://github.com/agntcy/agp/pull/106))
+
+### Fixed
+
+- *(python-bindings)* fix python examples ([#120](https://github.com/agntcy/agp/pull/120))
+- *(datapath)* fix reconnection logic ([#119](https://github.com/agntcy/agp/pull/119))
+
+### Other
+
+- improve connection pool performance ([#125](https://github.com/agntcy/agp/pull/125))
+- update copyright ([#109](https://github.com/agntcy/agp/pull/109))
+
 ## [0.4.2](https://github.com/agntcy/agp/compare/agp-datapath-v0.4.1...agp-datapath-v0.4.2) - 2025-03-19
 
 ### Added

--- a/data-plane/gateway/datapath/Cargo.toml
+++ b/data-plane/gateway/datapath/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "agp-datapath"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 license = { workspace = true }
 description = "Core data plane functionality for AGP"
 
 [dependencies]
-agp-config = { path = "../config", version = "0.1.5" }
-agp-tracing = { path = "../tracing", version = "0.1.3" }
+agp-config = { path = "../config", version = "0.1.6" }
+agp-tracing = { path = "../tracing", version = "0.1.4" }
 bit-vec = "0.8"
 bytes = { version = "1.9.0" }
 drain = { version = "0.1", features = ["retain"] }

--- a/data-plane/gateway/gateway/CHANGELOG.md
+++ b/data-plane/gateway/gateway/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.11](https://github.com/agntcy/agp/compare/agp-gw-v0.3.10...agp-gw-v0.3.11) - 2025-03-28
+
+### Other
+
+- update copyright ([#109](https://github.com/agntcy/agp/pull/109))
+
 ## [0.3.10](https://github.com/agntcy/agp/compare/agp-gw-v0.3.9...agp-gw-v0.3.10) - 2025-03-19
 
 ### Other

--- a/data-plane/gateway/gateway/Cargo.toml
+++ b/data-plane/gateway/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agp-gw"
-version = "0.3.10"
+version = "0.3.11"
 edition = "2021"
 license = { workspace = true }
 description = "The main gateway executable"
@@ -14,10 +14,10 @@ default = ["multicore"]
 multicore = ["tokio/rt-multi-thread", "num_cpus"]
 
 [dependencies]
-agp-config = { path = "../config", version = "0.1.5" }
-agp-service = { path = "../service", version = "0.2.1" }
-agp-signal = { path = "../signal", version = "0.1.0" }
-agp-tracing = { path = "../tracing", version = "0.1.3" }
+agp-config = { path = "../config", version = "0.1.6" }
+agp-service = { path = "../service", version = "0.3.0" }
+agp-signal = { path = "../signal", version = "0.1.1" }
+agp-tracing = { path = "../tracing", version = "0.1.4" }
 clap = { version = "4.5.23", features = ["derive", "env"] }
 duration-str = "0.12.0"
 lazy_static = "1.5.0"

--- a/data-plane/gateway/nop_component/Cargo.toml
+++ b/data-plane/gateway/nop_component/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = { workspace = true }
 
 [dependencies]
-agp-config = { path = "../config", version = "0.1.5" }
+agp-config = { path = "../config", version = "0.1.6" }
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/data-plane/gateway/service/CHANGELOG.md
+++ b/data-plane/gateway/service/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/agntcy/agp/compare/agp-service-v0.2.1...agp-service-v0.3.0) - 2025-03-28
+
+### Added
+
+- add timers for rtx ([#117](https://github.com/agntcy/agp/pull/117))
+- rename protobuf fields ([#116](https://github.com/agntcy/agp/pull/116))
+- add receiver buffer ([#107](https://github.com/agntcy/agp/pull/107))
+- producer buffer ([#105](https://github.com/agntcy/agp/pull/105))
+- *(data-plane/service)* [**breaking**] first draft of session layer ([#106](https://github.com/agntcy/agp/pull/106))
+
+### Other
+
+- *(service)* simplify session trait with async_trait ([#121](https://github.com/agntcy/agp/pull/121))
+- add Python SDK test cases for failure scenarios
+- update copyright ([#109](https://github.com/agntcy/agp/pull/109))
+
 ## [0.2.1](https://github.com/agntcy/agp/compare/agp-service-v0.2.0...agp-service-v0.2.1) - 2025-03-19
 
 ### Other

--- a/data-plane/gateway/service/Cargo.toml
+++ b/data-plane/gateway/service/Cargo.toml
@@ -2,12 +2,12 @@
 name = "agp-service"
 edition = "2021"
 license = { workspace = true }
-version = "0.2.1"
+version = "0.3.0"
 description = "Main service and public API to interact with AGP data plane."
 
 [dependencies]
-agp-config = { path = "../config", version = "0.1.5" }
-agp-datapath = { path = "../datapath", version = "0.4.2" }
+agp-config = { path = "../config", version = "0.1.6" }
+agp-datapath = { path = "../datapath", version = "0.5.0" }
 async-trait = "0.1.88"
 drain = { version = "0.1", features = ["retain"] }
 parking_lot = "0.12.3"

--- a/data-plane/gateway/signal/CHANGELOG.md
+++ b/data-plane/gateway/signal/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/agntcy/agp/compare/agp-signal-v0.1.0...agp-signal-v0.1.1) - 2025-03-28
+
+### Other
+
+- update copyright ([#109](https://github.com/agntcy/agp/pull/109))
+
 ## [0.1.0](https://github.com/agntcy/agp/releases/tag/agp-signal-v0.1.0) - 2025-02-10
 
 ### Added

--- a/data-plane/gateway/signal/Cargo.toml
+++ b/data-plane/gateway/signal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agp-signal"
 edition = "2021"
 license = { workspace = true }
-version = "0.1.0"
+version = "0.1.1"
 description = "Small library to handle OS signals."
 
 [dependencies]

--- a/data-plane/gateway/tracing/CHANGELOG.md
+++ b/data-plane/gateway/tracing/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/agntcy/agp/compare/agp-tracing-v0.1.3...agp-tracing-v0.1.4) - 2025-03-28
+
+### Other
+
+- update copyright ([#109](https://github.com/agntcy/agp/pull/109))
+
 ## [0.1.3](https://github.com/agntcy/agp/compare/agp-tracing-v0.1.2...agp-tracing-v0.1.3) - 2025-03-18
 
 ### Added

--- a/data-plane/gateway/tracing/Cargo.toml
+++ b/data-plane/gateway/tracing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agp-tracing"
 edition = "2021"
 license = { workspace = true }
-version = "0.1.3"
+version = "0.1.4"
 description = "Observability for AGP data plane: logs, traces and metrics infrastructure."
 
 [dependencies]

--- a/data-plane/python-bindings/Cargo.toml
+++ b/data-plane/python-bindings/Cargo.toml
@@ -10,10 +10,10 @@ name = "_agp_bindings"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-agp-config = { path = "../gateway/config", version = "0.1.5" }
-agp-datapath = { path = "../gateway/datapath", version = "0.4.2" }
-agp-service = { path = "../gateway/service", version = "0.2.1" }
-agp-tracing = { path = "../gateway/tracing", version = "0.1.3" }
+agp-config = { path = "../gateway/config", version = "0.1.6" }
+agp-datapath = { path = "../gateway/datapath", version = "0.5.0" }
+agp-service = { path = "../gateway/service", version = "0.3.0" }
+agp-tracing = { path = "../gateway/tracing", version = "0.1.4" }
 pyo3 = "0.23.3"
 pyo3-async-runtimes = { version = "0.23.0", features = ["tokio-runtime"] }
 pyo3-stub-gen = "0.7.0"

--- a/data-plane/testing/Cargo.toml
+++ b/data-plane/testing/Cargo.toml
@@ -17,10 +17,10 @@ name = "publisher"
 path = "src/bin/publisher.rs"
 
 [dependencies]
-agp-config = { path = "../gateway/config", version = "0.1.5" }
-agp-datapath = { path = "../gateway/datapath", version = "0.4.2" }
-agp-gw = { path = "../gateway/gateway", version = "0.3.10" }
-agp-service = { path = "../gateway/service", version = "0.2.1" }
+agp-config = { path = "../gateway/config", version = "0.1.6" }
+agp-datapath = { path = "../gateway/datapath", version = "0.5.0" }
+agp-gw = { path = "../gateway/gateway", version = "0.3.11" }
+agp-service = { path = "../gateway/service", version = "0.3.0" }
 clap = { version = "4.5", features = ["derive"] }
 indicatif = "0.17.11"
 parking_lot = "0.12"


### PR DESCRIPTION



## 🤖 New release

* `agp-tracing`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `agp-config`: 0.1.5 -> 0.1.6 (✓ API compatible changes)
* `agp-datapath`: 0.4.2 -> 0.5.0 (⚠ API breaking changes)
* `agp-service`: 0.2.1 -> 0.3.0 (⚠ API breaking changes)
* `agp-signal`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `agp-gw`: 0.3.10 -> 0.3.11 (✓ API compatible changes)

### ⚠ `agp-datapath` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_missing.ron

Failed in:
  enum agp_datapath::pubsub::proto::pubsub::v1::ServiceHeaderType, previously in file /tmp/.tmp56SSvM/agp-datapath/src/pubsub/gen/pubsub.proto.v1.rs:95

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/function_missing.ron

Failed in:
  function agp_datapath::messages::utils::create_subscription_to_forward, previously in file /tmp/.tmp56SSvM/agp-datapath/src/messages/utils.rs:273
  function agp_datapath::messages::utils::create_unsubscription_to_forward, previously in file /tmp/.tmp56SSvM/agp-datapath/src/messages/utils.rs:330
  function agp_datapath::messages::utils::create_subscription_from, previously in file /tmp/.tmp56SSvM/agp-datapath/src/messages/utils.rs:243
  function agp_datapath::messages::utils::create_unsubscription_from, previously in file /tmp/.tmp56SSvM/agp-datapath/src/messages/utils.rs:307
  function agp_datapath::messages::utils::create_default_service_header, previously in file /tmp/.tmp56SSvM/agp-datapath/src/messages/utils.rs:203

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/function_parameter_count_changed.ron

Failed in:
  agp_datapath::messages::utils::create_publication now takes 8 parameters instead of 6, in /tmp/.tmpmOdANP/agp/data-plane/gateway/datapath/src/messages/utils.rs:312
  agp_datapath::messages::utils::create_subscription now takes 5 parameters instead of 2, in /tmp/.tmpmOdANP/agp/data-plane/gateway/datapath/src/messages/utils.rs:263

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/struct_missing.ron

Failed in:
  struct agp_datapath::pubsub::proto::pubsub::v1::ServiceHeader, previously in file /tmp/.tmp56SSvM/agp-datapath/src/pubsub/gen/pubsub.proto.v1.rs:54
  struct agp_datapath::pubsub::ServiceHeader, previously in file /tmp/.tmp56SSvM/agp-datapath/src/pubsub/gen/pubsub.proto.v1.rs:54
```

### ⚠ `agp-service` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_variant_added.ron

Failed in:
  variant ServiceError:AgentAlreadyRegistered in /tmp/.tmpmOdANP/agp/data-plane/gateway/service/src/errors.rs:11
  variant ServiceError:AgentNotFound in /tmp/.tmpmOdANP/agp/data-plane/gateway/service/src/errors.rs:13
  variant ServiceError:SessionNotFound in /tmp/.tmpmOdANP/agp/data-plane/gateway/service/src/errors.rs:31
  variant ServiceError:SessionCreationError in /tmp/.tmpmOdANP/agp/data-plane/gateway/service/src/errors.rs:33
  variant ServiceError:SessionDeletionError in /tmp/.tmpmOdANP/agp/data-plane/gateway/service/src/errors.rs:35
  variant ServiceError:SessionSendError in /tmp/.tmpmOdANP/agp/data-plane/gateway/service/src/errors.rs:37
  variant ServiceError:AgentAlreadyRegistered in /tmp/.tmpmOdANP/agp/data-plane/gateway/service/src/errors.rs:11
  variant ServiceError:AgentNotFound in /tmp/.tmpmOdANP/agp/data-plane/gateway/service/src/errors.rs:13
  variant ServiceError:SessionNotFound in /tmp/.tmpmOdANP/agp/data-plane/gateway/service/src/errors.rs:31
  variant ServiceError:SessionCreationError in /tmp/.tmpmOdANP/agp/data-plane/gateway/service/src/errors.rs:33
  variant ServiceError:SessionDeletionError in /tmp/.tmpmOdANP/agp/data-plane/gateway/service/src/errors.rs:35
  variant ServiceError:SessionSendError in /tmp/.tmpmOdANP/agp/data-plane/gateway/service/src/errors.rs:37

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_variant_missing.ron

Failed in:
  variant ServiceError::MissingAgentError, previously in file /tmp/.tmp56SSvM/agp-service/src/errors.rs:11
  variant ServiceError::MissingAgentError, previously in file /tmp/.tmp56SSvM/agp-service/src/errors.rs:11

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/method_parameter_count_changed.ron

Failed in:
  agp_service::Service::subscribe now takes 5 parameters instead of 4, in /tmp/.tmpmOdANP/agp/data-plane/gateway/service/src/lib.rs:377
  agp_service::Service::unsubscribe now takes 5 parameters instead of 4, in /tmp/.tmpmOdANP/agp/data-plane/gateway/service/src/lib.rs:390
  agp_service::Service::set_route now takes 5 parameters instead of 4, in /tmp/.tmpmOdANP/agp/data-plane/gateway/service/src/lib.rs:403
  agp_service::Service::remove_route now takes 5 parameters instead of 4, in /tmp/.tmpmOdANP/agp/data-plane/gateway/service/src/lib.rs:417
  agp_service::Service::publish now takes 7 parameters instead of 5, in /tmp/.tmpmOdANP/agp/data-plane/gateway/service/src/lib.rs:431
  agp_service::Service::publish_to now takes 8 parameters instead of 6, in /tmp/.tmpmOdANP/agp/data-plane/gateway/service/src/lib.rs:445
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `agp-tracing`

<blockquote>

## [0.1.4](https://github.com/agntcy/agp/compare/agp-tracing-v0.1.3...agp-tracing-v0.1.4) - 2025-03-28

### Other

- update copyright ([#109](https://github.com/agntcy/agp/pull/109))
</blockquote>

## `agp-config`

<blockquote>

## [0.1.6](https://github.com/agntcy/agp/compare/agp-config-v0.1.5...agp-config-v0.1.6) - 2025-03-28

### Other

- update copyright ([#109](https://github.com/agntcy/agp/pull/109))
</blockquote>

## `agp-datapath`

<blockquote>

## [0.5.0](https://github.com/agntcy/agp/compare/agp-datapath-v0.4.2...agp-datapath-v0.5.0) - 2025-03-28

### Added

- add timers for rtx ([#117](https://github.com/agntcy/agp/pull/117))
- rename protobuf fields ([#116](https://github.com/agntcy/agp/pull/116))
- add receiver buffer ([#107](https://github.com/agntcy/agp/pull/107))
- producer buffer ([#105](https://github.com/agntcy/agp/pull/105))
- *(data-plane/service)* [**breaking**] first draft of session layer ([#106](https://github.com/agntcy/agp/pull/106))

### Fixed

- *(python-bindings)* fix python examples ([#120](https://github.com/agntcy/agp/pull/120))
- *(datapath)* fix reconnection logic ([#119](https://github.com/agntcy/agp/pull/119))

### Other

- improve connection pool performance ([#125](https://github.com/agntcy/agp/pull/125))
- update copyright ([#109](https://github.com/agntcy/agp/pull/109))
</blockquote>

## `agp-service`

<blockquote>

## [0.3.0](https://github.com/agntcy/agp/compare/agp-service-v0.2.1...agp-service-v0.3.0) - 2025-03-28

### Added

- add timers for rtx ([#117](https://github.com/agntcy/agp/pull/117))
- rename protobuf fields ([#116](https://github.com/agntcy/agp/pull/116))
- add receiver buffer ([#107](https://github.com/agntcy/agp/pull/107))
- producer buffer ([#105](https://github.com/agntcy/agp/pull/105))
- *(data-plane/service)* [**breaking**] first draft of session layer ([#106](https://github.com/agntcy/agp/pull/106))

### Other

- *(service)* simplify session trait with async_trait ([#121](https://github.com/agntcy/agp/pull/121))
- add Python SDK test cases for failure scenarios
- update copyright ([#109](https://github.com/agntcy/agp/pull/109))
</blockquote>

## `agp-signal`

<blockquote>

## [0.1.1](https://github.com/agntcy/agp/compare/agp-signal-v0.1.0...agp-signal-v0.1.1) - 2025-03-28

### Other

- update copyright ([#109](https://github.com/agntcy/agp/pull/109))
</blockquote>

## `agp-gw`

<blockquote>

## [0.3.11](https://github.com/agntcy/agp/compare/agp-gw-v0.3.10...agp-gw-v0.3.11) - 2025-03-28

### Other

- update copyright ([#109](https://github.com/agntcy/agp/pull/109))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).