### PR TITLE
fix(docker-bake): use IMAGE_TAGS when building locally

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -6,12 +6,12 @@
 
 # Docker build args
 variable "IMAGE_REPO" { default = "" }
-variable "IMAGE_TAG" { default = "v0.0.0-dev" }
+variable "IMAGE_TAG" { default = "latest" }
 
 function "get_tag" {
   params = [tags, name]
   // Check if IMAGE_REPO ends with name to avoid repetition
-  result = [for tag in tags:
+  result = [for tag in coalescelist(tags, [IMAGE_TAG]):
     can(regex("${name}$", IMAGE_REPO)) ?
       "${IMAGE_REPO}:${tag}" :
       "${IMAGE_REPO}/${name}:${tag}"


### PR DESCRIPTION
# Description

Consider tags specified in IMAGE_TAG, useful when building the images locally.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
