### PR TITLE
fix(testing-apps): build using common rust taskfiles

### DIFF
--- a/data-plane/testing/Dockerfile
+++ b/data-plane/testing/Dockerfile
@@ -1,7 +1,23 @@
 FROM rust:1.86 as builder
+
+RUN DEBIAN_FRONTEND=noninteractive \
+    apt-get update && \
+    apt-get install --no-install-recommends -y \
+        curl \
+        file \
+        make \
+        unzip \
+        git \
+        pkg-config \
+        clang-14 \
+        llvm-14
+
 WORKDIR /app
 COPY . .
-RUN cargo build --release --bin publisher --bin subscriber --bin workload-gen -p testing
+RUN task                                                                        \
+    data-plane:build                                                            \
+    BUILD_ARGS="--bin publisher --bin subscriber --bin workload-gen -p testing" \
+    PROFILE=release
 
 FROM debian:bookworm-slim as testutils
 RUN apt-get update && apt-get install -y \

--- a/data-plane/testing/Dockerfile
+++ b/data-plane/testing/Dockerfile
@@ -12,6 +12,9 @@ RUN DEBIAN_FRONTEND=noninteractive \
         clang-14 \
         llvm-14
 
+# Install taskfile
+RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
+
 WORKDIR /app
 COPY . .
 RUN task                                                                        \

--- a/tasks/rust.yaml
+++ b/tasks/rust.yaml
@@ -211,7 +211,7 @@ tasks:
     cmds:
       - task: toolchain:build
         vars:
-          ARGS: "--locked --all-targets --all-features"
+          ARGS: "{{.GLOBAL_ARGS}} {{ .BUILD_ARGS | default \"--all-targets --locked --all-features\" }}"
 
   vuln:
     desc: "Check for vulnerabilities"

--- a/tasks/rust.yaml
+++ b/tasks/rust.yaml
@@ -211,7 +211,7 @@ tasks:
     cmds:
       - task: toolchain:build
         vars:
-          ARGS: "{{.GLOBAL_ARGS}} {{ .BUILD_ARGS | default \"--all-targets --locked --all-features\" }}"
+          ARGS: "{{ .BUILD_ARGS | default \"--all-targets --locked --all-features\" }}"
 
   vuln:
     desc: "Check for vulnerabilities"


### PR DESCRIPTION
# Description

This will enforce the use of LLVM as opposed to GCC
for c components like aws-lc.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
