### PR TITLE
release agp-mcp-proxy-v0.1.1

### DIFF
--- a/data-plane/integrations/mcp/mcp-proxy/CHANGELOG.md
+++ b/data-plane/integrations/mcp/mcp-proxy/CHANGELOG.md
@@ -12,4 +12,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - release mcp proxy ([#206](https://github.com/agntcy/agp/pull/206))
-- release mcp proxy ([#204](https://github.com/agntcy/agp/pull/204))

--- a/data-plane/integrations/mcp/mcp-proxy/CHANGELOG.md
+++ b/data-plane/integrations/mcp/mcp-proxy/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/agntcy/agp/compare/agp-mcp-proxy-v0.1.0...agp-mcp-proxy-v0.1.1) - 2025-05-06
+
+### Added
+
+- release mcp proxy ([#206](https://github.com/agntcy/agp/pull/206))
+- release mcp proxy ([#204](https://github.com/agntcy/agp/pull/204))

--- a/data-plane/integrations/mcp/mcp-proxy/Cargo.lock
+++ b/data-plane/integrations/mcp/mcp-proxy/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "agp-mcp-proxy"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "agp-config",
  "agp-datapath",

--- a/data-plane/integrations/mcp/mcp-proxy/Cargo.toml
+++ b/data-plane/integrations/mcp/mcp-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agp-mcp-proxy"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "Proxy for exposing a native MCP server over AGP"


### PR DESCRIPTION



## 🤖 New release

* `agp-mcp-proxy`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/agntcy/agp/compare/agp-mcp-proxy-v0.1.0...agp-mcp-proxy-v0.1.1) - 2025-05-06

### Added

- release mcp proxy ([#206](https://github.com/agntcy/agp/pull/206))
- release mcp proxy ([#204](https://github.com/agntcy/agp/pull/204))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).