### PR TITLE
chore: release

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "agp-config"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "duration-str",
  "futures",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "agp-controller"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "agp-config",
  "agp-datapath",
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "agp-datapath"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "agp-config",
  "agp-tracing",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "agp-gw"
-version = "0.3.15"
+version = "0.3.16"
 dependencies = [
  "agp-config",
  "agp-service",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "agp-service"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "agp-config",
  "agp-controller",
@@ -188,7 +188,7 @@ dependencies = [
 
 [[package]]
 name = "agp-tracing"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "agp-config",
  "once_cell",

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -36,13 +36,13 @@ edition = "2024"
 
 [workspace.dependencies]
 # Local dependencies
-agp-config = { path = "gateway/config", version = "0.1.8" }
-agp-controller = { path = "gateway/controller", version = "0.1.1" }
-agp-datapath = { path = "gateway/datapath", version = "0.7.0" }
-agp-gw = { path = "gateway/gateway", version = "0.3.15" }
-agp-service = { path = "gateway/service", version = "0.4.2" }
+agp-config = { path = "gateway/config", version = "0.1.9" }
+agp-controller = { path = "gateway/controller", version = "0.2.0" }
+agp-datapath = { path = "gateway/datapath", version = "0.8.0" }
+agp-gw = { path = "gateway/gateway", version = "0.3.16" }
+agp-service = { path = "gateway/service", version = "0.5.0" }
 agp-signal = { path = "gateway/signal", version = "0.1.2" }
-agp-tracing = { path = "gateway/tracing", version = "0.2.1" }
+agp-tracing = { path = "gateway/tracing", version = "0.2.2" }
 
 # Core dependencies
 async-trait = "0.1.88"

--- a/data-plane/gateway/config/CHANGELOG.md
+++ b/data-plane/gateway/config/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/agntcy/agp/compare/agp-config-v0.1.8...agp-config-v0.1.9) - 2025-06-02
+
+### Added
+
+- *(fire-and-forget)* add support for sticky sessions ([#281](https://github.com/agntcy/agp/pull/281))
+
 ## [0.1.8](https://github.com/agntcy/agp/compare/agp-config-v0.1.7...agp-config-v0.1.8) - 2025-05-14
 
 ### Fixed

--- a/data-plane/gateway/config/Cargo.toml
+++ b/data-plane/gateway/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agp-config"
-version = "0.1.8"
+version = "0.1.9"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Configuration utilities"

--- a/data-plane/gateway/controller/CHANGELOG.md
+++ b/data-plane/gateway/controller/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/agntcy/agp/compare/agp-controller-v0.1.1...agp-controller-v0.2.0) - 2025-06-02
+
+### Added
+
+- list connections ([#280](https://github.com/agntcy/agp/pull/280))
+- *(control-plane)* list subscriptions on control-plane ([#265](https://github.com/agntcy/agp/pull/265))
+
+### Fixed
+
+- make naming consistent ([#290](https://github.com/agntcy/agp/pull/290))
+
 ## [0.1.1](https://github.com/agntcy/agp/compare/agp-controller-v0.1.0...agp-controller-v0.1.1) - 2025-05-14
 
 ### Other

--- a/data-plane/gateway/controller/Cargo.toml
+++ b/data-plane/gateway/controller/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agp-controller"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.1"
+version = "0.2.0"
 description = "Controller service and control API to configure the AGP data plane through the control plane."
 
 [dependencies]

--- a/data-plane/gateway/datapath/CHANGELOG.md
+++ b/data-plane/gateway/datapath/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/agntcy/agp/compare/agp-datapath-v0.7.0...agp-datapath-v0.8.0) - 2025-06-02
+
+### Added
+
+- list connections ([#280](https://github.com/agntcy/agp/pull/280))
+- *(fire-and-forget)* add support for sticky sessions ([#281](https://github.com/agntcy/agp/pull/281))
+- *(control-plane)* list subscriptions on control-plane ([#265](https://github.com/agntcy/agp/pull/265))
+- *(subscriptio-table)* store also readable names ([#269](https://github.com/agntcy/agp/pull/269))
+- add optional acks for FNF messages ([#264](https://github.com/agntcy/agp/pull/264))
+
+### Fixed
+
+- keep only the from_strings method to create an AgentType ([#288](https://github.com/agntcy/agp/pull/288))
+- *(data-path)* reconnection loop ([#283](https://github.com/agntcy/agp/pull/283))
+
 ## [0.7.0](https://github.com/agntcy/agp/compare/agp-datapath-v0.6.0...agp-datapath-v0.7.0) - 2025-05-14
 
 ### Added

--- a/data-plane/gateway/datapath/Cargo.toml
+++ b/data-plane/gateway/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agp-datapath"
-version = "0.7.0"
+version = "0.8.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Core data plane functionality for AGP"

--- a/data-plane/gateway/gateway/CHANGELOG.md
+++ b/data-plane/gateway/gateway/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.16](https://github.com/agntcy/agp/compare/agp-gw-v0.3.15...agp-gw-v0.3.16) - 2025-06-02
+
+### Added
+
+- *(fire-and-forget)* add support for sticky sessions ([#281](https://github.com/agntcy/agp/pull/281))
+
 ## [0.3.15](https://github.com/agntcy/agp/compare/agp-gw-v0.3.14...agp-gw-v0.3.15) - 2025-05-14
 
 ### Fixed

--- a/data-plane/gateway/gateway/Cargo.toml
+++ b/data-plane/gateway/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agp-gw"
-version = "0.3.15"
+version = "0.3.16"
 edition = { workspace = true }
 license = { workspace = true }
 description = "The main gateway executable."

--- a/data-plane/gateway/service/CHANGELOG.md
+++ b/data-plane/gateway/service/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/agntcy/agp/compare/agp-service-v0.4.2...agp-service-v0.5.0) - 2025-06-02
+
+### Added
+
+- *(fire-and-forget)* add support for sticky sessions ([#281](https://github.com/agntcy/agp/pull/281))
+- add optional acks for FNF messages ([#264](https://github.com/agntcy/agp/pull/264))
+
+### Fixed
+
+- *(fire-and-forget)* send the ack back to the source ([#273](https://github.com/agntcy/agp/pull/273))
+- create fnf session also on FnfReliable message ([#270](https://github.com/agntcy/agp/pull/270))
+
 ## [0.4.2](https://github.com/agntcy/agp/compare/agp-service-v0.4.1...agp-service-v0.4.2) - 2025-05-14
 
 ### Other

--- a/data-plane/gateway/service/Cargo.toml
+++ b/data-plane/gateway/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agp-service"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.4.2"
+version = "0.5.0"
 description = "Main service and public API to interact with AGP data plane."
 
 [dependencies]

--- a/data-plane/gateway/tracing/CHANGELOG.md
+++ b/data-plane/gateway/tracing/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/agntcy/agp/compare/agp-tracing-v0.2.1...agp-tracing-v0.2.2) - 2025-06-02
+
+### Other
+
+- updated the following local packages: agp-config
+
 ## [0.2.1](https://github.com/agntcy/agp/compare/agp-tracing-v0.2.0...agp-tracing-v0.2.1) - 2025-05-14
 
 ### Other

--- a/data-plane/gateway/tracing/Cargo.toml
+++ b/data-plane/gateway/tracing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agp-tracing"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.2.1"
+version = "0.2.2"
 description = "Observability for AGP data plane: logs, traces and metrics infrastructure."
 
 [dependencies]


### PR DESCRIPTION



## 🤖 New release

* `agp-config`: 0.1.8 -> 0.1.9 (✓ API compatible changes)
* `agp-datapath`: 0.7.0 -> 0.8.0 (⚠ API breaking changes)
* `agp-controller`: 0.1.1 -> 0.2.0 (⚠ API breaking changes)
* `agp-service`: 0.4.2 -> 0.5.0 (⚠ API breaking changes)
* `agp-gw`: 0.3.15 -> 0.3.16 (✓ API compatible changes)
* `agp-tracing`: 0.2.1 -> 0.2.2

### ⚠ `agp-datapath` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Subscribe.organization in /tmp/.tmprJUpvd/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:7
  field Subscribe.namespace in /tmp/.tmprJUpvd/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:9
  field Subscribe.agent_type in /tmp/.tmprJUpvd/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:11
  field Subscribe.organization in /tmp/.tmprJUpvd/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:7
  field Subscribe.namespace in /tmp/.tmprJUpvd/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:9
  field Subscribe.agent_type in /tmp/.tmprJUpvd/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:11

--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type Subscribe no longer derives Copy, in /tmp/.tmprJUpvd/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:3
  type Subscribe no longer derives Copy, in /tmp/.tmprJUpvd/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:3

--- failure enum_repr_variant_discriminant_changed: variant of an enum with explicit repr changed discriminant ---

Description:
An enum variant has changed its discriminant value. The enum has a defined primitive representation, so this breaks downstream code that used the discriminant value via an unsafe pointer cast.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#pointer-casting
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_repr_variant_discriminant_changed.ron

Failed in:
  variant SessionHeaderType::Request 2 -> 6 in /tmp/.tmprJUpvd/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:106
  variant SessionHeaderType::Reply 3 -> 7 in /tmp/.tmprJUpvd/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:107
  variant SessionHeaderType::Stream 4 -> 8 in /tmp/.tmprJUpvd/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:108
  variant SessionHeaderType::PubSub 5 -> 9 in /tmp/.tmprJUpvd/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:109
  variant SessionHeaderType::RtxRequest 6 -> 10 in /tmp/.tmprJUpvd/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:110
  variant SessionHeaderType::RtxReply 7 -> 11 in /tmp/.tmprJUpvd/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:111
  variant SessionHeaderType::BeaconStream 8 -> 12 in /tmp/.tmprJUpvd/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:112
  variant SessionHeaderType::BeaconPubSub 9 -> 13 in /tmp/.tmprJUpvd/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:113

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant SessionHeaderType:FnfReliable in /tmp/.tmprJUpvd/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:102
  variant SessionHeaderType:FnfAck in /tmp/.tmprJUpvd/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:103
  variant SessionHeaderType:FnfDiscovery in /tmp/.tmprJUpvd/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:104
  variant SessionHeaderType:FnfDiscoveryReply in /tmp/.tmprJUpvd/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:105

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/inherent_method_missing.ron

Failed in:
  Subscribe::with_header, previously in file /tmp/.tmp5D2qOs/agp-datapath/src/messages/utils.rs:310
  Subscribe::with_header, previously in file /tmp/.tmp5D2qOs/agp-datapath/src/messages/utils.rs:310
  AgentType::new, previously in file /tmp/.tmp5D2qOs/agp-datapath/src/messages/encoder.rs:68
  AgentType::with_organization, previously in file /tmp/.tmp5D2qOs/agp-datapath/src/messages/encoder.rs:90
  AgentType::with_namespace, previously in file /tmp/.tmp5D2qOs/agp-datapath/src/messages/encoder.rs:97
  AgentType::with_agent_type, previously in file /tmp/.tmp5D2qOs/agp-datapath/src/messages/encoder.rs:101
  AgentType::new, previously in file /tmp/.tmp5D2qOs/agp-datapath/src/messages/encoder.rs:68
  AgentType::with_organization, previously in file /tmp/.tmp5D2qOs/agp-datapath/src/messages/encoder.rs:90
  AgentType::with_namespace, previously in file /tmp/.tmp5D2qOs/agp-datapath/src/messages/encoder.rs:97
  AgentType::with_agent_type, previously in file /tmp/.tmp5D2qOs/agp-datapath/src/messages/encoder.rs:101

--- warning partial_ord_enum_variants_reordered: enum variants reordered in #[derive(PartialOrd)] enum ---

Description:
A public enum that derives PartialOrd had its variants reordered. #[derive(PartialOrd)] uses the enum variant order to set the enum's ordering behavior, so this change may break downstream code that relies on the previous order.
        ref: https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html#derivable
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/partial_ord_enum_variants_reordered.ron

Failed in:
  SessionHeaderType::Request moved from position 3 to 7, in /tmp/.tmprJUpvd/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:106
  SessionHeaderType::Reply moved from position 4 to 8, in /tmp/.tmprJUpvd/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:107
  SessionHeaderType::Stream moved from position 5 to 9, in /tmp/.tmprJUpvd/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:108
  SessionHeaderType::PubSub moved from position 6 to 10, in /tmp/.tmprJUpvd/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:109
  SessionHeaderType::RtxRequest moved from position 7 to 11, in /tmp/.tmprJUpvd/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:110
  SessionHeaderType::RtxReply moved from position 8 to 12, in /tmp/.tmprJUpvd/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:111
  SessionHeaderType::BeaconStream moved from position 9 to 13, in /tmp/.tmprJUpvd/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:112
  SessionHeaderType::BeaconPubSub moved from position 10 to 14, in /tmp/.tmprJUpvd/agp/data-plane/gateway/datapath/src/pubsub/gen/pubsub.proto.v1.rs:113
```

### ⚠ `agp-controller` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ConfigurationCommand.subscriptions_to_set in /tmp/.tmprJUpvd/agp/data-plane/gateway/controller/src/api/gen/controller.proto.v1.rs:54
  field ConfigurationCommand.subscriptions_to_delete in /tmp/.tmprJUpvd/agp/data-plane/gateway/controller/src/api/gen/controller.proto.v1.rs:56

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant Payload:SubscriptionListRequest in /tmp/.tmprJUpvd/agp/data-plane/gateway/controller/src/api/gen/controller.proto.v1.rs:18
  variant Payload:SubscriptionListResponse in /tmp/.tmprJUpvd/agp/data-plane/gateway/controller/src/api/gen/controller.proto.v1.rs:20
  variant Payload:ConnectionListRequest in /tmp/.tmprJUpvd/agp/data-plane/gateway/controller/src/api/gen/controller.proto.v1.rs:22
  variant Payload:ConnectionListResponse in /tmp/.tmprJUpvd/agp/data-plane/gateway/controller/src/api/gen/controller.proto.v1.rs:24

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_missing.ron

Failed in:
  struct agp_controller::api::proto::api::v1::Route, previously in file /tmp/.tmp5D2qOs/agp-controller/src/api/gen/controller.proto.v1.rs:29

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field routes_to_set of struct ConfigurationCommand, previously in file /tmp/.tmp5D2qOs/agp-controller/src/api/gen/controller.proto.v1.rs:46
  field routes_to_delete of struct ConfigurationCommand, previously in file /tmp/.tmp5D2qOs/agp-controller/src/api/gen/controller.proto.v1.rs:48
```

### ⚠ `agp-service` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field FireAndForgetConfiguration.timeout in /tmp/.tmprJUpvd/agp/data-plane/gateway/service/src/fire_and_forget.rs:28
  field FireAndForgetConfiguration.max_retries in /tmp/.tmprJUpvd/agp/data-plane/gateway/service/src/fire_and_forget.rs:29
  field FireAndForgetConfiguration.sticky in /tmp/.tmprJUpvd/agp/data-plane/gateway/service/src/fire_and_forget.rs:30

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant SessionError:SessionClosed in /tmp/.tmprJUpvd/agp/data-plane/gateway/service/src/errors.rs:89
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `agp-config`

<blockquote>

## [0.1.9](https://github.com/agntcy/agp/compare/agp-config-v0.1.8...agp-config-v0.1.9) - 2025-06-02

### Added

- *(fire-and-forget)* add support for sticky sessions ([#281](https://github.com/agntcy/agp/pull/281))
</blockquote>

## `agp-datapath`

<blockquote>

## [0.8.0](https://github.com/agntcy/agp/compare/agp-datapath-v0.7.0...agp-datapath-v0.8.0) - 2025-06-02

### Added

- list connections ([#280](https://github.com/agntcy/agp/pull/280))
- *(fire-and-forget)* add support for sticky sessions ([#281](https://github.com/agntcy/agp/pull/281))
- *(control-plane)* list subscriptions on control-plane ([#265](https://github.com/agntcy/agp/pull/265))
- *(subscriptio-table)* store also readable names ([#269](https://github.com/agntcy/agp/pull/269))
- add optional acks for FNF messages ([#264](https://github.com/agntcy/agp/pull/264))

### Fixed

- keep only the from_strings method to create an AgentType ([#288](https://github.com/agntcy/agp/pull/288))
- *(data-path)* reconnection loop ([#283](https://github.com/agntcy/agp/pull/283))
</blockquote>

## `agp-controller`

<blockquote>

## [0.2.0](https://github.com/agntcy/agp/compare/agp-controller-v0.1.1...agp-controller-v0.2.0) - 2025-06-02

### Added

- list connections ([#280](https://github.com/agntcy/agp/pull/280))
- *(control-plane)* list subscriptions on control-plane ([#265](https://github.com/agntcy/agp/pull/265))

### Fixed

- make naming consistent ([#290](https://github.com/agntcy/agp/pull/290))
</blockquote>

## `agp-service`

<blockquote>

## [0.5.0](https://github.com/agntcy/agp/compare/agp-service-v0.4.2...agp-service-v0.5.0) - 2025-06-02

### Added

- *(fire-and-forget)* add support for sticky sessions ([#281](https://github.com/agntcy/agp/pull/281))
- add optional acks for FNF messages ([#264](https://github.com/agntcy/agp/pull/264))

### Fixed

- *(fire-and-forget)* send the ack back to the source ([#273](https://github.com/agntcy/agp/pull/273))
- create fnf session also on FnfReliable message ([#270](https://github.com/agntcy/agp/pull/270))
</blockquote>

## `agp-gw`

<blockquote>

## [0.3.16](https://github.com/agntcy/agp/compare/agp-gw-v0.3.15...agp-gw-v0.3.16) - 2025-06-02

### Added

- *(fire-and-forget)* add support for sticky sessions ([#281](https://github.com/agntcy/agp/pull/281))
</blockquote>

## `agp-tracing`

<blockquote>

## [0.2.2](https://github.com/agntcy/agp/compare/agp-tracing-v0.2.1...agp-tracing-v0.2.2) - 2025-06-02

### Other

- updated the following local packages: agp-config
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).