### PR TITLE
refactor: split mls state and channel endpoint

### DIFF
--- a/data-plane/core/session/src/lib.rs
+++ b/data-plane/core/session/src/lib.rs
@@ -1,7 +1,6 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod channel_endpoint;
 mod common;
 mod config;
 pub mod context;
@@ -9,12 +8,14 @@ mod errors;
 mod handle;
 pub mod interceptor;
 pub mod interceptor_mls;
+mod mls_state;
 mod moderator_task;
 pub mod multicast;
 pub mod notification;
 pub mod point_to_point;
 pub mod producer_buffer;
 pub mod receiver_buffer;
+pub mod session_controller;
 mod session_layer;
 pub mod session_receiver;
 pub mod session_sender;

--- a/data-plane/core/session/src/mls_state.rs
+++ b/data-plane/core/session/src/mls_state.rs
@@ -1,0 +1,372 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+// Standard library imports
+use std::{
+    collections::{BTreeMap, HashMap, btree_map::Entry},
+    sync::Arc,
+};
+
+// Third-party crates
+use bincode::{Decode, Encode};
+use parking_lot::Mutex;
+use tracing::{debug, error, trace};
+
+use slim_auth::traits::{TokenProvider, Verifier};
+use slim_datapath::api::{ProtoMessage as Message, ProtoSessionMessageType};
+
+// Local crate
+use crate::SessionError;
+use slim_datapath::messages::Name;
+use slim_mls::mls::{CommitMsg, KeyPackageMsg, Mls, MlsIdentity, ProposalMsg, WelcomeMsg};
+
+pub(crate) trait MlsEndpoint {
+    /// check whether MLS is up
+    fn is_mls_up(&self) -> Result<bool, SessionError>;
+
+    /// rotate MLS keys
+    async fn update_mls_keys(&mut self) -> Result<(), SessionError>;
+}
+
+#[derive(Debug)]
+pub struct MlsState<P, V>
+where
+    P: TokenProvider + Send + Sync + Clone + 'static,
+    V: Verifier + Send + Sync + Clone + 'static,
+{
+    /// mls state for the channel of this endpoint
+    /// the mls state should be created and initiated in the app
+    /// so that it can be shared with the channel and the interceptors
+    pub(crate) mls: Arc<Mutex<Mls<P, V>>>,
+
+    /// used only if Some(mls)
+    pub(crate) group: Vec<u8>,
+
+    /// last mls message id
+    pub(crate) last_mls_msg_id: u32,
+
+    /// map of stored commits and proposals
+    pub(crate) stored_commits_proposals: BTreeMap<u32, Message>,
+
+    /// track if MLS is UP. For moderator this is true as soon as at least one participant
+    /// has sent back an ack after the welcome message, while for participant
+    /// this is true as soon as the welcome message is received and correctly processed
+    pub(crate) mls_up: bool,
+}
+
+impl<P, V> MlsState<P, V>
+where
+    P: TokenProvider + Send + Sync + Clone + 'static,
+    V: Verifier + Send + Sync + Clone + 'static,
+{
+    pub(crate) fn new(mls: Arc<Mutex<Mls<P, V>>>) -> Result<Self, SessionError> {
+        mls.lock()
+            .initialize()
+            .map_err(|e| SessionError::MLSInit(e.to_string()))?;
+
+        Ok(MlsState {
+            mls,
+            group: vec![],
+            last_mls_msg_id: 0,
+            stored_commits_proposals: BTreeMap::new(),
+            mls_up: false,
+        })
+    }
+
+    pub(crate) fn generate_key_package(&mut self) -> Result<KeyPackageMsg, SessionError> {
+        self.mls
+            .lock()
+            .generate_key_package()
+            .map_err(|e| SessionError::MLSInit(e.to_string()))
+    }
+
+    pub(crate) fn process_welcome_message(&mut self, msg: &Message) -> Result<(), SessionError> {
+        if self.last_mls_msg_id != 0 {
+            debug!("Welcome message already received, drop");
+            // we already got a welcome message, ignore this one
+            return Ok(());
+        }
+
+        let payload = msg
+            .get_payload()
+            .unwrap()
+            .as_command_payload()
+            .as_welcome_payload();
+        self.last_mls_msg_id = payload.msl_commit_id();
+        let welcome = payload.mls_welcome();
+
+        self.group = self
+            .mls
+            .lock()
+            .process_welcome(welcome)
+            .map_err(|e| SessionError::WelcomeMessage(e.to_string()))?;
+
+        self.mls_up = true;
+
+        Ok(())
+    }
+
+    pub(crate) fn process_control_message(
+        &mut self,
+        msg: Message,
+        local_name: &Name,
+    ) -> Result<bool, SessionError> {
+        if !self.is_valid_msg_id(msg)? {
+            // message already processed, drop it
+            return Ok(false);
+        }
+
+        // process all messages in map until the numbering is not continuous
+        while let Some(msg) = self
+            .stored_commits_proposals
+            .remove(&(self.last_mls_msg_id + 1))
+        {
+            trace!("processing stored message {}", msg.get_id());
+
+            // increment the last mls message id
+            self.last_mls_msg_id += 1;
+
+            // base on the message type, process it
+            match msg.get_session_header().session_message_type() {
+                ProtoSessionMessageType::GroupProposal => {
+                    self.process_proposal_message(msg, local_name)?;
+                }
+                ProtoSessionMessageType::GroupUpdate => {
+                    self.process_commit_message(msg)?;
+                }
+                _ => {
+                    error!("unknown control message type, drop it");
+                    return Err(SessionError::Processing(
+                        "unknown control message type".to_string(),
+                    ));
+                }
+            }
+        }
+
+        Ok(true)
+    }
+
+    fn process_commit_message(&mut self, commit: Message) -> Result<(), SessionError> {
+        trace!("processing stored commit {}", commit.get_id());
+
+        let payalod = commit
+            .get_payload()
+            .unwrap()
+            .as_command_payload()
+            .as_group_update_payload();
+        // get the payload
+        let commit = payalod.mls_commit();
+
+        // process the commit message
+        self.mls
+            .lock()
+            .process_commit(commit)
+            .map_err(|e| SessionError::CommitMessage(e.to_string()))
+    }
+
+    fn process_proposal_message(
+        &mut self,
+        proposal: Message,
+        local_name: &Name,
+    ) -> Result<(), SessionError> {
+        trace!("processing stored proposal {}", proposal.get_id());
+
+        let payload = proposal
+            .get_payload()
+            .unwrap()
+            .as_command_payload()
+            .as_group_proposal_payload();
+
+        let original_source = Name::from(payload.source.as_ref().ok_or_else(|| {
+            SessionError::Processing("missing source in proposal payload".to_string())
+        })?);
+        if original_source == *local_name {
+            // drop the message as we are the original source
+            debug!("Known proposal, drop the message");
+            return Ok(());
+        }
+
+        self.mls
+            .lock()
+            .process_proposal(&payload.mls_proposal, false)
+            .map_err(|e| SessionError::CommitMessage(e.to_string()))?;
+
+        Ok(())
+    }
+
+    fn is_valid_msg_id(&mut self, msg: Message) -> Result<bool, SessionError> {
+        // the first message to be received should be a welcome message
+        // this message will init the last_mls_msg_id. so if last_mls_msg_id = 0
+        // drop the commits
+        if self.last_mls_msg_id == 0 {
+            error!("welcome message not received yet, drop mls message");
+            return Err(SessionError::MLSIdMessage(
+                "welcome message not received yet, drop mls message".to_string(),
+            ));
+        }
+
+        if msg.get_id() <= self.last_mls_msg_id {
+            debug!(
+                "Message with id {} already processed, drop it. last message id {}",
+                msg.get_id(),
+                self.last_mls_msg_id
+            );
+            return Ok(false);
+        }
+
+        // store commit in hash map
+        match self.stored_commits_proposals.entry(msg.get_id()) {
+            Entry::Occupied(_) => {
+                debug!("Message with id {} already exists, drop it", msg.get_id());
+                Ok(false)
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(msg);
+                Ok(true)
+            }
+        }
+    }
+
+    pub(crate) fn is_mls_up(&self) -> Result<bool, SessionError> {
+        Ok(self.mls_up)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct MlsModeratorState<P, V>
+where
+    P: TokenProvider + Send + Sync + Clone + 'static,
+    V: Verifier + Send + Sync + Clone + 'static,
+{
+    /// mls state in common between moderator and
+    pub(crate) common: MlsState<P, V>,
+
+    /// map of the participants (with real ids) with package keys
+    /// used to remove participants from the channel
+    pub(crate) participants: HashMap<Name, MlsIdentity>,
+
+    /// message id of the next msl message to send
+    pub(crate) next_msg_id: u32,
+}
+
+impl<P, V> MlsModeratorState<P, V>
+where
+    P: TokenProvider + Send + Sync + Clone + 'static,
+    V: Verifier + Send + Sync + Clone + 'static,
+{
+    pub(crate) fn new(mls: MlsState<P, V>) -> Self {
+        MlsModeratorState {
+            common: mls,
+            participants: HashMap::new(),
+            next_msg_id: 0,
+        }
+    }
+
+    pub(crate) fn init_moderator(&mut self) -> Result<(), SessionError> {
+        self.common
+            .mls
+            .lock()
+            .create_group()
+            .map(|_| ())
+            .map_err(|e| SessionError::MLSInit(e.to_string()))
+    }
+
+    pub(crate) fn add_participant(
+        &mut self,
+        msg: &Message,
+    ) -> Result<(CommitMsg, WelcomeMsg), SessionError> {
+        let payload = msg
+            .get_payload()
+            .unwrap()
+            .as_command_payload()
+            .as_join_reply_payload();
+
+        match self.common.mls.lock().add_member(payload.key_package()) {
+            Ok(ret) => {
+                // add participant to the list
+                self.participants
+                    .insert(msg.get_source(), ret.member_identity);
+
+                Ok((ret.commit_message, ret.welcome_message))
+            }
+            Err(e) => {
+                error!(%e, "error adding new endpoint");
+                Err(SessionError::AddParticipant(e.to_string()))
+            }
+        }
+    }
+
+    pub(crate) fn remove_participant(&mut self, msg: &Message) -> Result<CommitMsg, SessionError> {
+        debug!("Remove participant from the MLS group");
+        let name = msg.get_dst();
+        let id = match self.participants.get(&name) {
+            Some(id) => id,
+            None => {
+                error!("the name does not exists in the group");
+                return Err(SessionError::RemoveParticipant(
+                    "participant does not exists".to_owned(),
+                ));
+            }
+        };
+        let ret = self
+            .common
+            .mls
+            .lock()
+            .remove_member(id)
+            .map_err(|e| SessionError::RemoveParticipant(e.to_string()))?;
+
+        // remove the participant from the list
+        self.participants.remove(&name);
+
+        Ok(ret)
+    }
+
+    pub(crate) fn process_proposal_message(
+        &mut self,
+        proposal: &ProposalMsg,
+    ) -> Result<CommitMsg, SessionError> {
+        let commit = self
+            .common
+            .mls
+            .lock()
+            .process_proposal(proposal, true)
+            .map_err(|e| SessionError::CommitMessage(e.to_string()))?;
+
+        Ok(commit)
+    }
+
+    pub(crate) fn process_local_pending_proposal(&mut self) -> Result<CommitMsg, SessionError> {
+        let commit = self
+            .common
+            .mls
+            .lock()
+            .process_local_pending_proposal()
+            .map_err(|e| SessionError::CommitMessage(e.to_string()))?;
+
+        Ok(commit)
+    }
+
+    pub(crate) fn get_next_mls_mgs_id(&mut self) -> u32 {
+        self.next_msg_id += 1;
+        self.next_msg_id
+    }
+
+    pub(crate) fn is_mls_up(&self) -> Result<bool, SessionError> {
+        self.common.is_mls_up()
+    }
+}
+
+#[derive(Debug, Clone, Encode, Decode)]
+pub struct MlsProposalMessagePayload {
+    pub(crate) source_name: Name,
+    pub(crate) mls_msg: Vec<u8>,
+}
+
+impl MlsProposalMessagePayload {
+    pub(crate) fn new(source_name: Name, mls_msg: Vec<u8>) -> Self {
+        MlsProposalMessagePayload {
+            source_name,
+            mls_msg,
+        }
+    }
+}

--- a/data-plane/core/session/src/multicast.rs
+++ b/data-plane/core/session/src/multicast.rs
@@ -27,12 +27,12 @@ use slim_datapath::{
 use crate::{
     Common, CommonSession, Id, MessageDirection, MessageHandler, SessionConfig, SessionConfigTrait,
     State, Transmitter,
-    channel_endpoint::{
-        ChannelEndpoint, ChannelModerator, ChannelParticipant, MlsEndpoint, MlsState,
-    },
     common::SessionMessage,
     errors::SessionError,
-    producer_buffer, receiver_buffer, timer,
+    mls_state::{MlsEndpoint, MlsState},
+    producer_buffer, receiver_buffer,
+    session_controller::{SessionController, SessionModerator, SessionParticipant},
+    timer,
 };
 use producer_buffer::ProducerBuffer;
 use receiver_buffer::ReceiverBuffer;
@@ -302,7 +302,7 @@ where
             // create the channel endpoint
             let mut channel_endpoint = match session_config.initiator {
                 true => {
-                    let cm = ChannelModerator::new(
+                    let cm = SessionModerator::new(
                         source.clone(),
                         session_config.channel_name.clone(),
                         id,
@@ -314,10 +314,10 @@ where
                         Some(tx_session),
                         session_config.metadata.clone(),
                     );
-                    ChannelEndpoint::ChannelModerator(cm)
+                    SessionController::SessionModerator(cm)
                 }
                 false => {
-                    let cp = ChannelParticipant::new(
+                    let cp = SessionParticipant::new(
                         source.clone(),
                         session_config.channel_name.clone(),
                         id,
@@ -328,7 +328,7 @@ where
                         tx.clone(),
                         session_config.metadata.clone(),
                     );
-                    ChannelEndpoint::ChannelParticipant(cp)
+                    SessionController::SessionParticipant(cp)
                 }
             };
 

--- a/data-plane/core/session/src/session_controller.rs
+++ b/data-plane/core/session/src/session_controller.rs
@@ -3,7 +3,7 @@
 
 // Standard library imports
 use std::{
-    collections::{BTreeMap, HashMap, VecDeque, btree_map::Entry},
+    collections::{HashMap, VecDeque},
     sync::Arc,
     time::Duration,
 };
@@ -11,7 +11,6 @@ use std::{
 // Third-party crates
 use async_trait::async_trait;
 use bincode::{Decode, Encode};
-use parking_lot::Mutex;
 use tracing::{debug, error, trace};
 
 use slim_auth::traits::{TokenProvider, Verifier};
@@ -28,13 +27,13 @@ use crate::{
     Id, SessionError, Transmitter,
     common::SessionMessage,
     interceptor_mls::{METADATA_MLS_ENABLED, METADATA_MLS_INIT_COMMIT_ID},
+    mls_state::{MlsEndpoint, MlsModeratorState, MlsProposalMessagePayload, MlsState},
     moderator_task::{
         AddParticipant, AddParticipantMls, ModeratorTask, RemoveParticipant, RemoveParticipantMls,
         TaskUpdate, UpdateParticipantMls,
     },
     traits::SessionComponentLifecycle,
 };
-use slim_mls::mls::{CommitMsg, KeyPackageMsg, Mls, MlsIdentity, ProposalMsg, WelcomeMsg};
 
 const CHANNEL_CREATION: &str = "CHANNEL_CREATION";
 const CHANNEL_SUBSCRIPTION: &str = "CHANNEL_SUBSCRIPTION";
@@ -92,15 +91,7 @@ trait OnMessageReceived {
     async fn on_message(&mut self, msg: Message) -> Result<(), SessionError>;
 }
 
-pub(crate) trait MlsEndpoint {
-    /// check whether MLS is up
-    fn is_mls_up(&self) -> Result<bool, SessionError>;
-
-    /// rotate MLS keys
-    async fn update_mls_keys(&mut self) -> Result<(), SessionError>;
-}
-
-impl<P, V, T> MlsEndpoint for ChannelEndpoint<P, V, T>
+impl<P, V, T> MlsEndpoint for SessionController<P, V, T>
 where
     P: TokenProvider + Send + Sync + Clone + 'static,
     V: Verifier + Send + Sync + Clone + 'static,
@@ -108,31 +99,31 @@ where
 {
     fn is_mls_up(&self) -> Result<bool, SessionError> {
         match self {
-            ChannelEndpoint::ChannelParticipant(cp) => cp.is_mls_up(),
-            ChannelEndpoint::ChannelModerator(cm) => cm.is_mls_up(),
+            SessionController::SessionParticipant(cp) => cp.is_mls_up(),
+            SessionController::SessionModerator(cm) => cm.is_mls_up(),
         }
     }
 
     async fn update_mls_keys(&mut self) -> Result<(), SessionError> {
         match self {
-            ChannelEndpoint::ChannelParticipant(cp) => cp.update_mls_keys().await,
-            ChannelEndpoint::ChannelModerator(cm) => cm.update_mls_keys().await,
+            SessionController::SessionParticipant(cp) => cp.update_mls_keys().await,
+            SessionController::SessionModerator(cm) => cm.update_mls_keys().await,
         }
     }
 }
 
 #[derive(Debug)]
-pub(crate) enum ChannelEndpoint<P, V, T>
+pub(crate) enum SessionController<P, V, T>
 where
     P: TokenProvider + Send + Sync + Clone + 'static,
     V: Verifier + Send + Sync + Clone + 'static,
     T: Transmitter + Send + Sync + Clone + 'static,
 {
-    ChannelParticipant(ChannelParticipant<P, V, T>),
-    ChannelModerator(ChannelModerator<P, V, T>),
+    SessionParticipant(SessionParticipant<P, V, T>),
+    SessionModerator(SessionModerator<P, V, T>),
 }
 
-impl<P, V, T> ChannelEndpoint<P, V, T>
+impl<P, V, T> SessionController<P, V, T>
 where
     P: TokenProvider + Send + Sync + Clone + 'static,
     V: Verifier + Send + Sync + Clone + 'static,
@@ -140,341 +131,16 @@ where
 {
     pub async fn on_message(&mut self, msg: Message) -> Result<(), SessionError> {
         match self {
-            ChannelEndpoint::ChannelParticipant(cp) => cp.on_message(msg).await,
-            ChannelEndpoint::ChannelModerator(cm) => cm.on_message(msg).await,
+            SessionController::SessionParticipant(cp) => cp.on_message(msg).await,
+            SessionController::SessionModerator(cm) => cm.on_message(msg).await,
         }
     }
 
     pub fn close(&mut self) {
         match self {
-            ChannelEndpoint::ChannelParticipant(cp) => cp.close(),
-            ChannelEndpoint::ChannelModerator(cm) => cm.close(),
+            SessionController::SessionParticipant(cp) => cp.close(),
+            SessionController::SessionModerator(cm) => cm.close(),
         }
-    }
-}
-
-#[derive(Debug)]
-pub struct MlsState<P, V>
-where
-    P: TokenProvider + Send + Sync + Clone + 'static,
-    V: Verifier + Send + Sync + Clone + 'static,
-{
-    /// mls state for the channel of this endpoint
-    /// the mls state should be created and initiated in the app
-    /// so that it can be shared with the channel and the interceptors
-    mls: Arc<Mutex<Mls<P, V>>>,
-
-    /// used only if Some(mls)
-    group: Vec<u8>,
-
-    /// last mls message id
-    last_mls_msg_id: u32,
-
-    /// map of stored commits and proposals
-    stored_commits_proposals: BTreeMap<u32, Message>,
-
-    /// track if MLS is UP. For moderator this is true as soon as at least one participant
-    /// has sent back an ack after the welcome message, while for participant
-    /// this is true as soon as the welcome message is received and correctly processed
-    mls_up: bool,
-}
-
-impl<P, V> MlsState<P, V>
-where
-    P: TokenProvider + Send + Sync + Clone + 'static,
-    V: Verifier + Send + Sync + Clone + 'static,
-{
-    pub(crate) fn new(mls: Arc<Mutex<Mls<P, V>>>) -> Result<Self, SessionError> {
-        mls.lock()
-            .initialize()
-            .map_err(|e| SessionError::MLSInit(e.to_string()))?;
-
-        Ok(MlsState {
-            mls,
-            group: vec![],
-            last_mls_msg_id: 0,
-            stored_commits_proposals: BTreeMap::new(),
-            mls_up: false,
-        })
-    }
-
-    fn generate_key_package(&mut self) -> Result<KeyPackageMsg, SessionError> {
-        self.mls
-            .lock()
-            .generate_key_package()
-            .map_err(|e| SessionError::MLSInit(e.to_string()))
-    }
-
-    fn process_welcome_message(&mut self, msg: &Message) -> Result<(), SessionError> {
-        if self.last_mls_msg_id != 0 {
-            debug!("Welcome message already received, drop");
-            // we already got a welcome message, ignore this one
-            return Ok(());
-        }
-
-        let payload = msg
-            .get_payload()
-            .unwrap()
-            .as_command_payload()
-            .as_welcome_payload();
-        self.last_mls_msg_id = payload.msl_commit_id();
-        let welcome = payload.mls_welcome();
-
-        self.group = self
-            .mls
-            .lock()
-            .process_welcome(welcome)
-            .map_err(|e| SessionError::WelcomeMessage(e.to_string()))?;
-
-        self.mls_up = true;
-
-        Ok(())
-    }
-
-    fn process_control_message(
-        &mut self,
-        msg: Message,
-        local_name: &Name,
-    ) -> Result<bool, SessionError> {
-        if !self.is_valid_msg_id(msg)? {
-            // message already processed, drop it
-            return Ok(false);
-        }
-
-        // process all messages in map until the numbering is not continuous
-        while let Some(msg) = self
-            .stored_commits_proposals
-            .remove(&(self.last_mls_msg_id + 1))
-        {
-            trace!("processing stored message {}", msg.get_id());
-
-            // increment the last mls message id
-            self.last_mls_msg_id += 1;
-
-            // base on the message type, process it
-            match msg.get_session_header().session_message_type() {
-                ProtoSessionMessageType::GroupProposal => {
-                    self.process_proposal_message(msg, local_name)?;
-                }
-                ProtoSessionMessageType::GroupUpdate => {
-                    self.process_commit_message(msg)?;
-                }
-                _ => {
-                    error!("unknown control message type, drop it");
-                    return Err(SessionError::Processing(
-                        "unknown control message type".to_string(),
-                    ));
-                }
-            }
-        }
-
-        Ok(true)
-    }
-
-    fn process_commit_message(&mut self, commit: Message) -> Result<(), SessionError> {
-        trace!("processing stored commit {}", commit.get_id());
-
-        let payalod = commit
-            .get_payload()
-            .unwrap()
-            .as_command_payload()
-            .as_group_update_payload();
-        // get the payload
-        let commit = payalod.mls_commit();
-
-        // process the commit message
-        self.mls
-            .lock()
-            .process_commit(commit)
-            .map_err(|e| SessionError::CommitMessage(e.to_string()))
-    }
-
-    fn process_proposal_message(
-        &mut self,
-        proposal: Message,
-        local_name: &Name,
-    ) -> Result<(), SessionError> {
-        trace!("processing stored proposal {}", proposal.get_id());
-
-        let payload = proposal
-            .get_payload()
-            .unwrap()
-            .as_command_payload()
-            .as_group_proposal_payload();
-
-        let original_source = Name::from(payload.source.as_ref().ok_or_else(|| {
-            SessionError::Processing("missing source in proposal payload".to_string())
-        })?);
-        if original_source == *local_name {
-            // drop the message as we are the original source
-            debug!("Known proposal, drop the message");
-            return Ok(());
-        }
-
-        self.mls
-            .lock()
-            .process_proposal(&payload.mls_proposal, false)
-            .map_err(|e| SessionError::CommitMessage(e.to_string()))?;
-
-        Ok(())
-    }
-
-    fn is_valid_msg_id(&mut self, msg: Message) -> Result<bool, SessionError> {
-        // the first message to be received should be a welcome message
-        // this message will init the last_mls_msg_id. so if last_mls_msg_id = 0
-        // drop the commits
-        if self.last_mls_msg_id == 0 {
-            error!("welcome message not received yet, drop mls message");
-            return Err(SessionError::MLSIdMessage(
-                "welcome message not received yet, drop mls message".to_string(),
-            ));
-        }
-
-        if msg.get_id() <= self.last_mls_msg_id {
-            debug!(
-                "Message with id {} already processed, drop it. last message id {}",
-                msg.get_id(),
-                self.last_mls_msg_id
-            );
-            return Ok(false);
-        }
-
-        // store commit in hash map
-        match self.stored_commits_proposals.entry(msg.get_id()) {
-            Entry::Occupied(_) => {
-                debug!("Message with id {} already exists, drop it", msg.get_id());
-                Ok(false)
-            }
-            Entry::Vacant(entry) => {
-                entry.insert(msg);
-                Ok(true)
-            }
-        }
-    }
-
-    fn is_mls_up(&self) -> Result<bool, SessionError> {
-        Ok(self.mls_up)
-    }
-}
-
-#[derive(Debug)]
-pub(crate) struct MlsModeratorState<P, V>
-where
-    P: TokenProvider + Send + Sync + Clone + 'static,
-    V: Verifier + Send + Sync + Clone + 'static,
-{
-    /// mls state in common between moderator and
-    common: MlsState<P, V>,
-
-    /// map of the participants (with real ids) with package keys
-    /// used to remove participants from the channel
-    participants: HashMap<Name, MlsIdentity>,
-
-    /// message id of the next msl message to send
-    next_msg_id: u32,
-}
-
-impl<P, V> MlsModeratorState<P, V>
-where
-    P: TokenProvider + Send + Sync + Clone + 'static,
-    V: Verifier + Send + Sync + Clone + 'static,
-{
-    pub(crate) fn new(mls: MlsState<P, V>) -> Self {
-        MlsModeratorState {
-            common: mls,
-            participants: HashMap::new(),
-            next_msg_id: 0,
-        }
-    }
-
-    fn init_moderator(&mut self) -> Result<(), SessionError> {
-        self.common
-            .mls
-            .lock()
-            .create_group()
-            .map(|_| ())
-            .map_err(|e| SessionError::MLSInit(e.to_string()))
-    }
-
-    fn add_participant(&mut self, msg: &Message) -> Result<(CommitMsg, WelcomeMsg), SessionError> {
-        let payload = msg
-            .get_payload()
-            .unwrap()
-            .as_command_payload()
-            .as_join_reply_payload();
-
-        match self.common.mls.lock().add_member(payload.key_package()) {
-            Ok(ret) => {
-                // add participant to the list
-                self.participants
-                    .insert(msg.get_source(), ret.member_identity);
-
-                Ok((ret.commit_message, ret.welcome_message))
-            }
-            Err(e) => {
-                error!(%e, "error adding new endpoint");
-                Err(SessionError::AddParticipant(e.to_string()))
-            }
-        }
-    }
-
-    fn remove_participant(&mut self, msg: &Message) -> Result<CommitMsg, SessionError> {
-        debug!("Remove participant from the MLS group");
-        let name = msg.get_dst();
-        let id = match self.participants.get(&name) {
-            Some(id) => id,
-            None => {
-                error!("the name does not exists in the group");
-                return Err(SessionError::RemoveParticipant(
-                    "participant does not exists".to_owned(),
-                ));
-            }
-        };
-        let ret = self
-            .common
-            .mls
-            .lock()
-            .remove_member(id)
-            .map_err(|e| SessionError::RemoveParticipant(e.to_string()))?;
-
-        // remove the participant from the list
-        self.participants.remove(&name);
-
-        Ok(ret)
-    }
-
-    fn process_proposal_message(
-        &mut self,
-        proposal: &ProposalMsg,
-    ) -> Result<CommitMsg, SessionError> {
-        let commit = self
-            .common
-            .mls
-            .lock()
-            .process_proposal(proposal, true)
-            .map_err(|e| SessionError::CommitMessage(e.to_string()))?;
-
-        Ok(commit)
-    }
-
-    fn process_local_pending_proposal(&mut self) -> Result<CommitMsg, SessionError> {
-        let commit = self
-            .common
-            .mls
-            .lock()
-            .process_local_pending_proposal()
-            .map_err(|e| SessionError::CommitMessage(e.to_string()))?;
-
-        Ok(commit)
-    }
-
-    fn get_next_mls_mgs_id(&mut self) -> u32 {
-        self.next_msg_id += 1;
-        self.next_msg_id
-    }
-
-    fn is_mls_up(&self) -> Result<bool, SessionError> {
-        self.common.is_mls_up()
     }
 }
 
@@ -484,23 +150,8 @@ pub struct JoinMessagePayload {
     moderator_name: Name,
 }
 
-#[derive(Debug, Clone, Encode, Decode)]
-pub struct MlsProposalMessagePayload {
-    source_name: Name,
-    mls_msg: Vec<u8>,
-}
-
-impl MlsProposalMessagePayload {
-    fn new(source_name: Name, mls_msg: Vec<u8>) -> Self {
-        MlsProposalMessagePayload {
-            source_name,
-            mls_msg,
-        }
-    }
-}
-
 #[derive(Debug)]
-struct Endpoint<T>
+struct SessionControllerState<T>
 where
     T: Transmitter + Send + Sync + Clone + 'static,
 {
@@ -535,7 +186,7 @@ where
     session_metadata: HashMap<String, String>,
 }
 
-impl<T> Endpoint<T>
+impl<T> SessionControllerState<T>
 where
     T: Transmitter + Send + Sync + Clone + 'static,
 {
@@ -552,7 +203,7 @@ where
         tx: T,
         session_metadata: HashMap<String, String>,
     ) -> Self {
-        Endpoint {
+        SessionControllerState {
             name,
             channel_name,
             session_id,
@@ -716,7 +367,7 @@ pub fn handle_channel_discovery_message(
 }
 
 #[derive(Debug)]
-pub struct ChannelParticipant<P, V, T>
+pub struct SessionParticipant<P, V, T>
 where
     P: TokenProvider + Send + Sync + Clone + 'static,
     V: Verifier + Send + Sync + Clone + 'static,
@@ -729,13 +380,13 @@ where
     timer: Option<crate::timer::Timer>,
 
     /// endpoint
-    endpoint: Endpoint<T>,
+    endpoint: SessionControllerState<T>,
 
     /// mls state
     mls_state: Option<MlsState<P, V>>,
 }
 
-impl<P, V, T> ChannelParticipant<P, V, T>
+impl<P, V, T> SessionParticipant<P, V, T>
 where
     P: TokenProvider + Send + Sync + Clone + 'static,
     V: Verifier + Send + Sync + Clone + 'static,
@@ -753,7 +404,7 @@ where
         tx: T,
         session_metadata: HashMap<String, String>,
     ) -> Self {
-        let endpoint = Endpoint::new(
+        let endpoint = SessionControllerState::new(
             name,
             channel_name,
             session_id,
@@ -764,7 +415,7 @@ where
             session_metadata,
         );
 
-        ChannelParticipant {
+        SessionParticipant {
             moderator_name: None,
             timer: None,
             endpoint,
@@ -954,7 +605,7 @@ where
     }
 }
 
-impl<P, V, T> MlsEndpoint for ChannelParticipant<P, V, T>
+impl<P, V, T> MlsEndpoint for SessionParticipant<P, V, T>
 where
     P: TokenProvider + Send + Sync + Clone + 'static,
     V: Verifier + Send + Sync + Clone + 'static,
@@ -1030,7 +681,7 @@ where
     }
 }
 
-impl<P, V, T> SessionComponentLifecycle for ChannelParticipant<P, V, T>
+impl<P, V, T> SessionComponentLifecycle for SessionParticipant<P, V, T>
 where
     P: TokenProvider + Send + Sync + Clone + 'static,
     V: Verifier + Send + Sync + Clone + 'static,
@@ -1044,7 +695,7 @@ where
     }
 }
 
-impl<P, V, T> OnMessageReceived for ChannelParticipant<P, V, T>
+impl<P, V, T> OnMessageReceived for SessionParticipant<P, V, T>
 where
     P: TokenProvider + Send + Sync + Clone + 'static,
     V: Verifier + Send + Sync + Clone + 'static,
@@ -1120,13 +771,13 @@ struct ChannelTimer {
 }
 
 #[derive(Debug)]
-pub struct ChannelModerator<P, V, T>
+pub struct SessionModerator<P, V, T>
 where
     P: TokenProvider + Send + Sync + Clone + 'static,
     V: Verifier + Send + Sync + Clone + 'static,
     T: Transmitter + Send + Sync + Clone + 'static,
 {
-    endpoint: Endpoint<T>,
+    endpoint: SessionControllerState<T>,
 
     /// list of pending task to execute
     tasks_todo: VecDeque<Message>,
@@ -1157,7 +808,7 @@ where
 }
 
 #[allow(clippy::too_many_arguments)]
-impl<P, V, T> ChannelModerator<P, V, T>
+impl<P, V, T> SessionModerator<P, V, T>
 where
     P: TokenProvider + Send + Sync + Clone + 'static,
     V: Verifier + Send + Sync + Clone + 'static,
@@ -1177,7 +828,7 @@ where
     ) -> Self {
         let mls_state = mls.map(MlsModeratorState::new);
 
-        let endpoint = Endpoint::new(
+        let endpoint = SessionControllerState::new(
             name,
             channel_name,
             session_id,
@@ -1188,7 +839,7 @@ where
             session_metadata,
         );
 
-        ChannelModerator {
+        SessionModerator {
             endpoint,
             tasks_todo: vec![].into(),
             current_task: None,
@@ -2013,7 +1664,7 @@ where
     }
 }
 
-impl<P, V, T> MlsEndpoint for ChannelModerator<P, V, T>
+impl<P, V, T> MlsEndpoint for SessionModerator<P, V, T>
 where
     P: TokenProvider + Send + Sync + Clone + 'static,
     V: Verifier + Send + Sync + Clone + 'static,
@@ -2098,7 +1749,7 @@ where
     }
 }
 
-impl<P, V, T> SessionComponentLifecycle for ChannelModerator<P, V, T>
+impl<P, V, T> SessionComponentLifecycle for SessionModerator<P, V, T>
 where
     P: TokenProvider + Send + Sync + Clone + 'static,
     V: Verifier + Send + Sync + Clone + 'static,
@@ -2114,7 +1765,7 @@ where
     }
 }
 
-impl<P, V, T> OnMessageReceived for ChannelModerator<P, V, T>
+impl<P, V, T> OnMessageReceived for SessionModerator<P, V, T>
 where
     P: TokenProvider + Send + Sync + Clone + 'static,
     V: Verifier + Send + Sync + Clone + 'static,
@@ -2232,8 +1883,10 @@ mod tests {
     use crate::transmitter::SessionTransmitter;
 
     use super::*;
+    use parking_lot::Mutex;
     use slim_auth::shared_secret::SharedSecret;
     use slim_auth::testutils::TEST_VALID_SECRET;
+    use slim_mls::mls::Mls;
     use tracing_test::traced_test;
 
     use slim_datapath::messages::Name;
@@ -2272,7 +1925,7 @@ mod tests {
         ))))
         .unwrap();
 
-        let mut cm = ChannelModerator::new(
+        let mut cm = SessionModerator::new(
             moderator.clone(),
             channel_name.clone(),
             SESSION_ID,
@@ -2284,7 +1937,7 @@ mod tests {
             None,
             HashMap::new(),
         );
-        let mut cp = ChannelParticipant::new(
+        let mut cp = SessionParticipant::new(
             participant.clone(),
             channel_name.clone(),
             SESSION_ID,

--- a/data-plane/core/session/src/session_layer.rs
+++ b/data-plane/core/session/src/session_layer.rs
@@ -30,7 +30,7 @@ use super::{
     Id, MessageDirection, SESSION_RANGE, Session, SessionConfig, SessionConfigTrait, SessionType,
     SlimChannelSender, Transmitter,
 };
-use super::{SessionError, channel_endpoint::handle_channel_discovery_message};
+use super::{SessionError, session_controller::handle_channel_discovery_message};
 use crate::interceptor::SessionInterceptorProvider; // needed for add_interceptor
 
 /// SessionLayer manages sessions and their lifecycle


### PR DESCRIPTION
# Description

Separate the MLS state code from the Channel Endpoint file.
Also rename Channel Endpoint in Session Controller.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
