### PR TITLE
feat: add intial testutil image build

### DIFF
--- a/.github/release-config.json
+++ b/.github/release-config.json
@@ -28,6 +28,10 @@
         "data-plane/integrations/mcp/agp-mcp/examples/mcp-server-time": {
             "package-name": "agp-mcp-server-time",
             "release-type": "simple"
+        },
+        "data-plane/testing": {
+            "package-name": "agp-testutils",
+            "release-type": "simple"
         }
     }
 }

--- a/.github/release-manifest.json
+++ b/.github/release-manifest.json
@@ -4,5 +4,6 @@
     "data-plane/integrations/mcp/agp-mcp/packages/agp-mcp": "0.1.5",
     "control-plane/agpctl": "0.1.4",
     "data-plane/integrations/mcp/agp-mcp/examples/llamaindex-time-agent": "0.1.1",
-    "data-plane/integrations/mcp/agp-mcp/examples/mcp-server-time": "0.1.1"
+    "data-plane/integrations/mcp/agp-mcp/examples/mcp-server-time": "0.1.1",
+    "data-plane/testing": "0.1.0"
 }

--- a/data-plane/testing/Dockerfile
+++ b/data-plane/testing/Dockerfile
@@ -1,0 +1,16 @@
+FROM rust:1.86 as builder
+WORKDIR /app
+COPY . .
+RUN cargo build --release --bin publisher --bin subscriber --bin workload-gen -p testing
+
+FROM debian:bookworm-slim as testutils
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY --from=builder /app/target/release/workload-gen /app/workload-gen
+COPY --from=builder /app/target/release/publisher /app/publisher
+COPY --from=builder /app/target/release/subscriber /app/subscriber
+
+CMD ["/app/workload-gen"]

--- a/data-plane/testing/Taskfile.yml
+++ b/data-plane/testing/Taskfile.yml
@@ -47,12 +47,12 @@ tasks:
   run:shutdown:
     desc: "Shutdown test"
     cmds:
-      - | 
+      - |
         echo "stop all subscribers"
         killall subscriber || true
         echo "stop all publishers"
         killall publisher || true
         echo "stop gateway"
         killall gateway || true
-  
+
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -104,3 +104,14 @@ target "llamaindex-time-agent" {
   ]
   tags = get_tag(target.docker-metadata-action.tags, "${target.llamaindex-time-agent.name}")
 }
+
+target "testutils" {
+  context = "./data-plane"
+  dockerfile = "./testing/Dockerfile"
+  target = "testutils"
+  inherits = [
+    "_common",
+    "docker-metadata-action",
+  ]
+  tags = get_tag(target.docker-metadata-action.tags, "${target.testutils.name}")
+}


### PR DESCRIPTION
# Description

Create a container image containing publisher, subscriber and workload-gen commands which are test utils for gateway testing.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
