### PR TITLE
chore(bindings): Use venv for stub generation task

### DIFF
--- a/data-plane/python/bindings/Taskfile.yaml
+++ b/data-plane/python/bindings/Taskfile.yaml
@@ -97,5 +97,7 @@ tasks:
 
   python:bindings:generate-stub:
     desc: "Generate stub file for the Python bindings"
-    cmds:
-      - cargo run --bin stub_gen
+    cmds: 
+      - cmd: |
+          export PYTHONHOME="$(dirname $(dirname $(realpath $(which .venv/bin/python))))"
+          uv run cargo run --bin stub_gen


### PR DESCRIPTION
# Description

This forces the generate-stub task to use the uv virtual environment's version of python detaching it from the system python version.

There is a bug in pyo3 which requires PYTHONHOME to be explicitly set when working inside of a virtualenv.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [X] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
