### PR TITLE
ci: fix cached taskfile executable issue

### DIFF
--- a/.github/actions/setup-python/action.yaml
+++ b/.github/actions/setup-python/action.yaml
@@ -46,7 +46,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.local
-        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ inputs.poetry-version }}
+        key: venv-${{ runner.os }}-${{ runner.arch }}-${{ steps.setup-python.outputs.python-version }}-${{ inputs.poetry-version }}
 
     - name: Install Poetry
       if: ${{ inputs.poetry-install }}


### PR DESCRIPTION
# Description

The setup-python action occasionally caches the executable for the wrong architecture of the task command.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [X] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
