### PR TITLE
fix: store componentID as string in sqlight db

### DIFF
--- a/control-plane/control-plane/internal/db/sqlite.go
+++ b/control-plane/control-plane/internal/db/sqlite.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/glebarez/sqlite"
@@ -40,7 +41,7 @@ type RouteModel struct {
 	Component0     string
 	Component1     string
 	Component2     string
-	ComponentID    *uint64
+	ComponentID    *string
 	Status         int
 	StatusMsg      string
 	Deleted        bool
@@ -184,7 +185,8 @@ func (s *SQLiteDBService) GetRoutesForDestinationNodeIDAndName(nodeID string, co
 	if componentID == nil {
 		query = query.Where("component_id IS NULL")
 	} else {
-		query = query.Where("component_id = ?", componentID.Value)
+		componentIDStr := strconv.FormatUint(componentID.Value, 10)
+		query = query.Where("component_id = ?", componentIDStr)
 	}
 
 	var routeModels []RouteModel
@@ -213,7 +215,8 @@ func (s *SQLiteDBService) GetRouteForSrcAndDestinationAndName(srcNodeID string, 
 	if componentID == nil {
 		query = query.Where("component_id IS NULL")
 	} else {
-		query = query.Where("component_id = ?", componentID.Value)
+		componentIDStr := strconv.FormatUint(componentID.Value, 10)
+		query = query.Where("component_id = ?", componentIDStr)
 	}
 
 	var routeModel RouteModel
@@ -404,9 +407,10 @@ func (s *SQLiteDBService) nodeModelToNode(nodeModel NodeModel) Node {
 }
 
 func (s *SQLiteDBService) routeToRouteModel(route Route) RouteModel {
-	var componentID *uint64
+	var componentID *string
 	if route.ComponentID != nil {
-		componentID = &route.ComponentID.Value
+		componentIDStr := strconv.FormatUint(route.ComponentID.Value, 10)
+		componentID = &componentIDStr
 	}
 
 	return RouteModel{
@@ -429,7 +433,9 @@ func (s *SQLiteDBService) routeToRouteModel(route Route) RouteModel {
 func (s *SQLiteDBService) routeModelToRoute(routeModel RouteModel) Route {
 	var componentID *wrapperspb.UInt64Value
 	if routeModel.ComponentID != nil {
-		componentID = &wrapperspb.UInt64Value{Value: *routeModel.ComponentID}
+		if componentIDValue, err := strconv.ParseUint(*routeModel.ComponentID, 10, 64); err == nil {
+			componentID = &wrapperspb.UInt64Value{Value: componentIDValue}
+		}
 	}
 
 	return Route{


### PR DESCRIPTION
# Description

Store componentID as string cause sqlight doesnt support uint64 vales with high bit set.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
