### PR TITLE
ci(setup-task): disable revocation check on windows

### DIFF
--- a/.github/actions/setup-task/action.yaml
+++ b/.github/actions/setup-task/action.yaml
@@ -117,7 +117,8 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
         echo "Task not found in cache, downloading..."
-        sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -b ~/.local/bin -d ${{ steps.get-version.outputs.version }}
+        [[ "$OS" = "windows" ]] && CURL_EXTRA="--ssl-no-revoke" || CURL_EXTRA=""
+        sh -c "$(curl ${CURL_EXTRA} --location https://taskfile.dev/install.sh)" -- -b ~/.local/bin -d ${{ steps.get-version.outputs.version }}
 
     - name: Verify installation
       shell: bash


### PR DESCRIPTION
# Description

Windows jobs are failing to retrieve the revocation list, as the server is currently offline.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
