### PR TITLE
release agp-mcp-proxy-v0.1.5

### DIFF
--- a/data-plane/integrations/mcp/mcp-proxy/CHANGELOG.md
+++ b/data-plane/integrations/mcp/mcp-proxy/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/agntcy/agp/compare/agp-mcp-proxy-v0.1.4...agp-mcp-proxy-v0.1.5) - 2025-06-02
+
+### Added
+
+- *(agp-mcp)* use sticky sessions ([#282](https://github.com/agntcy/agp/pull/282))
+- add optional acks for FNF messages ([#264](https://github.com/agntcy/agp/pull/264))
+
 ## [0.1.4](https://github.com/agntcy/agp/compare/agp-mcp-proxy-v0.1.3...agp-mcp-proxy-v0.1.4) - 2025-05-15
 
 ### Fixed

--- a/data-plane/integrations/mcp/mcp-proxy/Cargo.lock
+++ b/data-plane/integrations/mcp/mcp-proxy/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "agp-mcp-proxy"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "agp-config",
  "agp-datapath",

--- a/data-plane/integrations/mcp/mcp-proxy/Cargo.toml
+++ b/data-plane/integrations/mcp/mcp-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agp-mcp-proxy"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 license = "Apache-2.0"
 description = "Proxy for exposing a native MCP server over AGP"


### PR DESCRIPTION



## 🤖 New release

* `agp-mcp-proxy`: 0.1.4 -> 0.1.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.5](https://github.com/agntcy/agp/compare/agp-mcp-proxy-v0.1.4...agp-mcp-proxy-v0.1.5) - 2025-06-02

### Added

- *(agp-mcp)* use sticky sessions ([#282](https://github.com/agntcy/agp/pull/282))
- add optional acks for FNF messages ([#264](https://github.com/agntcy/agp/pull/264))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).