### PR TITLE
fix(setup-rust): save llvm install script outside the workspace

### DIFF
--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -29,9 +29,9 @@ runs:
       shell: bash
       run: |
         sudo apt-get update
-        curl -OL https://apt.llvm.org/llvm.sh
-        chmod +x llvm.sh
-        sudo ./llvm.sh 19
+        curl -L https://apt.llvm.org/llvm.sh -o /tmp/llvm.sh
+        chmod +x /tmp/llvm.sh
+        sudo /tmp/llvm.sh 19
         sudo apt-get install -y \
           pkg-config \
           make \


### PR DESCRIPTION
# Description

Avoid storing the llvm.sh in the workspace, in order to
prevent issues deriving from not having a clean workspace (e.g. when releaseing, see 
https://github.com/agntcy/slim/actions/runs/17638961682/job/50121258167).

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
