### PR TITLE
fix: add the possibility to ignore spelling errors

### DIFF
--- a/data-plane/_typos.toml
+++ b/data-plane/_typos.toml
@@ -1,0 +1,4 @@
+[default]
+extend-ignore-re = [
+    "(?Rm)^.*(#|//)\\s*spellchecker:disable-line$",
+]

--- a/data-plane/gateway/config/src/opaque.rs
+++ b/data-plane/gateway/config/src/opaque.rs
@@ -109,7 +109,7 @@ mod tests {
         assert!(opaque.contains("pass"));
         assert!(opaque.contains("word"));
         assert!(opaque.contains("passw"));
-        assert!(!opaque.contains("wordd"));
+        assert!(!opaque.contains("wordd")); // spellchecker:disable-line
         assert!(opaque.starts_with("pass"));
         assert!(opaque.ends_with("word"));
         assert!(!opaque.ends_with("worrd"));


### PR DESCRIPTION
# Description

`cargo typos` breaks the CI workflow with the following error:

```
error: `wordd` should be `world`, `word`
  --> ./gateway/config/src/opaque.rs:112:35
    |
112 |         assert!(!opaque.contains("wordd")); // spellchecker:off
    |                                   ^^^^^
    |
task: Failed to run task "data-plane:lint": exit status 2
```

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
