### PR TITLE
ci: disable cache settings in Docker build workflow

### DIFF
--- a/.github/workflows/reusable-docker-build-push.yaml
+++ b/.github/workflows/reusable-docker-build-push.yaml
@@ -72,8 +72,8 @@ jobs:
           targets: ${{ inputs.bake-targets }}
           push: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
           provenance: false
-          set: |
-            *.cache-from=type=gha
-            *.cache-to=type=gha,mode=max
+          # set: |
+          #   *.cache-from=type=gha
+          #   *.cache-to=type=gha,mode=max
         env:
           IMAGE_REPO: ${{ inputs.image-repo }}


### PR DESCRIPTION
# Description

The docker cache saved on gha is causing some runners to exhaust the disk space.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] CI

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
