### PR TITLE
fix: properly delete session in tests

### DIFF
--- a/data-plane/testing/src/bin/test_group.rs
+++ b/data-plane/testing/src/bin/test_group.rs
@@ -407,9 +407,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    // close session
-    let handle = session_arc.close().expect("error closing session");
-    handle.await.expect("error waiting the handler");
+    // delete session
+    let handle = app.delete_session(session_arc.as_ref())?;
+    drop(session_arc);
+    handle.await.expect("error deleting session");
     println!("test succeeded");
     Ok(())
 }

--- a/data-plane/testing/src/bin/test_p2p.rs
+++ b/data-plane/testing/src/bin/test_p2p.rs
@@ -421,6 +421,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
+    // delete the session
+    let handle = app
+        .delete_session(session_arc.as_ref())
+        .expect("an error occurred deleting the session");
+    drop(session_arc);
+
+    // await handle
+    handle
+        .await
+        .expect("an error occurred waiting for session deletion");
+
     // the total number of packets received must be max_packets
     let mut sum = 0;
     // if unicast we must see a single sendere


### PR DESCRIPTION
# Description

Fix group tests to gracefully close session upon termination.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
