### PR TITLE
fix(agp-bindings): build pypi package on ubuntu 22.04

### DIFF
--- a/.github/workflows/reusable-python-build-wheels.yaml
+++ b/.github/workflows/reusable-python-build-wheels.yaml
@@ -16,10 +16,10 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: ubuntu-24.04
+          - runner: ubuntu-22.04
             os: linux
             target: x86_64
-          - runner: ubuntu-24.04-arm
+          - runner: ubuntu-22.04-arm
             os: linux
             target: aarch64
           - runner: windows-latest

--- a/data-plane/python-bindings/README.md
+++ b/data-plane/python-bindings/README.md
@@ -854,7 +854,7 @@ async def main():
         type=str,
         help="Remote ID in the format organization/namespace/agent.",
     )
-    parser.add_argument("-m", "--message", type=str, help="Message to send.")
+    parser.add_argument("-m", "--message", type=str, help="Message to send")
     parser.add_argument(
         "-g",
         "--gateway",


### PR DESCRIPTION
# Description

By building the bindings on ubuntu 24.04 we force a glibc version that is quite recent and does not
work on old systems. Switch to ubuntu 22.04 to use 2.35

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
