### PR TITLE
chore: release

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "agp-config"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "duration-str",
  "futures",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agp-datapath"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "agp-config",
  "agp-tracing",
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "agp-gw"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "agp-config",
  "agp-service",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "agp-service"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "agp-config",
  "agp-controller",
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "agp-tracing"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "agp-config",
  "once_cell",

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -38,13 +38,13 @@ edition = "2024"
 
 [workspace.dependencies]
 # Local dependencies
-agp-config = { path = "gateway/config", version = "0.1.7" }
+agp-config = { path = "gateway/config", version = "0.1.8" }
 agp-controller = { path = "gateway/controller", version = "0.1.0" }
-agp-datapath = { path = "gateway/datapath", version = "0.6.0" }
-agp-gw = { path = "gateway/gateway", version = "0.3.12" }
-agp-service = { path = "gateway/service", version = "0.4.0" }
+agp-datapath = { path = "gateway/datapath", version = "0.6.1" }
+agp-gw = { path = "gateway/gateway", version = "0.3.13" }
+agp-service = { path = "gateway/service", version = "0.4.1" }
 agp-signal = { path = "gateway/signal", version = "0.1.2" }
-agp-tracing = { path = "gateway/tracing", version = "0.2.0" }
+agp-tracing = { path = "gateway/tracing", version = "0.2.1" }
 
 # Core dependencies
 async-trait = "0.1.88"

--- a/data-plane/gateway/config/CHANGELOG.md
+++ b/data-plane/gateway/config/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/agntcy/agp/compare/agp-config-v0.1.7...agp-config-v0.1.8) - 2025-05-05
+
+### Fixed
+
+- add the possibility to ignore spelling errors ([#199](https://github.com/agntcy/agp/pull/199))
+
 ## [0.1.7](https://github.com/agntcy/agp/compare/agp-config-v0.1.6...agp-config-v0.1.7) - 2025-04-24
 
 ### Added

--- a/data-plane/gateway/config/Cargo.toml
+++ b/data-plane/gateway/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agp-config"
-version = "0.1.7"
+version = "0.1.8"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Configuration utilities"

--- a/data-plane/gateway/datapath/CHANGELOG.md
+++ b/data-plane/gateway/datapath/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/agntcy/agp/compare/agp-datapath-v0.6.0...agp-datapath-v0.6.1) - 2025-05-05
+
+### Added
+
+- implement control API ([#147](https://github.com/agntcy/agp/pull/147))
+
 ## [0.6.0](https://github.com/agntcy/agp/compare/agp-datapath-v0.5.0...agp-datapath-v0.6.0) - 2025-04-24
 
 ### Added

--- a/data-plane/gateway/datapath/Cargo.toml
+++ b/data-plane/gateway/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agp-datapath"
-version = "0.6.0"
+version = "0.6.1"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Core data plane functionality for AGP"

--- a/data-plane/gateway/gateway/CHANGELOG.md
+++ b/data-plane/gateway/gateway/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.13](https://github.com/agntcy/agp/compare/agp-gw-v0.3.12...agp-gw-v0.3.13) - 2025-05-05
+
+### Other
+
+- updated the following local packages: agp-config, agp-service, agp-tracing
+
 ## [0.3.12](https://github.com/agntcy/agp/compare/agp-gw-v0.3.11...agp-gw-v0.3.12) - 2025-04-24
 
 ### Added

--- a/data-plane/gateway/gateway/Cargo.toml
+++ b/data-plane/gateway/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agp-gw"
-version = "0.3.12"
+version = "0.3.13"
 edition = { workspace = true }
 license = { workspace = true }
 description = "The main gateway executable"

--- a/data-plane/gateway/service/CHANGELOG.md
+++ b/data-plane/gateway/service/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/agntcy/agp/compare/agp-service-v0.4.0...agp-service-v0.4.1) - 2025-05-05
+
+### Added
+
+- implement control API ([#147](https://github.com/agntcy/agp/pull/147))
+
+### Fixed
+
+- shut down controller server properly ([#202](https://github.com/agntcy/agp/pull/202))
+- *(python-bindings)* test failure ([#194](https://github.com/agntcy/agp/pull/194))
+
 ## [0.4.0](https://github.com/agntcy/agp/compare/agp-service-v0.3.0...agp-service-v0.4.0) - 2025-04-24
 
 ### Added

--- a/data-plane/gateway/service/Cargo.toml
+++ b/data-plane/gateway/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agp-service"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.4.0"
+version = "0.4.1"
 description = "Main service and public API to interact with AGP data plane."
 
 [dependencies]

--- a/data-plane/gateway/tracing/CHANGELOG.md
+++ b/data-plane/gateway/tracing/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/agntcy/agp/compare/agp-tracing-v0.2.0...agp-tracing-v0.2.1) - 2025-05-05
+
+### Other
+
+- updated the following local packages: agp-config
+
 ## [0.2.0](https://github.com/agntcy/agp/compare/agp-tracing-v0.1.4...agp-tracing-v0.2.0) - 2025-04-24
 
 ### Added

--- a/data-plane/gateway/tracing/Cargo.toml
+++ b/data-plane/gateway/tracing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agp-tracing"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.2.0"
+version = "0.2.1"
 description = "Observability for AGP data plane: logs, traces and metrics infrastructure."
 
 [dependencies]


### PR DESCRIPTION



## 🤖 New release

* `agp-config`: 0.1.7 -> 0.1.8 (✓ API compatible changes)
* `agp-datapath`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `agp-service`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `agp-tracing`: 0.2.0 -> 0.2.1
* `agp-gw`: 0.3.12 -> 0.3.13

<details><summary><i><b>Changelog</b></i></summary><p>

## `agp-config`

<blockquote>

## [0.1.8](https://github.com/agntcy/agp/compare/agp-config-v0.1.7...agp-config-v0.1.8) - 2025-05-05

### Fixed

- add the possibility to ignore spelling errors ([#199](https://github.com/agntcy/agp/pull/199))
</blockquote>

## `agp-datapath`

<blockquote>

## [0.6.1](https://github.com/agntcy/agp/compare/agp-datapath-v0.6.0...agp-datapath-v0.6.1) - 2025-05-05

### Added

- implement control API ([#147](https://github.com/agntcy/agp/pull/147))
</blockquote>

## `agp-service`

<blockquote>

## [0.4.1](https://github.com/agntcy/agp/compare/agp-service-v0.4.0...agp-service-v0.4.1) - 2025-05-05

### Added

- implement control API ([#147](https://github.com/agntcy/agp/pull/147))

### Fixed

- shut down controller server properly ([#202](https://github.com/agntcy/agp/pull/202))
- *(python-bindings)* test failure ([#194](https://github.com/agntcy/agp/pull/194))
</blockquote>

## `agp-tracing`

<blockquote>

## [0.2.1](https://github.com/agntcy/agp/compare/agp-tracing-v0.2.0...agp-tracing-v0.2.1) - 2025-05-05

### Other

- updated the following local packages: agp-config
</blockquote>

## `agp-gw`

<blockquote>

## [0.3.13](https://github.com/agntcy/agp/compare/agp-gw-v0.3.12...agp-gw-v0.3.13) - 2025-05-05

### Other

- updated the following local packages: agp-config, agp-service, agp-tracing
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).