### PR TITLE
ci: add automated wheel building workflow for slim-bindings

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,0 +1,188 @@
+name: Build and Publish Wheels
+
+on:
+  # Trigger on new releases
+  release:
+    types: [published]
+  
+  # Allow manual trigger for testing
+  workflow_dispatch:
+    inputs:
+      publish_to_pypi:
+        description: 'Publish to PyPI (production)'
+        required: false
+        default: 'false'
+      publish_to_testpypi:
+        description: 'Publish to TestPyPI (testing)'
+        required: false
+        default: 'true'
+
+jobs:
+  build-wheels:
+    name: Build wheels on ${{ matrix.os }} for Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-13, macos-14]  # macos-13=x64, macos-14=ARM
+        python-version: ["3.12", "3.13"]
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      
+      - name: Install Maturin
+        run: pip install maturin
+      
+      - name: Build wheel
+        working-directory: data-plane/python/bindings
+        run: maturin build --release --out dist
+      
+      - name: Test wheel installation
+        run: |
+          pip install --find-links data-plane/python/bindings/dist slim-bindings --force-reinstall
+          python -c "import slim_bindings; print('slim-bindings imported successfully')"
+      
+      - name: Upload wheel as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}-py${{ matrix.python-version }}
+          path: data-plane/python/bindings/dist/*.whl
+          retention-days: 30
+
+  combine-wheels:
+    name: Combine all wheels
+    needs: build-wheels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all wheel artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          path: all-wheels
+          merge-multiple: true
+      
+      - name: List all wheels
+        run: ls -lh all-wheels/
+      
+      - name: Upload combined wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: all-wheels
+          path: all-wheels/*.whl
+          retention-days: 90
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: combine-wheels
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' && 
+      github.event.inputs.publish_to_testpypi == 'true'
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/slim-bindings
+    permissions:
+      id-token: write
+    
+    steps:
+      - name: Download all wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: all-wheels
+          path: dist
+      
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+          verbose: true
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: combine-wheels
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'release' || 
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_to_pypi == 'true')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/slim-bindings
+    permissions:
+      id-token: write
+    
+    steps:
+      - name: Download all wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: all-wheels
+          path: dist
+      
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
+          verbose: true
+
+  summary:
+    name: Build Summary
+    needs: [build-wheels, combine-wheels]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: all-wheels
+          path: wheels
+      
+      - name: Generate summary
+        run: |
+          echo "## 📦 Wheel Build Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Built Wheels" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Wheel | Size | Platform |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|------|----------|" >> $GITHUB_STEP_SUMMARY
+          
+          for wheel in wheels/*.whl; do
+            filename=$(basename "$wheel")
+            size=$(du -h "$wheel" | cut -f1)
+            
+            if [[ $filename == *"win_amd64"* ]]; then
+              platform="Windows x64"
+            elif [[ $filename == *"manylinux"* ]]; then
+              platform="Linux x64"
+            elif [[ $filename == *"macosx"*"x86_64"* ]]; then
+              platform="macOS x64"
+            elif [[ $filename == *"macosx"*"arm64"* ]]; then
+              platform="macOS ARM64"
+            else
+              platform="Unknown"
+            fi
+            
+            echo "| \`$filename\` | $size | $platform |" >> $GITHUB_STEP_SUMMARY
+          done
+          
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Next Steps" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            echo "✅ Wheels will be automatically published to PyPI" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "ℹ️  Manual trigger - wheels available as artifacts" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "To publish:" >> $GITHUB_STEP_SUMMARY
+            echo "1. Test on TestPyPI: Re-run workflow with 'Publish to TestPyPI' enabled" >> $GITHUB_STEP_SUMMARY
+            echo "2. Verify installation: \`pip install -i https://test.pypi.org/simple/ slim-bindings\`" >> $GITHUB_STEP_SUMMARY
+            echo "3. Publish to PyPI: Create a GitHub release or re-run with 'Publish to PyPI' enabled" >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
# Description

This PR adds automated wheel building for the `slim-bindings` Python package, eliminating the need for users to install Rust toolchain during installation.

## Problem

Currently, installing `slim-bindings` requires:
- Rust toolchain (~2GB disk space)
- 20-30 minute compilation time
- C++ build tools on Windows (~6 GB disk space)

This creates significant friction for Python developers using the AGNTCY SDK.

## Solution

Adds `.github/workflows/build-wheels.yml` that:

- Builds pre-compiled wheels for **4 platforms** × **2 Python versions** = **8 wheels**
  - Platforms: Linux, Windows, macOS (Intel + ARM)
  - Python: 3.12, 3.13
- Tests each wheel with import verification
- Publishes to PyPI on release (optional TestPyPI for testing)
- Reduces installation from **30 minutes → 3 seconds**

## Verification

All 8 wheels built successfully in [my fork](https://github.com/AhmedAbubaker98/slim/actions):
- Windows x64: 7.0 MB
- Linux x64: 8.4 MB  
- macOS Intel: 7.9 MB
- macOS ARM: 7.6 MB

Tested: Windows wheel installs and imports correctly with Python 3.13.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/agntcy/slim/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented (inline comments + setup instructions)
- [x] All code style checks pass (GitHub Actions YAML validated)
- [x] New code contribution is covered by automated tests (workflow includes wheel import tests)
- [x] All new and existing tests pass (verified in fork)

## Setup Required

### 1. Set up PyPI Trusted Publishing

**For PyPI** (https://pypi.org/manage/account/publishing/):
- Project: `slim-bindings`
- Owner: `agntcy`
- Repository: `slim`
- Workflow: `build-wheels.yml`
- Environment: `pypi`

**For TestPyPI** (https://test.pypi.org/manage/account/publishing/):
- Same settings, environment: `testpypi`

### 2. Create GitHub Environments

In repo **Settings** → **Environments**:
- Create: `pypi` (production)
- Create: `testpypi` (testing)

### 3. Test & Publish

**Test first:**
```bash
# Actions → Build and Publish Wheels → Run workflow
# Enable: Publish to TestPyPI
# Test: pip install -i https://test.pypi.org/simple/ slim-bindings
```

**Publish:**
```bash
# Create a GitHub release - wheels auto-publish to PyPI
git tag v0.6.1
git push origin v0.6.1
```

## Benefits

- ✅ No Rust required for users
- ✅ 3-second installation (vs 30 minutes)
- ✅ Better AGNTCY SDK adoption
- ✅ Automated on release

## Notes

- Uses `maturin` for Rust-Python wheel building
- Python 3.14 support pending PyO3 0.25+
- All wheels tested before upload
- Artifacts retained 30-90 days

---

**Ready for review!** This will significantly improve developer experience for `slim-bindings` users.
