### PR TITLE
fix(spire): get all x509 bundles

### DIFF
--- a/data-plane/core/auth/src/spire.rs
+++ b/data-plane/core/auth/src/spire.rs
@@ -398,29 +398,31 @@ impl SpireIdentityManager {
     }
 
     /// Get the X.509 bundle for an explicit trust domain (ignores config override)
-    pub fn get_x509_bundle_for_trust_domain(
-        &self,
+    pub async fn get_x509_bundle_for_trust_domain(
+        &mut self,
         trust_domain: impl Into<String>,
     ) -> Result<X509Bundle, AuthError> {
         let td_str = trust_domain.into();
-        let x509_source = self
-            .x509_source
-            .as_ref()
-            .ok_or_else(|| AuthError::ConfigError("X509Source not initialized".to_string()))?;
-        let td_parsed = TrustDomain::new(&td_str).map_err(|e| {
-            AuthError::ConfigError(format!("Invalid trust domain '{}': {}", td_str, e))
+
+        let c = self.client.as_mut().ok_or_else(|| {
+            AuthError::ConfigError("WorkloadApiClient not initialized".to_string())
         })?;
-        x509_source
-            .get_bundle_for_trust_domain(&td_parsed)
-            .map_err(|e| {
-                AuthError::ConfigError(format!(
-                    "Failed to get X509 bundle for trust domain {}: {}",
-                    td_str, e
-                ))
-            })?
-            .ok_or_else(|| {
-                AuthError::ConfigError(format!("No X509 bundle for trust domain {}", td_str))
-            })
+
+        let bundles = c.fetch_x509_bundles().await.map_err(|e| {
+            AuthError::ConfigError(format!("Failed to fetch all X509 bundles: {}", e))
+        })?;
+
+        let td = TrustDomain::new(&td_str).map_err(|e| {
+            AuthError::ConfigError(format!("Invalid trust domain {}: {}", td_str, e))
+        })?;
+
+        bundles
+            .get_bundle(&td)
+            .cloned()
+            .ok_or(AuthError::ConfigError(format!(
+                "No X509 bundle for trust domain {}",
+                td_str
+            )))
     }
 
     /// Internal helper to access JWT bundles

--- a/data-plane/core/config/src/tls/root_store_builder.rs
+++ b/data-plane/core/config/src/tls/root_store_builder.rs
@@ -121,7 +121,7 @@ impl RootStoreBuilder {
         root_store: &mut RootCertStore,
         spiffe_cfg: &spire::SpireConfig,
     ) -> Result<(), ConfigError> {
-        let spire_identity_manager = spiffe_cfg.create_provider().await.map_err(|e| {
+        let mut spire_identity_manager = spiffe_cfg.create_provider().await.map_err(|e| {
             ConfigError::InvalidFile(format!("failed to create SPIFFE provider: {}", e))
         })?;
 
@@ -129,6 +129,7 @@ impl RootStoreBuilder {
             for domain in &spiffe_cfg.trust_domains {
                 let bundle = spire_identity_manager
                     .get_x509_bundle_for_trust_domain(domain)
+                    .await
                     .map_err(|e| {
                         ConfigError::Spire(format!(
                             "failed to get X.509 bundle for trust domain {}: {}",


### PR DESCRIPTION
# Description

The current API to get the x509 bundles is using the streaming API, which
does not return the bundles for all the federated domains. Switching to
fetch_x509_bundles seems to resolve the issue.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
