### PR TITLE
chore: release

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "agp-config"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "duration-str",
  "futures",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "agp-datapath"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "agp-config",
  "agp-tracing",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "agp-gw"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "agp-config",
  "agp-service",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "agp-service"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "agp-config",
  "agp-datapath",
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "agp-signal"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "tokio",
  "tracing",
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "agp-tracing"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "agp-config",
  "once_cell",

--- a/data-plane/examples/Cargo.toml
+++ b/data-plane/examples/Cargo.toml
@@ -9,11 +9,11 @@ name = "sdk-mock"
 path = "src/sdk-mock/main.rs"
 
 [dependencies]
-agp-config = { path = "../gateway/config", version = "0.1.6" }
-agp-datapath = { path = "../gateway/datapath", version = "0.5.0" }
-agp-gw = { path = "../gateway/gateway", version = "0.3.11" }
-agp-service = { path = "../gateway/service", version = "0.3.0" }
-agp-signal = { path = "../gateway/signal", version = "0.1.1" }
+agp-config = { path = "../gateway/config", version = "0.1.7" }
+agp-datapath = { path = "../gateway/datapath", version = "0.6.0" }
+agp-gw = { path = "../gateway/gateway", version = "0.3.12" }
+agp-service = { path = "../gateway/service", version = "0.4.0" }
+agp-signal = { path = "../gateway/signal", version = "0.1.2" }
 clap = "4.5"
 tokio = "1"
 tracing = "0.1.41"

--- a/data-plane/gateway/config/CHANGELOG.md
+++ b/data-plane/gateway/config/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/agntcy/agp/compare/agp-config-v0.1.6...agp-config-v0.1.7) - 2025-04-24
+
+### Added
+
+- improve configuration handling for tracing ([#186](https://github.com/agntcy/agp/pull/186))
+- *(data-plane)* support for multiple servers ([#173](https://github.com/agntcy/agp/pull/173))
+
+### Fixed
+
+- *(data-plane)* make new linter version happy ([#184](https://github.com/agntcy/agp/pull/184))
+
+### Other
+
+- *(data-plane)* tonic 0.12.3 -> 0.13 ([#170](https://github.com/agntcy/agp/pull/170))
+- upgrade to rust edition 2024 and toolchain 1.86.0 ([#164](https://github.com/agntcy/agp/pull/164))
+
 ## [0.1.6](https://github.com/agntcy/agp/compare/agp-config-v0.1.5...agp-config-v0.1.6) - 2025-04-08
 
 ### Other

--- a/data-plane/gateway/config/Cargo.toml
+++ b/data-plane/gateway/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agp-config"
-version = "0.1.6"
+version = "0.1.7"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Configuration utilities"

--- a/data-plane/gateway/datapath/CHANGELOG.md
+++ b/data-plane/gateway/datapath/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/agntcy/agp/compare/agp-datapath-v0.5.0...agp-datapath-v0.6.0) - 2025-04-24
+
+### Added
+
+- improve configuration handling for tracing ([#186](https://github.com/agntcy/agp/pull/186))
+- add beacon messages from the producer for streaming and pub/sub ([#177](https://github.com/agntcy/agp/pull/177))
+- *(python-bindings)* improve configuration handling and further refactoring ([#167](https://github.com/agntcy/agp/pull/167))
+- *(session layer)* send rtx error if the packet is not in the producer buffer ([#166](https://github.com/agntcy/agp/pull/166))
+
+### Fixed
+
+- *(data-plane)* make new linter version happy ([#184](https://github.com/agntcy/agp/pull/184))
+
+### Other
+
+- *(data-plane)* tonic 0.12.3 -> 0.13 ([#170](https://github.com/agntcy/agp/pull/170))
+- upgrade to rust edition 2024 and toolchain 1.86.0 ([#164](https://github.com/agntcy/agp/pull/164))
+
 ## [0.5.0](https://github.com/agntcy/agp/compare/agp-datapath-v0.4.2...agp-datapath-v0.5.0) - 2025-04-08
 
 ### Added

--- a/data-plane/gateway/datapath/Cargo.toml
+++ b/data-plane/gateway/datapath/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "agp-datapath"
-version = "0.5.0"
+version = "0.6.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Core data plane functionality for AGP"
 
 [dependencies]
-agp-config = { path = "../config", version = "0.1.6" }
-agp-tracing = { path = "../tracing", version = "0.1.4" }
+agp-config = { path = "../config", version = "0.1.7" }
+agp-tracing = { path = "../tracing", version = "0.2.0" }
 bit-vec = "0.8"
 bytes = { version = "1.9.0" }
 drain = { version = "0.1", features = ["retain"] }

--- a/data-plane/gateway/gateway/CHANGELOG.md
+++ b/data-plane/gateway/gateway/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.12](https://github.com/agntcy/agp/compare/agp-gw-v0.3.11...agp-gw-v0.3.12) - 2025-04-24
+
+### Added
+
+- *(python-bindings)* improve configuration handling and further refactoring ([#167](https://github.com/agntcy/agp/pull/167))
+- *(data-plane)* support for multiple servers ([#173](https://github.com/agntcy/agp/pull/173))
+
+### Other
+
+- upgrade to rust edition 2024 and toolchain 1.86.0 ([#164](https://github.com/agntcy/agp/pull/164))
+
 ## [0.3.11](https://github.com/agntcy/agp/compare/agp-gw-v0.3.10...agp-gw-v0.3.11) - 2025-04-08
 
 ### Other

--- a/data-plane/gateway/gateway/Cargo.toml
+++ b/data-plane/gateway/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agp-gw"
-version = "0.3.11"
+version = "0.3.12"
 edition = { workspace = true }
 license = { workspace = true }
 description = "The main gateway executable"
@@ -14,10 +14,10 @@ default = ["multicore"]
 multicore = ["tokio/rt-multi-thread", "num_cpus"]
 
 [dependencies]
-agp-config = { path = "../config", version = "0.1.6" }
-agp-service = { path = "../service", version = "0.3.0" }
-agp-signal = { path = "../signal", version = "0.1.1" }
-agp-tracing = { path = "../tracing", version = "0.1.4" }
+agp-config = { path = "../config", version = "0.1.7" }
+agp-service = { path = "../service", version = "0.4.0" }
+agp-signal = { path = "../signal", version = "0.1.2" }
+agp-tracing = { path = "../tracing", version = "0.2.0" }
 clap = { version = "4.5.23", features = ["derive", "env"] }
 duration-str = "0.12.0"
 lazy_static = "1.5.0"

--- a/data-plane/gateway/nop_component/Cargo.toml
+++ b/data-plane/gateway/nop_component/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 license = { workspace = true }
 
 [dependencies]
-agp-config = { path = "../config", version = "0.1.6" }
+agp-config = { path = "../config", version = "0.1.7" }
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/data-plane/gateway/service/CHANGELOG.md
+++ b/data-plane/gateway/service/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/agntcy/agp/compare/agp-service-v0.3.0...agp-service-v0.4.0) - 2025-04-24
+
+### Added
+
+- *(session)* add default config for sessions created upon message reception ([#181](https://github.com/agntcy/agp/pull/181))
+- *(session)* add tests for session deletion ([#179](https://github.com/agntcy/agp/pull/179))
+- add beacon messages from the producer for streaming and pub/sub ([#177](https://github.com/agntcy/agp/pull/177))
+- *(python-bindings)* add session deletion API ([#176](https://github.com/agntcy/agp/pull/176))
+- *(python-bindings)* improve configuration handling and further refactoring ([#167](https://github.com/agntcy/agp/pull/167))
+- *(data-plane)* support for multiple servers ([#173](https://github.com/agntcy/agp/pull/173))
+- add exponential timers ([#172](https://github.com/agntcy/agp/pull/172))
+- *(session layer)* send rtx error if the packet is not in the producer buffer ([#166](https://github.com/agntcy/agp/pull/166))
+
+### Fixed
+
+- *(data-plane)* make new linter version happy ([#184](https://github.com/agntcy/agp/pull/184))
+
+### Other
+
+- *(data-plane)* tonic 0.12.3 -> 0.13 ([#170](https://github.com/agntcy/agp/pull/170))
+- upgrade to rust edition 2024 and toolchain 1.86.0 ([#164](https://github.com/agntcy/agp/pull/164))
+
 ## [0.3.0](https://github.com/agntcy/agp/compare/agp-service-v0.2.1...agp-service-v0.3.0) - 2025-04-08
 
 ### Added

--- a/data-plane/gateway/service/Cargo.toml
+++ b/data-plane/gateway/service/Cargo.toml
@@ -2,12 +2,12 @@
 name = "agp-service"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.0"
+version = "0.4.0"
 description = "Main service and public API to interact with AGP data plane."
 
 [dependencies]
-agp-config = { path = "../config", version = "0.1.6" }
-agp-datapath = { path = "../datapath", version = "0.5.0" }
+agp-config = { path = "../config", version = "0.1.7" }
+agp-datapath = { path = "../datapath", version = "0.6.0" }
 async-trait = "0.1.88"
 drain = { version = "0.1", features = ["retain"] }
 parking_lot = "0.12.3"

--- a/data-plane/gateway/signal/CHANGELOG.md
+++ b/data-plane/gateway/signal/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/agntcy/agp/compare/agp-signal-v0.1.1...agp-signal-v0.1.2) - 2025-04-24
+
+### Other
+
+- upgrade to rust edition 2024 and toolchain 1.86.0 ([#164](https://github.com/agntcy/agp/pull/164))
+
 ## [0.1.1](https://github.com/agntcy/agp/compare/agp-signal-v0.1.0...agp-signal-v0.1.1) - 2025-04-08
 
 ### Other

--- a/data-plane/gateway/signal/Cargo.toml
+++ b/data-plane/gateway/signal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agp-signal"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.1"
+version = "0.1.2"
 description = "Small library to handle OS signals."
 
 [dependencies]

--- a/data-plane/gateway/tracing/CHANGELOG.md
+++ b/data-plane/gateway/tracing/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/agntcy/agp/compare/agp-tracing-v0.1.4...agp-tracing-v0.2.0) - 2025-04-24
+
+### Added
+
+- improve configuration handling for tracing ([#186](https://github.com/agntcy/agp/pull/186))
+
+### Fixed
+
+- *(data-plane)* make new linter version happy ([#184](https://github.com/agntcy/agp/pull/184))
+
+### Other
+
+- upgrade to rust edition 2024 and toolchain 1.86.0 ([#164](https://github.com/agntcy/agp/pull/164))
+
 ## [0.1.4](https://github.com/agntcy/agp/compare/agp-tracing-v0.1.3...agp-tracing-v0.1.4) - 2025-04-08
 
 ### Other

--- a/data-plane/gateway/tracing/Cargo.toml
+++ b/data-plane/gateway/tracing/Cargo.toml
@@ -2,11 +2,11 @@
 name = "agp-tracing"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.4"
+version = "0.2.0"
 description = "Observability for AGP data plane: logs, traces and metrics infrastructure."
 
 [dependencies]
-agp-config = { path = "../config", version = "0.1.6" }
+agp-config = { path = "../config", version = "0.1.7" }
 once_cell = "1.21.0"
 opentelemetry = { version = "0.29.0", features = ["trace", "metrics"] }
 opentelemetry-otlp = { version = "0.29.0", features = ["metrics", "grpc-tonic"] }

--- a/data-plane/python-bindings/Cargo.toml
+++ b/data-plane/python-bindings/Cargo.toml
@@ -10,10 +10,10 @@ name = "_agp_bindings"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-agp-config = { path = "../gateway/config", version = "0.1.6" }
-agp-datapath = { path = "../gateway/datapath", version = "0.5.0" }
-agp-service = { path = "../gateway/service", version = "0.3.0" }
-agp-tracing = { path = "../gateway/tracing", version = "0.1.4" }
+agp-config = { path = "../gateway/config", version = "0.1.7" }
+agp-datapath = { path = "../gateway/datapath", version = "0.6.0" }
+agp-service = { path = "../gateway/service", version = "0.4.0" }
+agp-tracing = { path = "../gateway/tracing", version = "0.2.0" }
 pyo3 = "0.24.1"
 pyo3-async-runtimes = { version = "0.24", features = ["tokio-runtime"] }
 pyo3-stub-gen = "0.7.0"

--- a/data-plane/testing/Cargo.toml
+++ b/data-plane/testing/Cargo.toml
@@ -18,10 +18,10 @@ name = "publisher"
 path = "src/bin/publisher.rs"
 
 [dependencies]
-agp-config = { path = "../gateway/config", version = "0.1.6" }
-agp-datapath = { path = "../gateway/datapath", version = "0.5.0" }
-agp-gw = { path = "../gateway/gateway", version = "0.3.11" }
-agp-service = { path = "../gateway/service", version = "0.3.0" }
+agp-config = { path = "../gateway/config", version = "0.1.7" }
+agp-datapath = { path = "../gateway/datapath", version = "0.6.0" }
+agp-gw = { path = "../gateway/gateway", version = "0.3.12" }
+agp-service = { path = "../gateway/service", version = "0.4.0" }
 clap = { version = "4.5", features = ["derive"] }
 indicatif = "0.17.11"
 parking_lot = "0.12"


### PR DESCRIPTION



## 🤖 New release

* `agp-config`: 0.1.6 -> 0.1.7 (✓ API compatible changes)
* `agp-tracing`: 0.1.4 -> 0.2.0 (⚠ API breaking changes)
* `agp-datapath`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)
* `agp-service`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `agp-signal`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `agp-gw`: 0.3.11 -> 0.3.12 (✓ API compatible changes)

### ⚠ `agp-tracing` breaking changes

```text
--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/module_missing.ron

Failed in:
  mod agp_tracing::opaque, previously in file /tmp/.tmpdD0jc8/agp-tracing/src/opaque.rs:4

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/struct_missing.ron

Failed in:
  struct agp_tracing::opaque::OpaqueString, previously in file /tmp/.tmpdD0jc8/agp-tracing/src/opaque.rs:10
```

### ⚠ `agp-datapath` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_variant_added.ron

Failed in:
  variant SessionHeaderType:BeaconStream in /tmp/.tmpPm5sfl/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:102
  variant SessionHeaderType:BeaconPubSub in /tmp/.tmpPm5sfl/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:103
```

### ⚠ `agp-service` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_missing.ron

Failed in:
  enum agp_service::receiver_buffer::ReceiverBufferError, previously in file /tmp/.tmpdD0jc8/agp-service/src/receiver_buffer.rs:12

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_variant_added.ron

Failed in:
  variant ServiceError:ClientAlreadyConnected in /tmp/.tmpPm5sfl/agp/data-plane/gateway/service/src/errors.rs:37
  variant ServiceError:ServerNotFound in /tmp/.tmpPm5sfl/agp/data-plane/gateway/service/src/errors.rs:39
  variant ServiceError:MessageSendingError in /tmp/.tmpPm5sfl/agp/data-plane/gateway/service/src/errors.rs:41
  variant ServiceError:ClientAlreadyConnected in /tmp/.tmpPm5sfl/agp/data-plane/gateway/service/src/errors.rs:37
  variant ServiceError:ServerNotFound in /tmp/.tmpPm5sfl/agp/data-plane/gateway/service/src/errors.rs:39
  variant ServiceError:MessageSendingError in /tmp/.tmpPm5sfl/agp/data-plane/gateway/service/src/errors.rs:41
  variant SessionError:SessionDefaultNotSupported in /tmp/.tmpPm5sfl/agp/data-plane/gateway/service/src/errors.rs:73

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/inherent_method_missing.ron

Failed in:
  Service::serve, previously in file /tmp/.tmpdD0jc8/agp-service/src/lib.rs:249
  Service::stop, previously in file /tmp/.tmpdD0jc8/agp-service/src/lib.rs:308
  ServiceConfiguration::server, previously in file /tmp/.tmpdD0jc8/agp-service/src/lib.rs:72

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/method_parameter_count_changed.ron

Failed in:
  agp_service::timer::Timer::new now takes 5 parameters instead of 3, in /tmp/.tmpPm5sfl/agp/data-plane/gateway/service/src/timer.rs:48

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field max_retries of struct RequestResponseConfiguration, previously in file /tmp/.tmpdD0jc8/agp-service/src/request_response.rs:25
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `agp-config`

<blockquote>

## [0.1.7](https://github.com/agntcy/agp/compare/agp-config-v0.1.6...agp-config-v0.1.7) - 2025-04-24

### Added

- improve configuration handling for tracing ([#186](https://github.com/agntcy/agp/pull/186))
- *(data-plane)* support for multiple servers ([#173](https://github.com/agntcy/agp/pull/173))

### Fixed

- *(data-plane)* make new linter version happy ([#184](https://github.com/agntcy/agp/pull/184))

### Other

- *(data-plane)* tonic 0.12.3 -> 0.13 ([#170](https://github.com/agntcy/agp/pull/170))
- upgrade to rust edition 2024 and toolchain 1.86.0 ([#164](https://github.com/agntcy/agp/pull/164))
</blockquote>

## `agp-tracing`

<blockquote>

## [0.2.0](https://github.com/agntcy/agp/compare/agp-tracing-v0.1.4...agp-tracing-v0.2.0) - 2025-04-24

### Added

- improve configuration handling for tracing ([#186](https://github.com/agntcy/agp/pull/186))

### Fixed

- *(data-plane)* make new linter version happy ([#184](https://github.com/agntcy/agp/pull/184))

### Other

- upgrade to rust edition 2024 and toolchain 1.86.0 ([#164](https://github.com/agntcy/agp/pull/164))
</blockquote>

## `agp-datapath`

<blockquote>

## [0.6.0](https://github.com/agntcy/agp/compare/agp-datapath-v0.5.0...agp-datapath-v0.6.0) - 2025-04-24

### Added

- improve configuration handling for tracing ([#186](https://github.com/agntcy/agp/pull/186))
- add beacon messages from the producer for streaming and pub/sub ([#177](https://github.com/agntcy/agp/pull/177))
- *(python-bindings)* improve configuration handling and further refactoring ([#167](https://github.com/agntcy/agp/pull/167))
- *(session layer)* send rtx error if the packet is not in the producer buffer ([#166](https://github.com/agntcy/agp/pull/166))

### Fixed

- *(data-plane)* make new linter version happy ([#184](https://github.com/agntcy/agp/pull/184))

### Other

- *(data-plane)* tonic 0.12.3 -> 0.13 ([#170](https://github.com/agntcy/agp/pull/170))
- upgrade to rust edition 2024 and toolchain 1.86.0 ([#164](https://github.com/agntcy/agp/pull/164))
</blockquote>

## `agp-service`

<blockquote>

## [0.4.0](https://github.com/agntcy/agp/compare/agp-service-v0.3.0...agp-service-v0.4.0) - 2025-04-24

### Added

- *(session)* add default config for sessions created upon message reception ([#181](https://github.com/agntcy/agp/pull/181))
- *(session)* add tests for session deletion ([#179](https://github.com/agntcy/agp/pull/179))
- add beacon messages from the producer for streaming and pub/sub ([#177](https://github.com/agntcy/agp/pull/177))
- *(python-bindings)* add session deletion API ([#176](https://github.com/agntcy/agp/pull/176))
- *(python-bindings)* improve configuration handling and further refactoring ([#167](https://github.com/agntcy/agp/pull/167))
- *(data-plane)* support for multiple servers ([#173](https://github.com/agntcy/agp/pull/173))
- add exponential timers ([#172](https://github.com/agntcy/agp/pull/172))
- *(session layer)* send rtx error if the packet is not in the producer buffer ([#166](https://github.com/agntcy/agp/pull/166))

### Fixed

- *(data-plane)* make new linter version happy ([#184](https://github.com/agntcy/agp/pull/184))

### Other

- *(data-plane)* tonic 0.12.3 -> 0.13 ([#170](https://github.com/agntcy/agp/pull/170))
- upgrade to rust edition 2024 and toolchain 1.86.0 ([#164](https://github.com/agntcy/agp/pull/164))
</blockquote>

## `agp-signal`

<blockquote>

## [0.1.2](https://github.com/agntcy/agp/compare/agp-signal-v0.1.1...agp-signal-v0.1.2) - 2025-04-24

### Other

- upgrade to rust edition 2024 and toolchain 1.86.0 ([#164](https://github.com/agntcy/agp/pull/164))
</blockquote>

## `agp-gw`

<blockquote>

## [0.3.12](https://github.com/agntcy/agp/compare/agp-gw-v0.3.11...agp-gw-v0.3.12) - 2025-04-24

### Added

- *(python-bindings)* improve configuration handling and further refactoring ([#167](https://github.com/agntcy/agp/pull/167))
- *(data-plane)* support for multiple servers ([#173](https://github.com/agntcy/agp/pull/173))

### Other

- upgrade to rust edition 2024 and toolchain 1.86.0 ([#164](https://github.com/agntcy/agp/pull/164))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).