### PR TITLE
chore: release

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "agp-controller"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "agp-config",
  "agp-datapath",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "agp-gw"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "agp-config",
  "agp-service",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "agp-service"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "agp-config",
  "agp-controller",

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -39,10 +39,10 @@ edition = "2024"
 [workspace.dependencies]
 # Local dependencies
 agp-config = { path = "gateway/config", version = "0.1.8" }
-agp-controller = { path = "gateway/controller", version = "0.1.0" }
+agp-controller = { path = "gateway/controller", version = "0.1.1" }
 agp-datapath = { path = "gateway/datapath", version = "0.7.0" }
-agp-gw = { path = "gateway/gateway", version = "0.3.13" }
-agp-service = { path = "gateway/service", version = "0.4.1" }
+agp-gw = { path = "gateway/gateway", version = "0.3.14" }
+agp-service = { path = "gateway/service", version = "0.4.2" }
 agp-signal = { path = "gateway/signal", version = "0.1.2" }
 agp-tracing = { path = "gateway/tracing", version = "0.2.1" }
 

--- a/data-plane/gateway/controller/CHANGELOG.md
+++ b/data-plane/gateway/controller/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/agntcy/agp/compare/agp-controller-v0.1.0...agp-controller-v0.1.1) - 2025-05-14
+
+### Other
+
+- *(agp-controller)* release v0.1.0 ([#250](https://github.com/agntcy/agp/pull/250))
+
 ## [0.1.0](https://github.com/agntcy/agp/releases/tag/agp-controller-v0.1.0) - 2025-05-14
 
 ### Added

--- a/data-plane/gateway/controller/Cargo.toml
+++ b/data-plane/gateway/controller/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agp-controller"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.0"
+version = "0.1.1"
 description = "Controller service and control API to configure the AGP data plane through the control plane."
 
 [dependencies]

--- a/data-plane/gateway/gateway/CHANGELOG.md
+++ b/data-plane/gateway/gateway/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.14](https://github.com/agntcy/agp/compare/agp-gw-v0.3.13...agp-gw-v0.3.14) - 2025-05-14
+
+### Other
+
+- updated the following local packages: agp-service
+
 ## [0.3.13](https://github.com/agntcy/agp/compare/agp-gw-v0.3.12...agp-gw-v0.3.13) - 2025-05-14
 
 ### Other

--- a/data-plane/gateway/gateway/Cargo.toml
+++ b/data-plane/gateway/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agp-gw"
-version = "0.3.13"
+version = "0.3.14"
 edition = { workspace = true }
 license = { workspace = true }
 description = "The main gateway executable"

--- a/data-plane/gateway/service/CHANGELOG.md
+++ b/data-plane/gateway/service/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/agntcy/agp/compare/agp-service-v0.4.1...agp-service-v0.4.2) - 2025-05-14
+
+### Other
+
+- updated the following local packages: agp-controller
+
 ## [0.4.1](https://github.com/agntcy/agp/compare/agp-service-v0.4.0...agp-service-v0.4.1) - 2025-05-14
 
 ### Added

--- a/data-plane/gateway/service/Cargo.toml
+++ b/data-plane/gateway/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agp-service"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.4.1"
+version = "0.4.2"
 description = "Main service and public API to interact with AGP data plane."
 
 [dependencies]


### PR DESCRIPTION



## 🤖 New release

* `agp-controller`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `agp-service`: 0.4.1 -> 0.4.2
* `agp-gw`: 0.3.13 -> 0.3.14

<details><summary><i><b>Changelog</b></i></summary><p>

## `agp-controller`

<blockquote>

## [0.1.1](https://github.com/agntcy/agp/compare/agp-controller-v0.1.0...agp-controller-v0.1.1) - 2025-05-14

### Other

- *(agp-controller)* release v0.1.0 ([#250](https://github.com/agntcy/agp/pull/250))
</blockquote>

## `agp-service`

<blockquote>

## [0.4.2](https://github.com/agntcy/agp/compare/agp-service-v0.4.1...agp-service-v0.4.2) - 2025-05-14

### Other

- updated the following local packages: agp-controller
</blockquote>

## `agp-gw`

<blockquote>

## [0.3.14](https://github.com/agntcy/agp/compare/agp-gw-v0.3.13...agp-gw-v0.3.14) - 2025-05-14

### Other

- updated the following local packages: agp-service
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).