### PR TITLE
fix: workaround for running slimctl on Mac (installed with brew)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -44,6 +44,14 @@ homebrew_casks:
     description: "A CLI tool for managing SLIM Devices"
     homepage: "https://github.com/agntcy/slim/control-plane/slimctl"
     directory: Casks
+    hooks:
+      post:
+        # workaround for the problem described here: https://goreleaser.com/customization/homebrew_casks/#signing-and-notarizing
+        install: |
+          system "chmod", "+x", "#{staged_path}/slimctl"
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/slimctl"]
+          end
 
     binaries:
       - slimctl


### PR DESCRIPTION
# Description

* applied the workaround found [here](https://goreleaser.com/customization/homebrew_casks/#signing-and-notarizing)
* inferred build/version information for goreleaser builds  