### PR TITLE
feat(python-bindings): Remove remaining Py... names from python bindings

### DIFF
--- a/data-plane/python/bindings/README.md
+++ b/data-plane/python/bindings/README.md
@@ -29,11 +29,11 @@ You can choose among multiple identity provider / verifier strategies:
 
 | Provider Variant                      | Use Case                               | Notes |
 |--------------------------------------|-----------------------------------------|-------|
-| `PyIdentityProvider.SharedSecret`    | Local dev / tests                       | Symmetric; not for production |
-| `PyIdentityProvider.StaticJwt`       | Pre-issued token loaded from file       | No key rotation; simple |
-| `PyIdentityProvider.Jwt`             | Dynamically signed JWT (private key)    | Supports exp, iss, aud, sub, duration |
-| `PyIdentityVerifier.Jwt`             | Verifies JWT (public key or JWKS auto)  | Optional claim requirements (`require_iss`, etc.) |
-| `PyIdentityVerifier.SharedSecret`    | Matches shared secret provider          | Symmetric validation |
+| `IdentityProvider.SharedSecret`    | Local dev / tests                       | Symmetric; not for production |
+| `IdentityProvider.StaticJwt`       | Pre-issued token loaded from file       | No key rotation; simple |
+| `IdentityProvider.Jwt`             | Dynamically signed JWT (private key)    | Supports exp, iss, aud, sub, duration |
+| `IdentityVerifier.Jwt`             | Verifies JWT (public key or JWKS auto)  | Optional claim requirements (`require_iss`, etc.) |
+| `IdentityVerifier.SharedSecret`    | Matches shared secret provider          | Symmetric validation |
 
 JWKS auto‑resolution (when configured in the verifier with `autoresolve=True`) will:
 1. Try OpenID discovery (`/.well-known/openid-configuration`) for `jwks_uri`
@@ -58,10 +58,10 @@ import slim_bindings
 
 async def main():
     # 1. Create identity
-    provider = slim_bindings.PyIdentityProvider.SharedSecret(identity="demo", shared_secret="secret")
-    verifier = slim_bindings.PyIdentityVerifier.SharedSecret(identity="demo", shared_secret="secret")
+    provider = slim_bindings.IdentityProvider.SharedSecret(identity="demo", shared_secret="secret")
+    verifier = slim_bindings.IdentityVerifier.SharedSecret(identity="demo", shared_secret="secret")
 
-    local_name = slim_bindings.PyName("org", "namespace", "demo")
+    local_name = slim_bindings.Name("org", "namespace", "demo")
     slim = await slim_bindings.Slim.new(local_name, provider, verifier)
 
     # 2. (Optionally) connect as a client to a remote endpoint
@@ -89,9 +89,9 @@ asyncio.run(main())
 ### 3. Outbound Session (PointToPoint)
 
 ```python
-remote = slim_bindings.PyName("org", "namespace", "peer")
+remote = slim_bindings.Name("org", "namespace", "peer")
 session = await slim.create_session(
-    slim_bindings.PySessionConfiguration.PointToPoint(
+    slim_bindings.SessionConfiguration.PointToPoint(
         peer_name=remote,
         mls_enabled=True,
         metadata={"trace_id": "abc123"},

--- a/data-plane/python/bindings/SESSION.md
+++ b/data-plane/python/bindings/SESSION.md
@@ -94,7 +94,7 @@ Using the SLIM Python bindings, you can create a PointToPoint session as follows
 ```python
 # Assume local_app is an initialized application instance
 session = await local_app.create_session(
-    slim_bindings.PySessionConfiguration.PointToPoint(
+    slim_bindings.SessionConfiguration.PointToPoint(
         peer_name=remote_name,
         max_retries=5,
         timeout=datetime.timedelta(seconds=5),
@@ -104,7 +104,7 @@ session = await local_app.create_session(
 ```
 
 Parameters:
-* `peer_name` (required, PyName): Identifier of the remote participant
+* `peer_name` (required, Name): Identifier of the remote participant
     instance.
 * `max_retries` (optional, int): Retry attempts per message if Ack missing.
 * `timeout` (optional, timedelta): Wait per attempt for an Ack before retry.
@@ -153,7 +153,7 @@ example:
 ```python
 # Assume local_app is an initialized application instance
 session = await local_app.create_session(
-    slim_bindings.PySessionConfiguration.Group(
+    slim_bindings.SessionConfiguration.Group(
         channel_name=channel_name,
         max_retries=5,
         timeout=datetime.timedelta(seconds=5),
@@ -163,7 +163,7 @@ session = await local_app.create_session(
 ```
 
 Parameters:
-* `channel_name` (required, PyName): Channel name where all the messages are
+* `channel_name` (required, Name): Channel name where all the messages are
     delivered.
 * `max_retries` (optional, int): Retry attempts for missing Acks.
 * `timeout` (optional, timedelta): Wait per attempt for Ack before retry.
@@ -201,7 +201,7 @@ await session.invite(invite_name)
 ```
 
 Parameter:
-* `invite_name` (PyName): Identifier of the participant to add.
+* `invite_name` (Name): Identifier of the participant to add.
 
 
 When a moderator wants to add a new participant (e.g., an instance of App-C) to
@@ -292,7 +292,7 @@ await session.remove(remove_name)
 
 
 Parameter:
-* `remove_name` (PyName): Identifier of the participant to remove.
+* `remove_name` (Name): Identifier of the participant to remove.
 
 
 When a moderator wants to remove a participant (e.g., App-C/1) from a group

--- a/data-plane/python/bindings/examples/src/slim_bindings_examples/README_group.md
+++ b/data-plane/python/bindings/examples/src/slim_bindings_examples/README_group.md
@@ -87,8 +87,8 @@ session and can invite participants.
 ```python
 chat_channel = split_id(remote)  # e.g. agntcy/ns/chat
 created_session = await local_app.create_session(
-    slim_bindings.PySessionConfiguration.Group(  # Build group session configuration
-        channel_name=chat_channel,  # Logical group channel (PyName) all participants join; acts as group/topic identifier.
+    slim_bindings.SessionConfiguration.Group(  # Build group session configuration
+        channel_name=chat_channel,  # Logical group channel (Name) all participants join; acts as group/topic identifier.
         max_retries=5,  # Max per-message resend attempts upon missing ack before reporting a delivery failure.
         timeout=datetime.timedelta(
             seconds=5
@@ -132,15 +132,15 @@ while True:
     try:
         # Await next inbound message from the group session.
         # The returned parameters are a message context and the raw payload bytes.
-        # Check session.py for details on PyMessageContext contents.
+        # Check session.py for details on MessageContext contents.
         ctx, payload = await session.get_message()
         print_formatted_text(
             f"{ctx.source_name} > {payload.decode()}",
             style=custom_style,
         )
 ```
-The message is received with `session.get_message()`. `ctx` is a `PyMessageContext`
-with information about the received message. `ctx.source_name` is the `PyName` of
+The message is received with `session.get_message()`. `ctx` is a `MessageContext`
+with information about the received message. `ctx.source_name` is the `Name` of
 the sender, and `payload` is a `bytes` object carrying the published message.
 
 ### 4. Publishing messages

--- a/data-plane/python/bindings/examples/src/slim_bindings_examples/README_point_to_point.md
+++ b/data-plane/python/bindings/examples/src/slim_bindings_examples/README_point_to_point.md
@@ -86,7 +86,7 @@ all subsequent traffic is pinned to that peer for the session lifetime.
 remote_name = split_id(remote)
 await local_app.set_route(remote_name)
 session = await local_app.create_session(
-    slim_bindings.PySessionConfiguration.PointToPoint(
+    slim_bindings.SessionConfiguration.PointToPoint(
         peer_name=remote_name,
         max_retries=5,
         timeout=datetime.timedelta(seconds=5),

--- a/data-plane/python/bindings/examples/src/slim_bindings_examples/common.py
+++ b/data-plane/python/bindings/examples/src/slim_bindings_examples/common.py
@@ -369,7 +369,7 @@ async def create_local_app(
     # Convert local identifier to a strongly typed Name.
     local_name = split_id(local)
 
-    # Instantiate Slim (async constructor prepares underlying PyService).
+    # Instantiate Slim (async constructor prepares underlying Service).
     local_app = slim_bindings.Slim(local_name, provider, verifier)
 
     # Provide feedback to user (instance numeric id).

--- a/data-plane/python/bindings/examples/src/slim_bindings_examples/group.py
+++ b/data-plane/python/bindings/examples/src/slim_bindings_examples/group.py
@@ -17,7 +17,7 @@ Key concepts:
   - Invites are explicit: the moderator invites each participant after
     creating the session.
   - Participants that did not create the session simply wait for
-    listen_for_session() to yield their PySession.
+    listen_for_session() to yield their Session.
 
 Usage:
   slim-bindings-examples group \

--- a/data-plane/python/bindings/examples/src/slim_bindings_examples/slim.py
+++ b/data-plane/python/bindings/examples/src/slim_bindings_examples/slim.py
@@ -68,7 +68,7 @@ async def run_server(address: str, enable_opentelemetry: bool):
         secret="jasfhuejasdfhays3wtkrktasdhfsadu2rtkdhsfgeht",  # Must be > 32 bytes
     )
 
-    # Create Slim instance with a fixed PyName. Organization/namespace/app are illustrative.
+    # Create Slim instance with a fixed Name. Organization/namespace/app are illustrative.
     slim = slim_bindings.Slim(
         slim_bindings.Name("cisco", "default", "slim"), provider, verifier
     )

--- a/data-plane/python/bindings/slim_bindings/session.py
+++ b/data-plane/python/bindings/slim_bindings/session.py
@@ -28,7 +28,7 @@ class Session:
         safe to await concurrently.
 
     Lifecycle:
-        A `PySession` is typically obtained from `Slim.create_session(...)`
+        A `Session` is typically obtained from `Slim.create_session(...)`
         or `Slim.listen_for_session(...)`. Call `delete()`to release
         server-side resources.
 
@@ -48,7 +48,7 @@ class Session:
     @property
     def id(self) -> int:
         """Return the unique numeric identifier for this session."""
-        return self._ctx.id  # exposed by PySessionContext
+        return self._ctx.id  # exposed by SessionContext
 
     @property
     def metadata(self) -> dict[str, str]:

--- a/data-plane/python/bindings/slim_bindings/slim.py
+++ b/data-plane/python/bindings/slim_bindings/slim.py
@@ -18,7 +18,7 @@ from .session import Session
 
 class Slim:
     """
-    High-level façade over the underlying PyService (Rust core) providing a
+    High-level façade over the underlying Service (Rust core) providing a
     Pythonic API for:
       * Service initialization & authentication (via Slim.new)
       * Client connections to remote Slim services (connect / disconnect)
@@ -84,9 +84,9 @@ class Slim:
         the underlying service handle.
 
         Args:
-            name (PyName): Fully qualified local name (org/namespace/app).
-            provider (PyIdentityProvider): Identity provider for authentication.
-            verifier (PyIdentityVerifier): Identity verifier for validating peers.
+            name (Name): Fully qualified local name (org/namespace/app).
+            provider (IdentityProvider): Identity provider for authentication.
+            verifier (IdentityVerifier): Identity verifier for validating peers.
             local_service (bool): Whether this is a local service. Defaults to False.
 
         Note: Service initialization happens here via PyApp construction.
@@ -141,14 +141,14 @@ class Slim:
         destination: Name,
         session_config: SessionConfiguration,
     ) -> typing.Any:
-        """Create a new session and return its high-level PySession wrapper.
+        """Create a new session and return its high-level Session wrapper.
 
         Args:
             destination (Name): Target peer or channel name.
             session_config (SessionConfiguration): Parameters controlling creation.
 
         Returns:
-            PySession: Wrapper exposing high-level async operations for the session.
+            Session: Wrapper exposing high-level async operations for the session.
         """
         ctx, completion_handle = await self._app.create_session(
             destination, session_config
@@ -160,7 +160,7 @@ class Slim:
         Terminate and remove an existing session.
 
         Args:
-            session (PySession): Session wrapper previously returned by create_session.
+            session (Session): Session wrapper previously returned by create_session.
 
         Returns:
             None
@@ -318,7 +318,7 @@ class Slim:
         Await the next inbound session (optionally bounded by timeout).
 
         Returns:
-            PySession: Wrapper for the accepted session context.
+            Session: Wrapper for the accepted session context.
         """
 
         ctx: SessionContext = await self._app.listen_for_session(timeout)

--- a/data-plane/python/bindings/tests/conftest.py
+++ b/data-plane/python/bindings/tests/conftest.py
@@ -5,7 +5,7 @@
 
 Provides the 'server' fixture which spins up a Slim service. The fixture
 initializes tracing, launches the server asynchronously, waits briefly
-for readiness, and yields the underlying PyService so tests can
+for readiness, and yields the underlying Service so tests can
 establish sessions, publish messages, or perform connection logic.
 """
 
@@ -36,7 +36,7 @@ async def server(request):
             - None: No server created - creates global service
 
     Behavior:
-        1. Creates a PyService with SharedSecret auth (identity 'server').
+        1. Creates a Service with SharedSecret auth (identity 'server').
            This is not used here, as we use this SLIM instance only for packet forwarding.
         2. Initializes tracing (log_level=info) once.
         3. Starts the server with the provided endpoint (non-blocking) if endpoint provided.

--- a/data-plane/python/bindings/tests/test_bindings.py
+++ b/data-plane/python/bindings/tests/test_bindings.py
@@ -7,7 +7,7 @@ Integration tests for the slim_bindings Python layer.
 These tests exercise:
 - End-to-end PointToPoint session creation, message publish/reply, and cleanup.
 - Session configuration retrieval and default session configuration propagation.
-- Usage of the high-level Slim wrapper (PySession helper methods).
+- Usage of the high-level Slim wrapper (Session helper methods).
 - Automatic client reconnection after a server restart.
 - Error handling when targeting a non-existent subscription.
 
@@ -146,7 +146,7 @@ async def test_end_to_end(server):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", ["127.0.0.1:12345"], indirect=True)
 async def test_slim_wrapper(server):
-    """Exercise high-level Slim + PySession convenience API:
+    """Exercise high-level Slim + Session convenience API:
     - Instantiate two Slim instances
     - Connect & establish routing
     - Create PointToPoint session and publish


### PR DESCRIPTION
# Description

There were a few places in the docs/comments and in the python code which were refering to Py... objects still. This a cleanup that should leave on Py.. named things in the rust code.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [X] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
