### PR TITLE
fix(ci): use buildbot token for trigger integration tests in csit

### DIFF
--- a/.github/actions/trigger-integrations/action.yaml
+++ b/.github/actions/trigger-integrations/action.yaml
@@ -4,6 +4,11 @@
 ---
 name: Trigger integrations
 description: Run the integration tests in CSIT repository
+inputs:
+  github-token:
+    description: 'GitHub token'
+    required: false
+    default: ${{ github.token }}
 
 runs:
   using: 'composite'
@@ -27,6 +32,7 @@ runs:
     - name: Trigger integration tests
       uses: actions/github-script@v7
       with:
+        github-token: ${{ inputs.github-token }}
         script: |
           await github.rest.actions.createWorkflowDispatch({
               owner: 'agntcy',

--- a/.github/workflows/release-helm.yaml
+++ b/.github/workflows/release-helm.yaml
@@ -52,3 +52,5 @@ jobs:
     steps:
       - name: Trigger CSIT integration CI
         uses: ./.github/actions/trigger-integrations
+        with:
+          github-token: ${{ secrets.AGNTCY_BUILD_BOT_GH_TOKEN }}

--- a/.github/workflows/release-helm.yaml
+++ b/.github/workflows/release-helm.yaml
@@ -50,6 +50,10 @@ jobs:
     needs: [ release ]
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Trigger CSIT integration CI
         uses: ./.github/actions/trigger-integrations
         with:

--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -86,3 +86,5 @@ jobs:
           fetch-depth: 0
       - name: Trigger CSIT integration CI
         uses: ./.github/actions/trigger-integrations
+        with:
+          github-token: ${{ secrets.AGNTCY_BUILD_BOT_GH_TOKEN }}


### PR DESCRIPTION
# Description

Fix csit integration test trigger action

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
