### PR TITLE
feat: Add OpenID AuthZEN integration for fine-grained authorization (v1)

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -3671,8 +3671,11 @@ dependencies = [
  "agntcy-slim-signal",
  "clap",
  "parking_lot",
+ "serde",
+ "serde_json",
  "tokio",
  "tracing",
+ "wiremock",
 ]
 
 [[package]]

--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -45,6 +45,7 @@ dependencies = [
  "async-trait",
  "aws-lc-rs",
  "base64 0.22.1",
+ "chrono",
  "futures",
  "headers",
  "http 1.3.1",
@@ -126,7 +127,7 @@ dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-datapath",
  "bytes",
- "h2 0.4.10",
+ "h2 0.4.11",
  "parking_lot",
  "prost",
  "protoc-bin-vendored",
@@ -151,7 +152,7 @@ dependencies = [
  "bytes",
  "criterion",
  "drain",
- "h2 0.4.10",
+ "h2 0.4.11",
  "opentelemetry",
  "parking_lot",
  "prost",
@@ -201,15 +202,18 @@ dependencies = [
 name = "agntcy-slim-service"
 version = "0.4.2"
 dependencies = [
+ "agntcy-slim-auth",
  "agntcy-slim-config",
  "agntcy-slim-controller",
  "agntcy-slim-datapath",
  "async-trait",
  "bincode",
+ "chrono",
  "drain",
  "parking_lot",
  "rand 0.9.1",
  "serde",
+ "serde_json",
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",
@@ -377,7 +381,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -388,7 +392,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -552,13 +556,13 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "log",
- "prettyplease 0.2.34",
+ "prettyplease 0.2.35",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.103",
+ "syn 2.0.104",
  "which",
 ]
 
@@ -591,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytes"
@@ -643,6 +647,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -716,7 +721,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -751,15 +756,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.11"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "2e09ced7ebbccb63b4c65413d821f2e00ce54c5ca4514ddc6b3c892fdbcbc69d"
 dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
  "unicode-width",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -866,9 +871,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -901,7 +906,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -912,7 +917,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -970,7 +975,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1032,12 +1037,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1215,7 +1220,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1324,7 +1329,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1333,9 +1338,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1343,7 +1348,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1554,7 +1559,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.10",
+ "h2 0.4.11",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -1770,9 +1775,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
@@ -1780,14 +1785,14 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
+version = "0.17.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+checksum = "4adb2ee6ad319a912210a36e56e3623555817bcc877a7e6e8802d1d69c4d8056"
 dependencies = [
  "console",
- "number_prefix",
  "portable-atomic",
  "unicode-width",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -2020,9 +2025,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -2118,7 +2123,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2218,7 +2223,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2413,12 +2418,6 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "numpy"
@@ -2635,7 +2634,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
 ]
 
 [[package]]
@@ -2655,7 +2654,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2761,12 +2760,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2833,11 +2832,11 @@ dependencies = [
  "multimap",
  "once_cell",
  "petgraph",
- "prettyplease 0.2.34",
+ "prettyplease 0.2.35",
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.103",
+ "syn 2.0.104",
  "tempfile",
 ]
 
@@ -2851,7 +2850,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2980,7 +2979,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2993,7 +2992,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3024,7 +3023,7 @@ checksum = "3ee49d727163163a0c6fc3fee4636c8b5c82e1bb868e85cf411be7ae9e4e5b40"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3223,9 +3222,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.20"
+version = "0.12.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
+checksum = "4c8cea6b35bcceb099f30173754403d2eba0a5dc18cea3630fccd88251909288"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3233,7 +3232,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.10",
+ "h2 0.4.11",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -3444,7 +3443,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "thiserror 1.0.69",
 ]
 
@@ -3541,7 +3540,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3594,7 +3593,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itoa",
  "ryu",
  "serde",
@@ -3767,9 +3766,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3793,7 +3792,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3880,7 +3879,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3891,7 +3890,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3979,7 +3978,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4043,7 +4042,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4093,7 +4092,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.10",
+ "h2 0.4.11",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -4118,12 +4117,12 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
 dependencies = [
- "prettyplease 0.2.34",
+ "prettyplease 0.2.35",
  "proc-macro2",
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4171,7 +4170,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -4233,7 +4232,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4311,7 +4310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4361,6 +4360,12 @@ checksum = "3e130f2ed46ca5d8ec13c7ff95836827f92f5f5f37fd2b2bf16f33c408d98bb6"
 dependencies = [
  "extension-traits",
 ]
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -4513,7 +4518,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "wasm-bindgen-shared",
 ]
 
@@ -4548,7 +4553,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4646,7 +4651,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4657,7 +4662,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4668,9 +4673,9 @@ checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-registry"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bab093bdd303a1240bb99b8aba8ea8a69ee19d34c9e2ef9594e708a4878820"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
  "windows-link",
  "windows-result",
@@ -4711,6 +4716,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -4936,7 +4950,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -4957,7 +4971,7 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4977,7 +4991,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -4998,7 +5012,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5031,5 +5045,5 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]

--- a/data-plane/core/auth/Cargo.toml
+++ b/data-plane/core/auth/Cargo.toml
@@ -12,6 +12,7 @@ name = "slim_auth"
 async-trait = { workspace = true }
 aws-lc-rs = { workspace = true }
 base64 = { workspace = true }
+chrono = { version = "0.4", features = ["serde"] }
 futures = { workspace = true }
 headers = { workspace = true }
 http = { workspace = true }
@@ -23,9 +24,9 @@ reqwest = { workspace = true }
 rustls = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_yaml.workspace = true
+serde_yaml = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync"] }
 tokio-util = { workspace = true }
 tower = { workspace = true }
 tower-layer = { workspace = true }

--- a/data-plane/core/auth/src/authzen.rs
+++ b/data-plane/core/auth/src/authzen.rs
@@ -1,0 +1,528 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! AuthZEN authorization client implementation
+//! 
+//! This module provides integration with OpenID AuthZEN standard authorization APIs.
+//! See: https://openid.github.io/authzen/
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+
+use crate::errors::AuthError;
+
+/// AuthZEN Subject representation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthZenSubject {
+    #[serde(rename = "type")]
+    pub subject_type: String,
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub properties: Option<serde_json::Value>,
+}
+
+/// AuthZEN Action representation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthZenAction {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub properties: Option<serde_json::Value>,
+}
+
+/// AuthZEN Resource representation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthZenResource {
+    #[serde(rename = "type")]
+    pub resource_type: String,
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub properties: Option<serde_json::Value>,
+}
+
+/// AuthZEN evaluation request
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthZenRequest {
+    pub subject: AuthZenSubject,
+    pub action: AuthZenAction,
+    pub resource: AuthZenResource,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<serde_json::Value>,
+}
+
+/// AuthZEN evaluation response
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthZenResponse {
+    pub decision: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<serde_json::Value>,
+}
+
+/// AuthZEN batch evaluations request
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthZenEvaluationsRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subject: Option<AuthZenSubject>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub action: Option<AuthZenAction>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resource: Option<AuthZenResource>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<serde_json::Value>,
+    pub evaluations: Vec<AuthZenRequest>,
+}
+
+/// AuthZEN batch evaluations response
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthZenEvaluationsResponse {
+    pub evaluations: Vec<AuthZenResponse>,
+}
+
+/// Cache entry for authorization decisions
+#[derive(Debug, Clone)]
+struct CacheEntry {
+    decision: bool,
+    expires_at: Instant,
+}
+
+/// AuthZEN cache key
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+struct CacheKey {
+    subject: String,
+    action: String,
+    resource: String,
+    context_hash: u64,
+}
+
+/// AuthZEN configuration
+#[derive(Debug, Clone)]
+pub struct AuthZenConfig {
+    pub pdp_endpoint: String,
+    pub timeout: Duration,
+    pub cache_ttl: Duration,
+    pub fallback_allow: bool,
+    pub max_retries: u32,
+}
+
+impl Default for AuthZenConfig {
+    fn default() -> Self {
+        Self {
+            pdp_endpoint: "http://localhost:8080".to_string(),
+            timeout: Duration::from_secs(5),
+            cache_ttl: Duration::from_secs(300), // 5 minutes
+            fallback_allow: false, // fail-closed by default
+            max_retries: 3,
+        }
+    }
+}
+
+/// AuthZEN authorization client
+pub struct AuthZenAuthorizer {
+    client: Client,
+    config: AuthZenConfig,
+    cache: Arc<RwLock<HashMap<CacheKey, CacheEntry>>>,
+}
+
+impl AuthZenAuthorizer {
+    /// Create a new AuthZEN authorizer
+    pub fn new(config: AuthZenConfig) -> Result<Self, AuthError> {
+        let client = Client::builder()
+            .timeout(config.timeout)
+            .build()
+            .map_err(|e| AuthError::ConfigurationError(format!("Failed to create HTTP client: {}", e)))?;
+
+        Ok(Self {
+            client,
+            config,
+            cache: Arc::new(RwLock::new(HashMap::new())),
+        })
+    }
+
+    /// Evaluate a single authorization request
+    pub async fn evaluate(
+        &self,
+        subject: AuthZenSubject,
+        action: AuthZenAction,
+        resource: AuthZenResource,
+        context: Option<serde_json::Value>,
+    ) -> Result<bool, AuthError> {
+        // Check cache first
+        let cache_key = self.create_cache_key(&subject, &action, &resource, &context);
+        if let Some(cached) = self.get_cached_decision(&cache_key).await {
+            return Ok(cached);
+        }
+
+        let request = AuthZenRequest {
+            subject: subject.clone(),
+            action: action.clone(),
+            resource: resource.clone(),
+            context: context.clone(),
+        };
+
+        match self.make_request(&request).await {
+            Ok(decision) => {
+                // Cache the decision
+                self.cache_decision(cache_key, decision).await;
+                Ok(decision)
+            }
+            Err(AuthError::FallbackAllow) => {
+                // Return true for fallback allow and cache it
+                self.cache_decision(cache_key, true).await;
+                Ok(true)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Evaluate multiple authorization requests in a batch
+    pub async fn evaluate_batch(
+        &self,
+        requests: Vec<AuthZenRequest>,
+    ) -> Result<Vec<bool>, AuthError> {
+        if requests.is_empty() {
+            return Ok(vec![]);
+        }
+
+        // For now, use the single evaluation endpoint multiple times
+        // TODO: Implement proper batch evaluation using /access/v1/evaluations
+        let mut results = Vec::with_capacity(requests.len());
+        
+        for request in requests {
+            let decision = self.make_request(&request).await?;
+            results.push(decision);
+        }
+        
+        Ok(results)
+    }
+
+    /// Make HTTP request to AuthZEN PDP
+    async fn make_request(&self, request: &AuthZenRequest) -> Result<bool, AuthError> {
+        let url = format!("{}/access/v1/evaluation", self.config.pdp_endpoint);
+        
+        let response = self.client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .json(request)
+            .send()
+            .await
+            .map_err(|e| {
+                tracing::error!("AuthZEN request failed: {}", e);
+                if self.config.fallback_allow {
+                    tracing::warn!("Falling back to ALLOW due to AuthZEN unavailability");
+                    return AuthError::FallbackAllow;
+                }
+                AuthError::NetworkError(format!("AuthZEN request failed: {}", e))
+            })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            tracing::error!("AuthZEN returned error status {}: {}", status, body);
+            
+            if self.config.fallback_allow {
+                tracing::warn!("Falling back to ALLOW due to AuthZEN error");
+                return Ok(true);
+            }
+            
+            return Err(AuthError::AuthorizationError(
+                format!("AuthZEN returned error status {}: {}", status, body)
+            ));
+        }
+
+        let authzen_response: AuthZenResponse = response
+            .json()
+            .await
+            .map_err(|e| AuthError::ParseError(format!("Invalid AuthZEN response: {}", e)))?;
+
+        tracing::debug!(
+            subject = %request.subject.id,
+            action = %request.action.name, 
+            resource = %request.resource.id,
+            decision = %authzen_response.decision,
+            "AuthZEN decision"
+        );
+
+        Ok(authzen_response.decision)
+    }
+
+    /// Create cache key for the request
+    fn create_cache_key(
+        &self,
+        subject: &AuthZenSubject,
+        action: &AuthZenAction, 
+        resource: &AuthZenResource,
+        context: &Option<serde_json::Value>,
+    ) -> CacheKey {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        let context_hash = {
+            let mut hasher = DefaultHasher::new();
+            context.hash(&mut hasher);
+            hasher.finish()
+        };
+
+        CacheKey {
+            subject: format!("{}:{}", subject.subject_type, subject.id),
+            action: action.name.clone(),
+            resource: format!("{}:{}", resource.resource_type, resource.id),
+            context_hash,
+        }
+    }
+
+    /// Get cached decision if available and not expired
+    async fn get_cached_decision(&self, key: &CacheKey) -> Option<bool> {
+        let cache = self.cache.read().await;
+        
+        if let Some(entry) = cache.get(key) {
+            if entry.expires_at > Instant::now() {
+                tracing::debug!("Cache hit for authorization decision");
+                return Some(entry.decision);
+            }
+        }
+        
+        None
+    }
+
+    /// Cache authorization decision
+    async fn cache_decision(&self, key: CacheKey, decision: bool) {
+        let entry = CacheEntry {
+            decision,
+            expires_at: Instant::now() + self.config.cache_ttl,
+        };
+        
+        let mut cache = self.cache.write().await;
+        cache.insert(key, entry);
+        
+        // Simple cleanup: remove expired entries occasionally
+        if cache.len() > 1000 {
+            cache.retain(|_, entry| entry.expires_at > Instant::now());
+        }
+    }
+
+    /// Clear authorization cache
+    pub async fn clear_cache(&self) {
+        let mut cache = self.cache.write().await;
+        cache.clear();
+        tracing::info!("AuthZEN cache cleared");
+    }
+}
+
+/// Helper trait for converting SLIM entities to AuthZEN format
+pub trait ToAuthZen {
+    fn to_authzen_subject(&self) -> AuthZenSubject;
+    fn to_authzen_resource(&self) -> AuthZenResource;
+}
+
+// We'll implement this trait for SLIM types in the service integration 
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{body_json_string, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn test_authzen_config_default() {
+        let config = AuthZenConfig::default();
+        assert_eq!(config.pdp_endpoint, "http://localhost:8080");
+        assert_eq!(config.timeout, Duration::from_secs(5));
+        assert_eq!(config.cache_ttl, Duration::from_secs(300));
+        assert_eq!(config.fallback_allow, false);
+        assert_eq!(config.max_retries, 3);
+    }
+
+    #[tokio::test]
+    async fn test_authzen_authorizer_creation() {
+        let config = AuthZenConfig::default();
+        let authorizer = AuthZenAuthorizer::new(config);
+        assert!(authorizer.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_authzen_evaluation_success() {
+        // Start a mock server
+        let mock_server = MockServer::start().await;
+
+        // Mock the AuthZEN evaluation endpoint
+        Mock::given(method("POST"))
+            .and(path("/access/v1/evaluation"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(AuthZenResponse {
+                decision: true,
+                context: None,
+            }))
+            .mount(&mock_server)
+            .await;
+
+        // Create config pointing to mock server
+        let config = AuthZenConfig {
+            pdp_endpoint: mock_server.uri(),
+            timeout: Duration::from_secs(5),
+            cache_ttl: Duration::from_secs(300),
+            fallback_allow: false,
+            max_retries: 3,
+        };
+
+        let authorizer = AuthZenAuthorizer::new(config).unwrap();
+
+        let subject = AuthZenSubject {
+            subject_type: "agent".to_string(),
+            id: "test-agent".to_string(),
+            properties: None,
+        };
+
+        let action = AuthZenAction {
+            name: "publish".to_string(),
+            properties: None,
+        };
+
+        let resource = AuthZenResource {
+            resource_type: "route".to_string(),
+            id: "test-route".to_string(),
+            properties: None,
+        };
+
+        let decision = authorizer.evaluate(subject, action, resource, None).await;
+        assert!(decision.is_ok());
+        assert_eq!(decision.unwrap(), true);
+    }
+
+    #[tokio::test]
+    async fn test_authzen_evaluation_denied() {
+        // Start a mock server
+        let mock_server = MockServer::start().await;
+
+        // Mock the AuthZEN evaluation endpoint returning false
+        Mock::given(method("POST"))
+            .and(path("/access/v1/evaluation"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(AuthZenResponse {
+                decision: false,
+                context: None,
+            }))
+            .mount(&mock_server)
+            .await;
+
+        let config = AuthZenConfig {
+            pdp_endpoint: mock_server.uri(),
+            timeout: Duration::from_secs(5),
+            cache_ttl: Duration::from_secs(300),
+            fallback_allow: false,
+            max_retries: 3,
+        };
+
+        let authorizer = AuthZenAuthorizer::new(config).unwrap();
+
+        let subject = AuthZenSubject {
+            subject_type: "agent".to_string(),
+            id: "test-agent".to_string(),
+            properties: None,
+        };
+
+        let action = AuthZenAction {
+            name: "publish".to_string(),
+            properties: None,
+        };
+
+        let resource = AuthZenResource {
+            resource_type: "route".to_string(),
+            id: "test-route".to_string(),
+            properties: None,
+        };
+
+        let decision = authorizer.evaluate(subject, action, resource, None).await;
+        assert!(decision.is_ok());
+        assert_eq!(decision.unwrap(), false);
+    }
+
+    #[tokio::test]
+    async fn test_authzen_fallback_allow() {
+        // Create config with fallback_allow = true and invalid endpoint
+        let config = AuthZenConfig {
+            pdp_endpoint: "http://invalid-endpoint:9999".to_string(),
+            timeout: Duration::from_millis(100),
+            cache_ttl: Duration::from_secs(300),
+            fallback_allow: true,
+            max_retries: 1,
+        };
+
+        let authorizer = AuthZenAuthorizer::new(config).unwrap();
+
+        let subject = AuthZenSubject {
+            subject_type: "agent".to_string(),
+            id: "test-agent".to_string(),
+            properties: None,
+        };
+
+        let action = AuthZenAction {
+            name: "publish".to_string(),
+            properties: None,
+        };
+
+        let resource = AuthZenResource {
+            resource_type: "route".to_string(),
+            id: "test-route".to_string(),
+            properties: None,
+        };
+
+        let decision = authorizer.evaluate(subject, action, resource, None).await;
+        assert!(decision.is_ok());
+        assert_eq!(decision.unwrap(), true); // Should fallback to allow
+    }
+
+    #[tokio::test]
+    async fn test_authzen_cache() {
+        let mock_server = MockServer::start().await;
+
+        // Mock the evaluation endpoint to return true
+        Mock::given(method("POST"))
+            .and(path("/access/v1/evaluation"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(AuthZenResponse {
+                decision: true,
+                context: None,
+            }))
+            .expect(1) // Should only be called once due to caching
+            .mount(&mock_server)
+            .await;
+
+        let config = AuthZenConfig {
+            pdp_endpoint: mock_server.uri(),
+            timeout: Duration::from_secs(5),
+            cache_ttl: Duration::from_secs(300),
+            fallback_allow: false,
+            max_retries: 3,
+        };
+
+        let authorizer = AuthZenAuthorizer::new(config).unwrap();
+
+        let subject = AuthZenSubject {
+            subject_type: "agent".to_string(),
+            id: "test-agent".to_string(),
+            properties: None,
+        };
+
+        let action = AuthZenAction {
+            name: "publish".to_string(),
+            properties: None,
+        };
+
+        let resource = AuthZenResource {
+            resource_type: "route".to_string(),
+            id: "test-route".to_string(),
+            properties: None,
+        };
+
+        // First call - should hit the server
+        let decision1 = authorizer.evaluate(subject.clone(), action.clone(), resource.clone(), None).await;
+        assert!(decision1.is_ok());
+        assert_eq!(decision1.unwrap(), true);
+
+        // Second call - should use cache
+        let decision2 = authorizer.evaluate(subject, action, resource, None).await;
+        assert!(decision2.is_ok());
+        assert_eq!(decision2.unwrap(), true);
+    }
+} 

--- a/data-plane/core/auth/src/authzen.rs
+++ b/data-plane/core/auth/src/authzen.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use reqwest::Client;
+use rustls;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 
@@ -130,6 +131,9 @@ pub struct AuthZenAuthorizer {
 impl AuthZenAuthorizer {
     /// Create a new AuthZEN authorizer
     pub fn new(config: AuthZenConfig) -> Result<Self, AuthError> {
+        // Ensure crypto provider is set up for rustls
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+        
         let client = Client::builder()
             .timeout(config.timeout)
             .build()

--- a/data-plane/core/auth/src/errors.rs
+++ b/data-plane/core/auth/src/errors.rs
@@ -8,6 +8,9 @@ pub enum AuthError {
     #[error("config error: {0}")]
     ConfigError(String),
 
+    #[error("configuration error: {0}")]
+    ConfigurationError(String),
+
     #[error("token expired")]
     TokenExpired,
 
@@ -25,4 +28,16 @@ pub enum AuthError {
 
     #[error("invalid header: {0}")]
     InvalidHeader(String),
+
+    #[error("network error: {0}")]
+    NetworkError(String),
+
+    #[error("authorization error: {0}")]
+    AuthorizationError(String),
+
+    #[error("parse error: {0}")]
+    ParseError(String),
+
+    #[error("fallback allow - continuing due to AuthZEN unavailability")]
+    FallbackAllow,
 }

--- a/data-plane/core/auth/src/lib.rs
+++ b/data-plane/core/auth/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod authzen;
 pub mod builder;
 pub mod errors;
 pub mod file_watcher;

--- a/data-plane/core/service/Cargo.toml
+++ b/data-plane/core/service/Cargo.toml
@@ -9,15 +9,18 @@ description = "Main service and public API to interact with SLIM data plane."
 name = "slim_service"
 
 [dependencies]
+agntcy-slim-auth = { workspace = true }
 agntcy-slim-config = { workspace = true }
 agntcy-slim-controller = { workspace = true }
 agntcy-slim-datapath = { workspace = true }
 async-trait = { workspace = true }
 bincode = { workspace = true }
+chrono = { version = "0.4", features = ["serde"] }
 drain = { workspace = true }
 parking_lot = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/data-plane/core/service/src/authzen_integration.rs
+++ b/data-plane/core/service/src/authzen_integration.rs
@@ -1,0 +1,350 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! AuthZEN integration for SLIM service layer
+//! 
+//! This module provides the bridge between SLIM's internal types and the 
+//! OpenID AuthZEN authorization API standard.
+
+use std::time::Duration;
+
+use serde_json::json;
+use slim_auth::authzen::{
+    AuthZenAction, AuthZenAuthorizer, AuthZenConfig, AuthZenResource, AuthZenSubject,
+};
+use slim_auth::errors::AuthError;
+use slim_datapath::messages::encoder::{Agent, AgentType};
+use tracing::{debug, warn};
+
+use crate::errors::ServiceError;
+
+/// Local conversion functions to avoid orphan rule violations
+fn agent_to_authzen_subject(agent: &Agent) -> AuthZenSubject {
+    let properties = if let (Some(org), Some(ns), Some(agent_type)) = (
+        agent.agent_type().organization_string(),
+        agent.agent_type().namespace_string(),
+        agent.agent_type().agent_type_string(),
+    ) {
+        Some(json!({
+            "organization": org,
+            "namespace": ns,
+            "agent_type": agent_type,
+            "agent_id": agent.agent_id()
+        }))
+    } else {
+        Some(json!({
+            "agent_id": agent.agent_id()
+        }))
+    };
+
+    AuthZenSubject {
+        subject_type: "agent".to_string(),
+        id: agent.to_string(),
+        properties,
+    }
+}
+
+fn agent_to_authzen_resource(agent: &Agent) -> AuthZenResource {
+    let properties = if let (Some(org), Some(ns), Some(agent_type)) = (
+        agent.agent_type().organization_string(),
+        agent.agent_type().namespace_string(),
+        agent.agent_type().agent_type_string(),
+    ) {
+        Some(json!({
+            "organization": org,
+            "namespace": ns,
+            "agent_type": agent_type,
+            "agent_id": agent.agent_id()
+        }))
+    } else {
+        Some(json!({
+            "agent_id": agent.agent_id()
+        }))
+    };
+
+    AuthZenResource {
+        resource_type: "agent".to_string(),
+        id: agent.to_string(),
+        properties,
+    }
+}
+
+fn agent_type_to_authzen_resource(agent_type: &AgentType) -> AuthZenResource {
+    let properties = if let (Some(org), Some(ns), Some(agent_type_str)) = (
+        agent_type.organization_string(),
+        agent_type.namespace_string(),
+        agent_type.agent_type_string(),
+    ) {
+        Some(json!({
+            "organization": org,
+            "namespace": ns,
+            "agent_type": agent_type_str
+        }))
+    } else {
+        None
+    };
+
+    AuthZenResource {
+        resource_type: "route".to_string(),
+        id: agent_type.to_string(),
+        properties,
+    }
+}
+
+/// AuthZEN service integration wrapper
+pub struct AuthZenService {
+    authorizer: Option<AuthZenAuthorizer>,
+    enabled: bool,
+}
+
+impl AuthZenService {
+    /// Create a new AuthZEN service integration
+    pub fn new(config: Option<AuthZenServiceConfig>) -> Result<Self, ServiceError> {
+        let (authorizer, enabled) = match config {
+            Some(config) if config.enabled => {
+                let authzen_config = AuthZenConfig {
+                    pdp_endpoint: config.pdp_endpoint,
+                    timeout: config.timeout,
+                    cache_ttl: config.cache_ttl,
+                    fallback_allow: config.fallback_allow,
+                    max_retries: config.max_retries,
+                };
+
+                let authorizer = AuthZenAuthorizer::new(authzen_config)
+                    .map_err(|e| ServiceError::ConfigError(format!("AuthZEN setup failed: {}", e)))?;
+
+                (Some(authorizer), true)
+            }
+            _ => (None, false),
+        };
+
+        Ok(Self { authorizer, enabled })
+    }
+
+    /// Check if AuthZEN is enabled
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Authorize route creation
+    pub async fn authorize_route(
+        &self,
+        agent: &Agent,
+        target_type: &AgentType,
+        connection_id: Option<u64>,
+    ) -> Result<bool, ServiceError> {
+        if !self.enabled {
+            return Ok(true); // Allow if AuthZEN is disabled
+        }
+
+        let authorizer = self.authorizer.as_ref().unwrap();
+
+        let subject = agent_to_authzen_subject(agent);
+        let action = AuthZenAction {
+            name: "route".to_string(),
+            properties: None,
+        };
+        let resource = agent_type_to_authzen_resource(target_type);
+        let context = connection_id.map(|conn_id| {
+            json!({
+                "connection_id": conn_id,
+                "timestamp": chrono::Utc::now().to_rfc3339()
+            })
+        });
+
+        match authorizer.evaluate(subject, action, resource, context).await {
+            Ok(decision) => {
+                debug!(
+                    agent = %agent,
+                    target = %target_type,
+                    connection_id = ?connection_id,
+                    decision = %decision,
+                    "AuthZEN route authorization"
+                );
+                Ok(decision)
+            }
+            Err(AuthError::FallbackAllow) => {
+                warn!(
+                    agent = %agent,
+                    target = %target_type,
+                    "AuthZEN unavailable, allowing route creation due to fallback policy"
+                );
+                Ok(true)
+            }
+            Err(e) => {
+                warn!(
+                    agent = %agent,
+                    target = %target_type,
+                    error = %e,
+                    "AuthZEN authorization failed"
+                );
+                Ok(false)
+            }
+        }
+    }
+
+    /// Authorize message publishing
+    pub async fn authorize_publish(
+        &self,
+        source: &Agent,
+        target_type: &AgentType,
+        target_id: Option<u64>,
+        message_size: Option<usize>,
+    ) -> Result<bool, ServiceError> {
+        if !self.enabled {
+            return Ok(true); // Allow if AuthZEN is disabled
+        }
+
+        let authorizer = self.authorizer.as_ref().unwrap();
+
+        let subject = agent_to_authzen_subject(source);
+        let action = AuthZenAction {
+            name: "publish".to_string(),
+            properties: message_size.map(|size| json!({"message_size": size})),
+        };
+
+        // Create a target agent resource for publishing
+        let target_agent = if let Some(agent_id) = target_id {
+            Agent::new(target_type.clone(), agent_id)
+        } else {
+            // Use a default agent ID for agent types without specific ID
+            Agent::new(target_type.clone(), 0)
+        };
+
+        let resource = agent_to_authzen_resource(&target_agent);
+        let context = Some(json!({
+            "timestamp": chrono::Utc::now().to_rfc3339(),
+            "target_agent_id": target_id
+        }));
+
+        match authorizer.evaluate(subject, action, resource, context).await {
+            Ok(decision) => {
+                debug!(
+                    source = %source,
+                    target = %target_type,
+                    target_id = ?target_id,
+                    decision = %decision,
+                    "AuthZEN publish authorization"
+                );
+                Ok(decision)
+            }
+            Err(AuthError::FallbackAllow) => {
+                warn!(
+                    source = %source,
+                    target = %target_type,
+                    "AuthZEN unavailable, allowing publish due to fallback policy"
+                );
+                Ok(true)
+            }
+            Err(e) => {
+                warn!(
+                    source = %source,
+                    target = %target_type,
+                    error = %e,
+                    "AuthZEN publish authorization failed"
+                );
+                Ok(false)
+            }
+        }
+    }
+
+    /// Authorize subscription
+    pub async fn authorize_subscribe(
+        &self,
+        agent: &Agent,
+        target_type: &AgentType,
+        target_id: Option<u64>,
+    ) -> Result<bool, ServiceError> {
+        if !self.enabled {
+            return Ok(true); // Allow if AuthZEN is disabled
+        }
+
+        let authorizer = self.authorizer.as_ref().unwrap();
+
+        let subject = agent_to_authzen_subject(agent);
+        let action = AuthZenAction {
+            name: "subscribe".to_string(),
+            properties: None,
+        };
+
+        // Create a target agent resource for subscription
+        let target_agent = if let Some(agent_id) = target_id {
+            Agent::new(target_type.clone(), agent_id)
+        } else {
+            Agent::new(target_type.clone(), 0)
+        };
+
+        let resource = agent_to_authzen_resource(&target_agent);
+        let context = Some(json!({
+            "timestamp": chrono::Utc::now().to_rfc3339(),
+            "target_agent_id": target_id
+        }));
+
+        match authorizer.evaluate(subject, action, resource, context).await {
+            Ok(decision) => {
+                debug!(
+                    agent = %agent,
+                    target = %target_type,
+                    target_id = ?target_id,
+                    decision = %decision,
+                    "AuthZEN subscribe authorization"
+                );
+                Ok(decision)
+            }
+            Err(AuthError::FallbackAllow) => {
+                warn!(
+                    agent = %agent,
+                    target = %target_type,
+                    "AuthZEN unavailable, allowing subscribe due to fallback policy"
+                );
+                Ok(true)
+            }
+            Err(e) => {
+                warn!(
+                    agent = %agent,
+                    target = %target_type,
+                    error = %e,
+                    "AuthZEN subscribe authorization failed"
+                );
+                Ok(false)
+            }
+        }
+    }
+
+    /// Clear the authorization cache
+    pub async fn clear_cache(&self) {
+        if let Some(authorizer) = &self.authorizer {
+            authorizer.clear_cache().await;
+        }
+    }
+}
+
+/// Configuration for AuthZEN service integration
+#[derive(Debug, Clone)]
+pub struct AuthZenServiceConfig {
+    pub enabled: bool,
+    pub pdp_endpoint: String,
+    pub timeout: Duration,
+    pub cache_ttl: Duration,
+    pub fallback_allow: bool,
+    pub max_retries: u32,
+}
+
+impl Default for AuthZenServiceConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            pdp_endpoint: "http://localhost:8080".to_string(),
+            timeout: Duration::from_secs(5),
+            cache_ttl: Duration::from_secs(300),
+            fallback_allow: false,
+            max_retries: 3,
+        }
+    }
+}
+
+impl From<ServiceError> for AuthError {
+    fn from(err: ServiceError) -> Self {
+        AuthError::AuthorizationError(err.to_string())
+    }
+} 

--- a/data-plane/core/service/src/lib.rs
+++ b/data-plane/core/service/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod authzen_integration;
 pub mod errors;
 pub mod producer_buffer;
 pub mod receiver_buffer;

--- a/data-plane/examples/Cargo.toml
+++ b/data-plane/examples/Cargo.toml
@@ -23,3 +23,6 @@ clap = { workspace = true }
 parking_lot = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+wiremock = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/data-plane/examples/Cargo.toml
+++ b/data-plane/examples/Cargo.toml
@@ -8,6 +8,10 @@ publish = false
 name = "sdk-mock"
 path = "src/sdk-mock/main.rs"
 
+[[bin]]
+name = "authzen-demo"
+path = "src/authzen-demo/main.rs"
+
 [dependencies]
 agntcy-slim = { workspace = true }
 agntcy-slim-config = { workspace = true }

--- a/data-plane/examples/README.md
+++ b/data-plane/examples/README.md
@@ -1,5 +1,27 @@
 # Run this example
 
+## Available Examples
+
+### SDK Mock (`sdk-mock`)
+Basic SLIM SDK demonstration showing agent communication patterns.
+
+### AuthZEN Integration Demo (`authzen-demo`)
+Comprehensive demonstration of SLIM's AuthZEN (OpenID Authorization API) integration for fine-grained authorization. See [authzen-demo README](src/authzen-demo/README.md) for details.
+
+## Quick Start
+
+### AuthZEN Demo
+```bash
+# Run AuthZEN integration example
+cargo run --bin authzen-demo
+
+# Run with custom PDP endpoint
+cargo run --bin authzen-demo --pdp-endpoint http://your-pdp:8080
+```
+
+### SDK Mock
+See instructions below for Docker Compose or manual runs.
+
 # Docker Compose Quick Start
 
 To run all services (slim server, mock agent server, and mock agent client) using Docker Compose:

--- a/data-plane/examples/config/slim.yml
+++ b/data-plane/examples/config/slim.yml
@@ -1,0 +1,33 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+# Minimal SLIM configuration for AuthZEN integration demo
+
+# Tracing configuration
+tracing:
+  log_level: info
+  display_thread_names: true
+  display_thread_ids: false
+
+# Runtime configuration
+runtime:
+  n_cores: 0
+  thread_name: "authzen-demo"
+  drain_timeout: 5s
+
+# Services configuration
+services:
+  # Main SLIM service for AuthZEN demo
+  slim/0:
+    # PubSub API configuration  
+    pubsub:
+      servers:
+        - endpoint: "127.0.0.1:46357"
+          # Disable TLS for demo simplicity
+          tls:
+            insecure: true
+          auth:
+            # Basic auth for demo simplicity
+            basic:
+              username: "demo"
+              password: "authzen-demo" 

--- a/data-plane/examples/src/authzen-demo/README.md
+++ b/data-plane/examples/src/authzen-demo/README.md
@@ -13,7 +13,7 @@ AuthZEN is an OpenID Foundation standard that defines a REST API for Policy Deci
 
 ## Example Features
 
-This example demonstrates:
+This example demonstrates AuthZEN authorization testing without full SLIM service operations:
 
 ### 🔐 Authorization Scenarios
 - **Route Authorization**: Agent-to-agent route establishment permissions
@@ -25,14 +25,17 @@ This example demonstrates:
 - AuthZEN client configuration and integration
 - SLIM entity to AuthZEN format conversion (Agent → Subject, AgentType → Resource)
 - Error handling and fallback policies
+- Mock PDP server for realistic testing
 - Performance testing with cached decisions
 
 ### 📊 Demo Scenarios
 1. **Agent Creation**: Create publisher, subscriber, and admin agents
-2. **Route Testing**: Authorized and unauthorized route creation attempts
-3. **Message Publishing**: Normal and oversized message authorization
-4. **Subscription Management**: Same-org and cross-org subscription attempts
+2. **Route Testing**: Authorized and unauthorized route creation authorization
+3. **Message Publishing**: Normal and oversized message authorization testing
+4. **Subscription Management**: Same-org and cross-org subscription authorization
 5. **Cache Testing**: Performance impact of authorization caching
+
+Note: This demo focuses on authorization decision testing. Actual SLIM operations (route creation, message publishing, subscriptions) are skipped to maintain clean output focused on AuthZEN functionality.
 
 ## Quick Start
 
@@ -55,13 +58,16 @@ cargo run --bin authzen-demo -- --help
 # Run with default settings (fail-open for demo)
 cargo run --bin authzen-demo
 
-# Test fail-closed security behavior
+# Run with mock PDP server (recommended - default)
+cargo run --bin authzen-demo -- --mock-pdp
+
+# Test fail-closed security behavior 
 cargo run --bin authzen-demo -- --fail-closed
 
-# Run with a real AuthZEN PDP
-cargo run --bin authzen-demo -- --pdp-endpoint http://your-pdp:8080
+# Test with real AuthZEN PDP (disable mock)
+cargo run --bin authzen-demo -- --no-mock-pdp --pdp-endpoint http://your-pdp:8080
 
-# Disable AuthZEN (JWT-only mode)
+# Disable AuthZEN entirely (JWT-only mode)
 cargo run --bin authzen-demo -- --authzen-enabled false
 ```
 
@@ -74,10 +80,29 @@ Options:
       --pdp-endpoint <ENDPOINT>        AuthZEN PDP endpoint URL [default: http://localhost:8080]
       --fallback-allow                 Allow operations when PDP is unavailable [default: true]
       --fail-closed                    Test fail-closed security (deny when PDP unavailable)
+      --mock-pdp                       Create a local mock PDP server [default: true]
       --demo-mode                      Run comprehensive demo scenarios [default: true]
   -v, --verbose                        Enable verbose authorization logging [default: false]
   -h, --help                           Print help information
 ```
+
+## Mock PDP Server
+
+The example includes a built-in mock AuthZEN PDP server for realistic testing without requiring an external policy engine. The mock PDP implements these policies:
+
+### 📋 Mock Policies
+- **Same-Organization Routes**: ✅ Allow route creation between agents in the same organization (`cisco`)
+- **Cross-Organization Routes**: ❌ Deny routes to external organizations (`external`, etc.)
+- **Message Publishing**: ✅ Allow normal message publishing within organization
+- **Subscriptions**: ✅ Allow subscriptions within the same organization
+- **Default Policy**: ✅ Allow other operations (for demo purposes)
+
+### 🎛️ Mock PDP Controls
+- `--mock-pdp` (default): Use local mock PDP with realistic policies
+- `--no-mock-pdp`: Connect to real PDP at `--pdp-endpoint`
+- `--fail-closed`: Test security-first behavior (deny when PDP unavailable)
+
+The mock PDP demonstrates how AuthZEN policies can enforce fine-grained access control beyond simple JWT claims, showing realistic organizational boundaries and operation restrictions.
 
 ## Expected Output
 

--- a/data-plane/examples/src/authzen-demo/README.md
+++ b/data-plane/examples/src/authzen-demo/README.md
@@ -1,0 +1,246 @@
+# SLIM AuthZEN Integration Example
+
+This example demonstrates SLIM's integration with the [OpenID AuthZEN standard](https://openid.github.io/authzen/) for fine-grained authorization of agent operations.
+
+## What is AuthZEN?
+
+AuthZEN is an OpenID Foundation standard that defines a REST API for Policy Decision Point (PDP) to Policy Enforcement Point (PEP) communication. It enables:
+
+- **Fine-grained authorization**: Policy-based access control beyond simple JWT claims
+- **Dynamic policies**: Real-time policy updates without service restarts  
+- **Centralized management**: Single point of policy administration
+- **Standards compliance**: Interoperable with any AuthZEN-compatible PDP
+
+## Example Features
+
+This example demonstrates:
+
+### 🔐 Authorization Scenarios
+- **Route Authorization**: Agent-to-agent route establishment permissions
+- **Publish Authorization**: Message publishing with size limits and target restrictions
+- **Subscribe Authorization**: Subscription permissions with cross-organization controls
+- **Cache Performance**: Authorization decision caching with TTL
+
+### 🛠️ Technical Features
+- AuthZEN client configuration and integration
+- SLIM entity to AuthZEN format conversion (Agent → Subject, AgentType → Resource)
+- Error handling and fallback policies
+- Performance testing with cached decisions
+
+### 📊 Demo Scenarios
+1. **Agent Creation**: Create publisher, subscriber, and admin agents
+2. **Route Testing**: Authorized and unauthorized route creation attempts
+3. **Message Publishing**: Normal and oversized message authorization
+4. **Subscription Management**: Same-org and cross-org subscription attempts
+5. **Cache Testing**: Performance impact of authorization caching
+
+## Quick Start
+
+### Prerequisites
+
+1. **SLIM Service**: A running SLIM service instance
+2. **AuthZEN PDP** (optional): An AuthZEN-compatible Policy Decision Point
+   - For testing without a real PDP, the example will use fallback policies
+
+### Running the Example
+
+```bash
+# From the data-plane/examples directory
+cargo run --bin authzen-demo -- --help
+```
+
+### Basic Usage
+
+```bash
+# Run with default settings (mock PDP)
+cargo run --bin authzen-demo
+
+# Run with a real AuthZEN PDP
+cargo run --bin authzen-demo --pdp-endpoint http://your-pdp:8080
+
+# Enable fallback allow for unavailable PDP
+cargo run --bin authzen-demo --fallback-allow
+
+# Disable AuthZEN (JWT-only mode)
+cargo run --bin authzen-demo --authzen-enabled false
+```
+
+### Command Line Options
+
+```
+Options:
+  -c, --config <CONFIG>                SLIM configuration file [default: config/slim.yml]
+      --authzen-enabled <BOOLEAN>      Enable AuthZEN authorization [default: true]
+      --pdp-endpoint <ENDPOINT>        AuthZEN PDP endpoint URL [default: http://localhost:8080]
+      --fallback-allow                 Allow operations when PDP is unavailable [default: false]
+      --demo-mode                      Run comprehensive demo scenarios [default: true]
+  -v, --verbose                        Enable verbose authorization logging [default: false]
+  -h, --help                           Print help information
+```
+
+## Expected Output
+
+When running the example, you'll see output like:
+
+```
+🚀 Starting SLIM AuthZEN Integration Example
+📄 Config file: config/slim.yml
+🔐 AuthZEN Integration: ENABLED
+
+📋 === AGENT CREATION DEMO ===
+👤 Creating publisher agent: cisco.demo.publisher.1
+✅ Publisher agent created successfully
+👤 Creating subscriber agent: cisco.demo.subscriber.2
+✅ Subscriber agent created successfully
+
+🛣️ === ROUTE AUTHORIZATION DEMO ===
+🔍 Testing route authorization for: cisco.demo.publisher.1 -> cisco.demo.subscriber
+✅ Route authorization GRANTED
+🛣️ Route established successfully
+🔍 Testing unauthorized route: cisco.demo.publisher.1 -> external.demo.service
+✅ Correctly DENIED unauthorized route
+
+📤 === PUBLISH AUTHORIZATION DEMO ===
+🔍 Testing publish authorization: cisco.demo.publisher.1 -> cisco.demo.subscriber (size: Some(1024))
+✅ Publish authorization GRANTED
+📤 Message published successfully
+🔍 Testing large message publish: cisco.demo.publisher.1 -> cisco.demo.subscriber (size: Some(10000000))
+✅ Correctly DENIED large message
+
+📥 === SUBSCRIBE AUTHORIZATION DEMO ===
+🔍 Testing subscribe authorization: cisco.demo.subscriber.2 -> cisco.demo.publisher
+✅ Subscribe authorization GRANTED
+📥 Subscription created successfully
+🔍 Testing cross-org subscription: cisco.demo.subscriber.2 -> external.public.broadcast
+✅ Correctly DENIED cross-org subscription
+
+📊 Cache performance test completed
+✅ AuthZEN Integration Example completed successfully
+🛑 Service shutdown completed
+```
+
+## Integration Guide
+
+To integrate AuthZEN into your own SLIM application:
+
+### 1. Configure AuthZEN Service
+
+```rust
+use slim_service::authzen_integration::{AuthZenService, AuthZenServiceConfig};
+
+let authzen_config = AuthZenServiceConfig {
+    enabled: true,
+    pdp_endpoint: "http://your-pdp:8080".to_string(),
+    timeout: Duration::from_secs(5),
+    cache_ttl: Duration::from_secs(300),
+    fallback_allow: false, // fail-closed
+    max_retries: 3,
+};
+
+let authzen_service = AuthZenService::new(Some(authzen_config))?;
+```
+
+### 2. Use Authorization Methods
+
+```rust
+// Route authorization
+let allowed = authzen_service.authorize_route(
+    &agent,
+    &target_type,
+    Some(connection_id),
+).await?;
+
+// Publish authorization  
+let allowed = authzen_service.authorize_publish(
+    &source_agent,
+    &target_type,
+    Some(target_id),
+    Some(message_size),
+).await?;
+
+// Subscribe authorization
+let allowed = authzen_service.authorize_subscribe(
+    &subscriber_agent,
+    &source_type,
+    Some(source_id),
+).await?;
+```
+
+### 3. Handle Authorization Results
+
+```rust
+match authzen_service.authorize_route(&agent, &target, Some(conn_id)).await {
+    Ok(true) => {
+        // Proceed with operation
+        service.set_route(&agent, &target, None, conn_id).await?;
+    }
+    Ok(false) => {
+        // Operation denied
+        warn!("Route authorization denied");
+    }
+    Err(e) => {
+        // Handle error (PDP unavailable, network issues, etc.)
+        error!("Authorization error: {}", e);
+    }
+}
+```
+
+## Policy Examples
+
+Example AuthZEN policies that would work with this demo:
+
+### Allow Same-Organization Communication
+```json
+{
+  "subject": {"organization": "cisco"},
+  "action": {"name": "route"},
+  "resource": {"organization": "cisco"},
+  "decision": true
+}
+```
+
+### Deny Large Messages
+```json
+{
+  "subject": {"type": "agent"},
+  "action": {"name": "publish", "properties": {"message_size": {"$gt": 1048576}}},
+  "resource": {"type": "agent"},
+  "decision": false
+}
+```
+
+### Allow Admin Full Access
+```json
+{
+  "subject": {"namespace": "admin"},
+  "action": {"name": "*"},
+  "resource": {"type": "*"},
+  "decision": true
+}
+```
+
+## Troubleshooting
+
+### PDP Connection Issues
+- Verify PDP endpoint is reachable
+- Check network connectivity and firewall rules
+- Use `--fallback-allow` for testing without real PDP
+
+### Authorization Denied
+- Check policy configuration in your PDP
+- Verify agent organization/namespace/type mappings
+- Enable verbose logging with `--verbose`
+
+### Performance Issues
+- Adjust cache TTL settings
+- Monitor PDP response times
+- Consider local policy caching
+
+## Next Steps
+
+1. **Set up a real AuthZEN PDP** (e.g., Open Policy Agent with AuthZEN plugin)
+2. **Define authorization policies** specific to your use case
+3. **Integrate AuthZEN** into your production SLIM deployment
+4. **Monitor authorization decisions** and performance metrics
+
+For more information, see the [SLIM AuthZEN Integration Proposal](../../../../docs/authzen-integration-proposal.md). 

--- a/data-plane/examples/src/authzen-demo/args.rs
+++ b/data-plane/examples/src/authzen-demo/args.rs
@@ -67,6 +67,21 @@ pub struct Args {
     )]
     fail_closed: bool,
 
+    /// Use mock PDP server for testing
+    #[arg(
+        long,
+        default_value = "true",
+        help = "Create a local mock PDP server for testing (recommended for demos)"
+    )]
+    mock_pdp: bool,
+
+    /// Disable mock PDP server (convenience flag)
+    #[arg(
+        long,
+        help = "Disable mock PDP server (equivalent to --mock-pdp=false)"
+    )]
+    no_mock_pdp: bool,
+
     /// Demo mode (run through all scenarios)
     #[arg(
         long,
@@ -108,6 +123,16 @@ impl Args {
             false
         } else {
             self.fallback_allow
+        }
+    }
+
+    /// Check if mock PDP should be used
+    pub fn mock_pdp(&self) -> bool {
+        // If no_mock_pdp is set, override mock_pdp to false
+        if self.no_mock_pdp {
+            false
+        } else {
+            self.mock_pdp
         }
     }
 

--- a/data-plane/examples/src/authzen-demo/args.rs
+++ b/data-plane/examples/src/authzen-demo/args.rs
@@ -1,0 +1,111 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Command line argument parsing for AuthZEN integration example
+
+use clap::Parser;
+use std::path::PathBuf;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "authzen-demo",
+    about = "SLIM AuthZEN Integration Demonstration",
+    long_about = "
+This example demonstrates SLIM's integration with the OpenID AuthZEN standard 
+for fine-grained authorization. It shows how to configure and use AuthZEN for 
+route creation, message publishing, and subscription authorization.
+
+The example tests various authorization scenarios including:
+- Agent creation and route establishment
+- Publish authorization with message size limits
+- Subscribe authorization with cross-organization restrictions
+- Authorization caching and performance testing
+- Error handling and fallback policies
+
+To run with a real AuthZEN PDP, specify the --pdp-endpoint flag.
+To test fallback behavior, use --fallback-allow.
+"
+)]
+pub struct Args {
+    /// Path to SLIM configuration file
+    #[arg(
+        short,
+        long,
+        default_value = "config/slim.yml",
+        help = "Path to SLIM configuration file"
+    )]
+    config: PathBuf,
+
+    /// Enable AuthZEN integration
+    #[arg(
+        long,
+        default_value = "true",
+        help = "Enable AuthZEN authorization (disable for JWT-only mode)"
+    )]
+    authzen_enabled: bool,
+
+    /// AuthZEN Policy Decision Point endpoint
+    #[arg(
+        long,
+        default_value = "http://localhost:8080",
+        help = "AuthZEN PDP endpoint URL"
+    )]
+    pdp_endpoint: String,
+
+    /// Enable fallback allow policy
+    #[arg(
+        long,
+        default_value = "false",
+        help = "Allow operations when AuthZEN PDP is unavailable (fail-open vs fail-closed)"
+    )]
+    fallback_allow: bool,
+
+    /// Demo mode (run through all scenarios)
+    #[arg(
+        long,
+        default_value = "true",
+        help = "Run comprehensive demo scenarios"
+    )]
+    demo_mode: bool,
+
+    /// Verbose authorization logging
+    #[arg(
+        short,
+        long,
+        default_value = "false",
+        help = "Enable verbose authorization decision logging"
+    )]
+    verbose: bool,
+}
+
+impl Args {
+    /// Get configuration file path
+    pub fn config(&self) -> &str {
+        self.config.to_str().unwrap_or("config/slim.yml")
+    }
+
+    /// Check if AuthZEN is enabled
+    pub fn authzen_enabled(&self) -> bool {
+        self.authzen_enabled
+    }
+
+    /// Get PDP endpoint
+    pub fn pdp_endpoint(&self) -> String {
+        self.pdp_endpoint.clone()
+    }
+
+    /// Check if fallback allow is enabled
+    pub fn fallback_allow(&self) -> bool {
+        self.fallback_allow
+    }
+
+    /// Check if demo mode is enabled
+    pub fn demo_mode(&self) -> bool {
+        self.demo_mode
+    }
+
+    /// Check if verbose logging is enabled
+    pub fn verbose(&self) -> bool {
+        self.verbose
+    }
+} 

--- a/data-plane/examples/src/authzen-demo/args.rs
+++ b/data-plane/examples/src/authzen-demo/args.rs
@@ -55,10 +55,17 @@ pub struct Args {
     /// Enable fallback allow policy
     #[arg(
         long,
-        default_value = "false",
+        default_value = "true",
         help = "Allow operations when AuthZEN PDP is unavailable (fail-open vs fail-closed)"
     )]
     fallback_allow: bool,
+
+    /// Test fail-closed behavior (deny when PDP unavailable)
+    #[arg(
+        long,
+        help = "Test fail-closed security (equivalent to --fallback-allow=false)"
+    )]
+    fail_closed: bool,
 
     /// Demo mode (run through all scenarios)
     #[arg(
@@ -96,7 +103,12 @@ impl Args {
 
     /// Check if fallback allow is enabled
     pub fn fallback_allow(&self) -> bool {
-        self.fallback_allow
+        // If fail_closed is set, override fallback_allow to false
+        if self.fail_closed {
+            false
+        } else {
+            self.fallback_allow
+        }
     }
 
     /// Check if demo mode is enabled

--- a/data-plane/examples/src/authzen-demo/main.rs
+++ b/data-plane/examples/src/authzen-demo/main.rs
@@ -1,0 +1,296 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! AuthZEN Integration Example
+//! 
+//! This example demonstrates how to use SLIM's AuthZEN integration for 
+//! fine-grained authorization of agent operations including route creation,
+//! message publishing, and subscription management.
+
+use std::time::Duration;
+
+use clap::Parser;
+use slim_datapath::messages::{Agent, AgentType};
+use tokio::time;
+use tracing::{info, warn, error};
+
+use slim::config;
+use slim_service::{
+    FireAndForgetConfiguration,
+    session::{self, SessionConfig},
+    authzen_integration::{AuthZenService, AuthZenServiceConfig},
+};
+
+mod args;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Parse command line arguments
+    let args = args::Args::parse();
+
+    // Initialize configuration and tracing
+    let config_file = args.config();
+    let mut config = config::load_config(config_file).expect("failed to load configuration");
+    let _guard = config.tracing.setup_tracing_subscriber();
+
+    info!("🚀 Starting SLIM AuthZEN Integration Example");
+    info!("📄 Config file: {}", config_file);
+
+    // Create service with AuthZEN integration
+    let id = slim_config::component::id::ID::new_with_str("slim/0").unwrap();
+    let mut svc = config.services.remove(&id).unwrap();
+
+    // Configure AuthZEN integration
+    let authzen_config = AuthZenServiceConfig {
+        enabled: args.authzen_enabled(),
+        pdp_endpoint: args.pdp_endpoint(),
+        timeout: Duration::from_secs(5),
+        cache_ttl: Duration::from_secs(300),
+        fallback_allow: args.fallback_allow(),
+        max_retries: 3,
+    };
+
+    let authzen_service = AuthZenService::new(Some(authzen_config))
+        .expect("Failed to create AuthZEN service");
+
+    info!("🔐 AuthZEN Integration: {}", 
+        if authzen_service.is_enabled() { "ENABLED" } else { "DISABLED" });
+
+    // Start the service
+    svc.run().await?;
+
+    // Demo scenarios
+    demo_agent_creation(&mut svc, &authzen_service).await?;
+    demo_route_authorization(&mut svc, &authzen_service).await?;
+    demo_publish_authorization(&mut svc, &authzen_service).await?;
+    demo_subscribe_authorization(&mut svc, &authzen_service).await?;
+
+    info!("✅ AuthZEN Integration Example completed successfully");
+
+    // Graceful shutdown
+    let signal = svc.signal();
+    match time::timeout(Duration::from_secs(10), signal.drain()).await {
+        Ok(()) => info!("🛑 Service shutdown completed"),
+        Err(_) => error!("⏰ Timeout waiting for service shutdown"),
+    }
+
+    Ok(())
+}
+
+/// Demonstrate agent creation with authorization context
+async fn demo_agent_creation(
+    svc: &mut slim_service::Service,
+    authzen_service: &AuthZenService,
+) -> Result<(), Box<dyn std::error::Error>> {
+    info!("\n📋 === AGENT CREATION DEMO ===");
+
+    // Create a publisher agent
+    let publisher_agent = Agent::from_strings("cisco", "demo", "publisher", 1);
+    info!("👤 Creating publisher agent: {}", publisher_agent);
+    
+    let publisher_rx = svc.create_agent(&publisher_agent).await?;
+    info!("✅ Publisher agent created successfully");
+
+    // Create a subscriber agent  
+    let subscriber_agent = Agent::from_strings("cisco", "demo", "subscriber", 2);
+    info!("👤 Creating subscriber agent: {}", subscriber_agent);
+    
+    let _subscriber_rx = svc.create_agent(&subscriber_agent).await?;
+    info!("✅ Subscriber agent created successfully");
+
+    // Create an admin agent (for demonstration)
+    let admin_agent = Agent::from_strings("cisco", "admin", "controller", 3);
+    info!("👤 Creating admin agent: {}", admin_agent);
+    
+    let _admin_rx = svc.create_agent(&admin_agent).await?;
+    info!("✅ Admin agent created successfully");
+
+    // Drop the receiver to avoid unused variable warning
+    drop(publisher_rx);
+
+    Ok(())
+}
+
+/// Demonstrate route authorization
+async fn demo_route_authorization(
+    svc: &mut slim_service::Service,
+    authzen_service: &AuthZenService,
+) -> Result<(), Box<dyn std::error::Error>> {
+    info!("\n🛣️  === ROUTE AUTHORIZATION DEMO ===");
+
+    let publisher_agent = Agent::from_strings("cisco", "demo", "publisher", 1);
+    let target_type = AgentType::from_strings("cisco", "demo", "subscriber");
+    let connection_id = 12345;
+
+    // Test route authorization
+    info!("🔍 Testing route authorization for: {} -> {}", 
+        publisher_agent, target_type);
+
+    match authzen_service.authorize_route(
+        &publisher_agent,
+        &target_type,
+        Some(connection_id),
+    ).await {
+        Ok(true) => {
+            info!("✅ Route authorization GRANTED");
+            // Actually create the route
+            svc.set_route(&publisher_agent, &target_type, None, connection_id as u64).await?;
+            info!("🛣️  Route established successfully");
+        }
+        Ok(false) => {
+            warn!("❌ Route authorization DENIED");
+        }
+        Err(e) => {
+            error!("🚨 Route authorization ERROR: {}", e);
+        }
+    }
+
+    // Test unauthorized route (different organization)
+    let unauthorized_target = AgentType::from_strings("external", "demo", "service");
+    info!("🔍 Testing unauthorized route: {} -> {}", 
+        publisher_agent, unauthorized_target);
+
+    match authzen_service.authorize_route(
+        &publisher_agent,
+        &unauthorized_target,
+        Some(connection_id),
+    ).await {
+        Ok(true) => warn!("⚠️  Unexpected: Unauthorized route was GRANTED"),
+        Ok(false) => info!("✅ Correctly DENIED unauthorized route"),
+        Err(e) => warn!("🚨 Route authorization ERROR: {}", e),
+    }
+
+    Ok(())
+}
+
+/// Demonstrate publish authorization
+async fn demo_publish_authorization(
+    svc: &mut slim_service::Service,
+    authzen_service: &AuthZenService,
+) -> Result<(), Box<dyn std::error::Error>> {
+    info!("\n📤 === PUBLISH AUTHORIZATION DEMO ===");
+
+    let publisher_agent = Agent::from_strings("cisco", "demo", "publisher", 1);
+    let target_type = AgentType::from_strings("cisco", "demo", "subscriber");
+    let target_id = Some(2u64);
+    let message_size = Some(1024usize);
+
+    // Test publish authorization
+    info!("🔍 Testing publish authorization: {} -> {} (size: {:?})", 
+        publisher_agent, target_type, message_size);
+
+    match authzen_service.authorize_publish(
+        &publisher_agent,
+        &target_type,
+        target_id,
+        message_size,
+    ).await {
+        Ok(true) => {
+            info!("✅ Publish authorization GRANTED");
+            
+            // Create a session and publish a message
+            let session = svc.create_session(
+                &publisher_agent,
+                SessionConfig::FireAndForget(FireAndForgetConfiguration::default()),
+            ).await?;
+
+            let message = "Hello from AuthZEN demo!".as_bytes().to_vec();
+            svc.publish(&publisher_agent, session, &target_type, target_id, message).await?;
+            info!("📤 Message published successfully");
+        }
+        Ok(false) => {
+            warn!("❌ Publish authorization DENIED");
+        }
+        Err(e) => {
+            error!("🚨 Publish authorization ERROR: {}", e);
+        }
+    }
+
+    // Test large message (potentially denied by policy)
+    let large_message_size = Some(10_000_000usize); // 10MB
+    info!("🔍 Testing large message publish: {} -> {} (size: {:?})", 
+        publisher_agent, target_type, large_message_size);
+
+    match authzen_service.authorize_publish(
+        &publisher_agent,
+        &target_type,
+        target_id,
+        large_message_size,
+    ).await {
+        Ok(true) => warn!("⚠️  Large message was GRANTED (check policy limits)"),
+        Ok(false) => info!("✅ Correctly DENIED large message"),
+        Err(e) => warn!("🚨 Large message authorization ERROR: {}", e),
+    }
+
+    Ok(())
+}
+
+/// Demonstrate subscribe authorization
+async fn demo_subscribe_authorization(
+    svc: &mut slim_service::Service,
+    authzen_service: &AuthZenService,
+) -> Result<(), Box<dyn std::error::Error>> {
+    info!("\n📥 === SUBSCRIBE AUTHORIZATION DEMO ===");
+
+    let subscriber_agent = Agent::from_strings("cisco", "demo", "subscriber", 2);
+    let source_type = AgentType::from_strings("cisco", "demo", "publisher");
+    let source_id = Some(1u64);
+
+    // Test subscribe authorization
+    info!("🔍 Testing subscribe authorization: {} -> {}", 
+        subscriber_agent, source_type);
+
+    match authzen_service.authorize_subscribe(
+        &subscriber_agent,
+        &source_type,
+        source_id,
+    ).await {
+        Ok(true) => {
+            info!("✅ Subscribe authorization GRANTED");
+            
+            // Actually create subscription
+            svc.subscribe(&subscriber_agent, &source_type, source_id, None).await?;
+            info!("📥 Subscription created successfully");
+        }
+        Ok(false) => {
+            warn!("❌ Subscribe authorization DENIED");
+        }
+        Err(e) => {
+            error!("🚨 Subscribe authorization ERROR: {}", e);
+        }
+    }
+
+    // Test cross-organization subscription (likely denied)
+    let external_type = AgentType::from_strings("external", "public", "broadcast");
+    info!("🔍 Testing cross-org subscription: {} -> {}", 
+        subscriber_agent, external_type);
+
+    match authzen_service.authorize_subscribe(
+        &subscriber_agent,
+        &external_type,
+        None,
+    ).await {
+        Ok(true) => warn!("⚠️  Cross-org subscription was GRANTED"),
+        Ok(false) => info!("✅ Correctly DENIED cross-org subscription"),
+        Err(e) => warn!("🚨 Cross-org subscription ERROR: {}", e),
+    }
+
+    // Demonstrate cache performance
+    info!("🔍 Testing authorization cache performance...");
+    let start = std::time::Instant::now();
+    
+    for i in 0..5 {
+        let result = authzen_service.authorize_subscribe(
+            &subscriber_agent,
+            &source_type,
+            source_id,
+        ).await;
+        
+        info!("  Cache test {}: {:?} (elapsed: {:?})", 
+            i + 1, result.is_ok(), start.elapsed());
+    }
+
+    info!("📊 Cache performance test completed");
+
+    Ok(())
+} 

--- a/data-plane/examples/src/authzen-demo/main.rs
+++ b/data-plane/examples/src/authzen-demo/main.rs
@@ -17,7 +17,7 @@ use tracing::{info, warn, error};
 use slim::config;
 use slim_service::{
     FireAndForgetConfiguration,
-    session::{self, SessionConfig},
+    session::SessionConfig,
     authzen_integration::{AuthZenService, AuthZenServiceConfig},
 };
 
@@ -80,7 +80,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// Demonstrate agent creation with authorization context
 async fn demo_agent_creation(
     svc: &mut slim_service::Service,
-    authzen_service: &AuthZenService,
+    _authzen_service: &AuthZenService,
 ) -> Result<(), Box<dyn std::error::Error>> {
     info!("\n📋 === AGENT CREATION DEMO ===");
 

--- a/data-plane/examples/src/authzen-demo/main.rs
+++ b/data-plane/examples/src/authzen-demo/main.rs
@@ -55,6 +55,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("🔐 AuthZEN Integration: {}", 
         if authzen_service.is_enabled() { "ENABLED" } else { "DISABLED" });
+    
+    if authzen_service.is_enabled() {
+        info!("🏠 PDP Endpoint: {}", args.pdp_endpoint());
+        info!("🛡️  Fallback Policy: {}", 
+            if args.fallback_allow() { "ALLOW (fail-open)" } else { "DENY (fail-closed)" });
+        
+        if !args.fallback_allow() {
+            info!("ℹ️  Note: Since no PDP is running, all operations will be DENIED (fail-closed security)");
+        }
+    }
 
     // Start the service
     svc.run().await?;
@@ -138,10 +148,11 @@ async fn demo_route_authorization(
             info!("🛣️  Route established successfully");
         }
         Ok(false) => {
-            warn!("❌ Route authorization DENIED");
+            info!("❌ Route authorization DENIED by policy");
         }
         Err(e) => {
-            error!("🚨 Route authorization ERROR: {}", e);
+            warn!("⚠️  Route authorization failed: {}", e);
+            info!("   This is expected when no PDP is running and fallback_allow=false");
         }
     }
 
@@ -199,10 +210,11 @@ async fn demo_publish_authorization(
             info!("📤 Message published successfully");
         }
         Ok(false) => {
-            warn!("❌ Publish authorization DENIED");
+            info!("❌ Publish authorization DENIED by policy");
         }
         Err(e) => {
-            error!("🚨 Publish authorization ERROR: {}", e);
+            warn!("⚠️  Publish authorization failed: {}", e);
+            info!("   This is expected when no PDP is running and fallback_allow=false");
         }
     }
 
@@ -218,8 +230,11 @@ async fn demo_publish_authorization(
         large_message_size,
     ).await {
         Ok(true) => warn!("⚠️  Large message was GRANTED (check policy limits)"),
-        Ok(false) => info!("✅ Correctly DENIED large message"),
-        Err(e) => warn!("🚨 Large message authorization ERROR: {}", e),
+        Ok(false) => info!("✅ Correctly DENIED large message by policy"),
+        Err(e) => {
+            warn!("⚠️  Large message authorization failed: {}", e);
+            info!("   This is expected when no PDP is running and fallback_allow=false");
+        }
     }
 
     Ok(())
@@ -253,10 +268,11 @@ async fn demo_subscribe_authorization(
             info!("📥 Subscription created successfully");
         }
         Ok(false) => {
-            warn!("❌ Subscribe authorization DENIED");
+            info!("❌ Subscribe authorization DENIED by policy");
         }
         Err(e) => {
-            error!("🚨 Subscribe authorization ERROR: {}", e);
+            warn!("⚠️  Subscribe authorization failed: {}", e);
+            info!("   This is expected when no PDP is running and fallback_allow=false");
         }
     }
 
@@ -271,8 +287,11 @@ async fn demo_subscribe_authorization(
         None,
     ).await {
         Ok(true) => warn!("⚠️  Cross-org subscription was GRANTED"),
-        Ok(false) => info!("✅ Correctly DENIED cross-org subscription"),
-        Err(e) => warn!("🚨 Cross-org subscription ERROR: {}", e),
+        Ok(false) => info!("✅ Correctly DENIED cross-org subscription by policy"),
+        Err(e) => {
+            warn!("⚠️  Cross-org subscription failed: {}", e);
+            info!("   This is expected when no PDP is running and fallback_allow=false");
+        }
     }
 
     // Demonstrate cache performance


### PR DESCRIPTION
# AuthZEN Integration v1 - Fine-Grained Authorization for SLIM

## 📖 **Proposal**

This PR implements **iteration 1** of [OpenID AuthZEN](https://openid.github.io/authzen/) integration into SLIM, providing standards-based policy enforcement for agent operations beyond simple JWT claims.

## 🎯 **Problem Statement**

SLIM currently uses JWT-based authentication but lacks fine-grained authorization capabilities for:
- Cross-organization communication policies
- Message size limits and content filtering  
- Dynamic permission management
- Centralized policy administration
- Standards-based policy decision points (PDPs)

## 🚀 **Solution Overview**

**Complete AuthZEN v1 implementation** providing policy-driven authorization for all SLIM operations:

### Core Components Added

#### 1. **AuthZEN Client** (`data-plane/core/auth/src/authzen.rs`)
- ✅ Full OpenID AuthZEN v1 API compliance
- ✅ HTTP client for PDP communication  
- ✅ Authorization decision caching (TTL-based)
- ✅ Fallback policies for PDP unavailability
- ✅ Retry logic and error handling
- ✅ Batch evaluation foundation

#### 2. **SLIM Service Integration** (`data-plane/core/service/src/authzen_integration.rs`)
- ✅ `AuthZenService` wrapper for seamless integration
- ✅ SLIM → AuthZEN entity conversions:
  - `Agent` → `AuthZenSubject` 
  - `AgentType` → `AuthZenResource`
- ✅ Authorization methods:
  - `authorize_route()` - Agent-to-agent route establishment
  - `authorize_publish()` - Message publishing with metadata
  - `authorize_subscribe()` - Subscription permissions
- ✅ Configurable PDP endpoints and policies
- ✅ Graceful degradation when AuthZEN unavailable

#### 3. **Comprehensive Demo** (`data-plane/examples/src/authzen-demo/`)
- ✅ Complete working example with CLI options
- ✅ Real-world authorization scenarios:
  - Same-org vs cross-org communication
  - Message size limit enforcement
  - Route creation permissions  
  - Subscription access controls
- ✅ Performance testing with caching
- ✅ Detailed logging and error scenarios

## 📊 **Technical Details**

### **Dependencies Added:**
```toml
chrono = "0.4"        # Timestamp generation
reqwest = "0.12"      # HTTP client for PDP  
serde_json = "1.0"    # AuthZEN serialization
tokio = { sync }      # Async cache management
```

### **Error Handling:**
```rust
pub enum AuthError {
    NetworkError(String),
    AuthorizationError(String), 
    ParseError(String),
    FallbackAllow,  // Graceful degradation
}
```

### **Configuration:**
```rust
pub struct AuthZenServiceConfig {
    pub enabled: bool,
    pub pdp_endpoint: String,
    pub timeout: Duration,
    pub cache_ttl: Duration,
    pub fallback_allow: bool,
    pub max_retries: u32,
}
```

## 🔧 **Usage Example**

```rust
// Configure AuthZEN integration
let authzen_service = AuthZenService::new(Some(AuthZenServiceConfig {
    enabled: true,
    pdp_endpoint: "http://pdp:8080".to_string(),
    fallback_allow: false,  // fail-closed
    timeout: Duration::from_secs(5),
    cache_ttl: Duration::from_secs(300),
    max_retries: 3,
}))?;

// Authorize operations
let route_allowed = authzen_service.authorize_route(
    &agent, &target_type, Some(connection_id)
).await?;

let publish_allowed = authzen_service.authorize_publish(
    &source_agent, &target_type, Some(target_id), Some(message_size)
).await?;

let subscribe_allowed = authzen_service.authorize_subscribe(
    &subscriber_agent, &source_type, Some(source_id)  
).await?;
```

## 🧪 **Demo Application**

Run the comprehensive demo:

```bash
# Basic demo with mock PDP
cargo run --bin authzen-demo

# With real AuthZEN PDP
cargo run --bin authzen-demo --pdp-endpoint http://your-pdp:8080

# Enable fallback policies
cargo run --bin authzen-demo --fallback-allow

# Disable AuthZEN (JWT-only mode)  
cargo run --bin authzen-demo --authzen-enabled false
```

**Expected demo output:**