### PR TITLE
fix(python-bindings): build sdist only once

### DIFF
--- a/.github/workflows/reusable-python-build-wheels.yaml
+++ b/.github/workflows/reusable-python-build-wheels.yaml
@@ -7,6 +7,25 @@ on:
   workflow_call:
 
 jobs:
+  python-bindings-sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install protoc
+        run: |
+          sudo apt update && sudo apt install -y protobuf-compiler
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist
+          working-directory: ./data-plane/python-bindings
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-sdist
+          path: ./data-plane/python-bindings/dist
+
   python-bindings-wheels:
     runs-on: ${{ matrix.platform.runner }}
     defaults:

--- a/data-plane/python-bindings/Taskfile.yml
+++ b/data-plane/python-bindings/Taskfile.yml
@@ -87,8 +87,6 @@ tasks:
               -i                              \
               ${PYTHONS[@]}
 
-            uv run maturin sdist --out dist
-
   python-bindings:example:server:
     desc: "Run the server example"
     env:


### PR DESCRIPTION
# Description

build the sdist package only once

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
