### PR TITLE
feat: add basic auth to ingress

### DIFF
--- a/charts/slim-control-plane/Chart.yaml
+++ b/charts/slim-control-plane/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/slim-control-plane/templates/ingress.yaml
+++ b/charts/slim-control-plane/templates/ingress.yaml
@@ -10,8 +10,13 @@ metadata:
   name: {{ include "control-plane.fullname" . }}
   labels:
     {{- include "control-plane.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
   annotations:
+  {{- if .Values.ingress.basicAuth.enabled }}
+    nginx.ingress.kubernetes.io/auth-type: basic
+    nginx.ingress.kubernetes.io/auth-secret: {{ .Values.ingress.basicAuth.existingBasicAuthSecret }}
+    nginx.ingress.kubernetes.io/auth-realm: {{ .Values.ingress.basicAuth.realm }}
+  {{- end }}
+  {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/charts/slim-control-plane/values.yaml
+++ b/charts/slim-control-plane/values.yaml
@@ -30,11 +30,11 @@ config:
   southbound:
     httpHost: 0.0.0.0
     httpPort: "{{ .Values.service.south.port }}"
-# Uncomment below to enable MTLS by Spire
-#     tls:
-#       useSpiffe: true
-#     spire:
-#       socketPath: "unix:///run/spire/agent-sockets/api.sock"
+  # Uncomment below to enable MTLS by Spire
+  #     tls:
+  #       useSpiffe: true
+  #     spire:
+  #       socketPath: "unix:///run/spire/agent-sockets/api.sock"
 
   logging:
     level: DEBUG
@@ -67,10 +67,12 @@ podAnnotations: {}
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 podLabels: {}
 
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -91,7 +93,8 @@ service:
 ingress:
   enabled: false
   className: ""
-  annotations: {}
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
@@ -103,8 +106,13 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+  basicAuth:
+    enabled: false
+    existingBasicAuthSecret: ""
+    realm: ""
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following


### PR DESCRIPTION
# Description

Adding optional basic auth to the ingress.

Related issue: https://github.com/agntcy/slim/issues/691

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
