### PR TITLE
chore: release

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agntcy-protoc-slimrpc-plugin"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-service",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-auth"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-testing",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-testing",
@@ -150,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.10.3"
+version = "0.11.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-tracing",
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -260,7 +260,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -281,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-signal"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "tokio",
  "tracing",
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.2.7"
+version = "0.3.0"
 dependencies = [
  "agntcy-slim-config",
  "once_cell",

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -34,18 +34,18 @@ resolver = "2"
 
 [workspace.dependencies]
 # Local dependencies
-agntcy-slim = { path = "core/slim", version = "0.7.1" }
-agntcy-slim-auth = { path = "core/auth", version = "0.4.1" }
-agntcy-slim-bindings = { path = "bindings/rust", version = "0.7.0" }
-agntcy-slim-config = { path = "core/config", version = "0.4.3" }
-agntcy-slim-controller = { path = "core/controller", version = "0.4.3" }
-agntcy-slim-datapath = { path = "core/datapath", version = "0.10.3" }
-agntcy-slim-mls = { path = "core/mls", version = "0.1.5" }
-agntcy-slim-service = { path = "core/service", version = "0.8.2", default-features = false }
-agntcy-slim-session = { path = "core/session", version = "0.1.2" }
-agntcy-slim-signal = { path = "core/signal", version = "0.1.3" }
+agntcy-slim = { path = "core/slim", version = "0.7.2" }
+agntcy-slim-auth = { path = "core/auth", version = "0.5.0" }
+agntcy-slim-bindings = { path = "bindings/rust", version = "1.0.0-rc.0" }
+agntcy-slim-config = { path = "core/config", version = "0.5.0" }
+agntcy-slim-controller = { path = "core/controller", version = "0.4.4" }
+agntcy-slim-datapath = { path = "core/datapath", version = "0.11.0" }
+agntcy-slim-mls = { path = "core/mls", version = "0.1.6" }
+agntcy-slim-service = { path = "core/service", version = "0.8.3", default-features = false }
+agntcy-slim-session = { path = "core/session", version = "0.1.3" }
+agntcy-slim-signal = { path = "core/signal", version = "0.1.4" }
 agntcy-slim-testing = { path = "testing" }
-agntcy-slim-tracing = { path = "core/tracing", version = "0.2.7" }
+agntcy-slim-tracing = { path = "core/tracing", version = "0.3.0" }
 
 anyhow = "1.0.98"
 

--- a/data-plane/bindings/rust/CHANGELOG.md
+++ b/data-plane/bindings/rust/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0-rc.0](https://github.com/agntcy/slim/releases/tag/slim-bindings-v1.0.0-rc.0) - 2026-01-29
+
+### Added
+
+- *(bindings)* set release candidate 1.0.0-rc.0 ([#1135](https://github.com/agntcy/slim/pull/1135))
+- *(bindings)* move to new python bindings ([#1116](https://github.com/agntcy/slim/pull/1116))
+- *(session)* Add direction to slim app to control message flow ([#1121](https://github.com/agntcy/slim/pull/1121))
+- generate python bindings with uniffi ([#1046](https://github.com/agntcy/slim/pull/1046))
+
+### Other
+
+- *(Taskfile)* move zig installation to global tools ([#1120](https://github.com/agntcy/slim/pull/1120))
+- *(bindings)* do not expose tokio-specific APIs to foreign async calls ([#1110](https://github.com/agntcy/slim/pull/1110))
+- *(bindings)* allow multiple global services ([#1106](https://github.com/agntcy/slim/pull/1106))
+- *(bindings)* rename BindingsAdapter into App and BindingsSessionContext into Session ([#1104](https://github.com/agntcy/slim/pull/1104))

--- a/data-plane/core/auth/CHANGELOG.md
+++ b/data-plane/core/auth/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/agntcy/slim/compare/slim-auth-v0.4.1...slim-auth-v0.5.0) - 2026-01-29
+
+### Added
+
+- Support different trust domains in auto route setup ([#1001](https://github.com/agntcy/slim/pull/1001))
+
+### Fixed
+
+- *(bindings)* improve identity error handling ([#1042](https://github.com/agntcy/slim/pull/1042))
+
+### Other
+
+- unified typed error handling across core crates ([#976](https://github.com/agntcy/slim/pull/976))
+
 ## [0.4.1](https://github.com/agntcy/slim/compare/slim-auth-v0.4.0...slim-auth-v0.4.1) - 2025-11-17
 
 ### Added

--- a/data-plane/core/auth/Cargo.toml
+++ b/data-plane/core/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-auth"
-version = "0.4.1"
+version = "0.5.0"
 license = { workspace = true }
 edition = { workspace = true }
 description = "Authentication utilities for the Agntcy Slim framework"

--- a/data-plane/core/config/CHANGELOG.md
+++ b/data-plane/core/config/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/agntcy/slim/compare/slim-config-v0.4.3...slim-config-v0.5.0) - 2026-01-29
+
+### Added
+
+- Support different trust domains in auto route setup ([#1001](https://github.com/agntcy/slim/pull/1001))
+- *(bindings)* expose identity configuration ([#1092](https://github.com/agntcy/slim/pull/1092))
+- *(bindings)* expose complete configuration for auth and creating clients, servers ([#1084](https://github.com/agntcy/slim/pull/1084))
+- make backoff retry configurable ([#991](https://github.com/agntcy/slim/pull/991))
+
+### Other
+
+- unified typed error handling across core crates ([#976](https://github.com/agntcy/slim/pull/976))
+
 ## [0.4.3](https://github.com/agntcy/slim/compare/slim-config-v0.4.2...slim-config-v0.4.3) - 2025-11-21
 
 ### Fixed

--- a/data-plane/core/config/Cargo.toml
+++ b/data-plane/core/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-config"
-version = "0.4.3"
+version = "0.5.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Configuration utilities"

--- a/data-plane/core/controller/CHANGELOG.md
+++ b/data-plane/core/controller/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4](https://github.com/agntcy/slim/compare/slim-controller-v0.4.3...slim-controller-v0.4.4) - 2026-01-29
+
+### Added
+
+- Support different trust domains in auto route setup ([#1001](https://github.com/agntcy/slim/pull/1001))
+- *(bindings)* expose identity configuration ([#1092](https://github.com/agntcy/slim/pull/1092))
+- send group acknowledge from the session ([#1050](https://github.com/agntcy/slim/pull/1050))
+- make backoff retry configurable ([#991](https://github.com/agntcy/slim/pull/991))
+
+### Fixed
+
+- *(controller)* start the controller service only if the related config is provided ([#1054](https://github.com/agntcy/slim/pull/1054))
+- *(bindings)* improve identity error handling ([#1042](https://github.com/agntcy/slim/pull/1042))
+
+### Other
+
+- *(bindings)* do not expose tokio-specific APIs to foreign async calls ([#1110](https://github.com/agntcy/slim/pull/1110))
+- *(lint)* use latest version of tools ([#1067](https://github.com/agntcy/slim/pull/1067))
+- unified typed error handling across core crates ([#976](https://github.com/agntcy/slim/pull/976))
+
 ## [0.4.3](https://github.com/agntcy/slim/compare/slim-controller-v0.4.2...slim-controller-v0.4.3) - 2025-11-21
 
 ### Fixed

--- a/data-plane/core/controller/Cargo.toml
+++ b/data-plane/core/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-controller"
-version = "0.4.3"
+version = "0.4.4"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Controller service and control API to configure the SLIM data plane through the control plane."

--- a/data-plane/core/datapath/CHANGELOG.md
+++ b/data-plane/core/datapath/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/agntcy/slim/compare/slim-datapath-v0.10.3...slim-datapath-v0.11.0) - 2026-01-29
+
+### Added
+
+- add reference count to subscription table ([#1143](https://github.com/agntcy/slim/pull/1143))
+- generate python bindings with uniffi ([#1046](https://github.com/agntcy/slim/pull/1046))
+- *(bindings)* configuration file support ([#1099](https://github.com/agntcy/slim/pull/1099))
+- *(bindings)* expose participant list to the application ([#1089](https://github.com/agntcy/slim/pull/1089))
+- *(session)* handle moderator unexpected stop ([#1024](https://github.com/agntcy/slim/pull/1024))
+- make backoff retry configurable ([#991](https://github.com/agntcy/slim/pull/991))
+- Update group state on unexpected application stop ([#1014](https://github.com/agntcy/slim/pull/1014))
+- detect and handle unexpected participant disconnections ([#1004](https://github.com/agntcy/slim/pull/1004))
+
+### Fixed
+
+- match all function send only to local applications ([#1132](https://github.com/agntcy/slim/pull/1132))
+- *(session)* route dataplane errors to correct session ([#1056](https://github.com/agntcy/slim/pull/1056))
+- *(session)* correctly remove routes on session close ([#1039](https://github.com/agntcy/slim/pull/1039))
+
+### Other
+
+- *(bindings)* do not expose tokio-specific APIs to foreign async calls ([#1110](https://github.com/agntcy/slim/pull/1110))
+- *(lint)* use latest version of tools ([#1067](https://github.com/agntcy/slim/pull/1067))
+- unified typed error handling across core crates ([#976](https://github.com/agntcy/slim/pull/976))
+
 ## [0.10.3](https://github.com/agntcy/slim/compare/slim-datapath-v0.10.2...slim-datapath-v0.10.3) - 2025-11-21
 
 ### Added

--- a/data-plane/core/datapath/Cargo.toml
+++ b/data-plane/core/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-datapath"
-version = "0.10.3"
+version = "0.11.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Core data plane functionality for SLIM"

--- a/data-plane/core/mls/CHANGELOG.md
+++ b/data-plane/core/mls/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/agntcy/slim/compare/slim-mls-v0.1.5...slim-mls-v0.1.6) - 2026-01-29
+
+### Fixed
+
+- *(bindings)* improve identity error handling ([#1042](https://github.com/agntcy/slim/pull/1042))
+
+### Other
+
+- unified typed error handling across core crates ([#976](https://github.com/agntcy/slim/pull/976))
+
 ## [0.1.5](https://github.com/agntcy/slim/compare/slim-mls-v0.1.4...slim-mls-v0.1.5) - 2025-11-21
 
 ### Other

--- a/data-plane/core/mls/Cargo.toml
+++ b/data-plane/core/mls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-mls"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.5"
+version = "0.1.6"
 description = "Messaging Layer Security for SLIM data plane."
 
 [lib]

--- a/data-plane/core/service/CHANGELOG.md
+++ b/data-plane/core/service/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.3](https://github.com/agntcy/slim/compare/slim-service-v0.8.2...slim-service-v0.8.3) - 2026-01-29
+
+### Added
+
+- *(session)* Add direction to slim app to control message flow ([#1121](https://github.com/agntcy/slim/pull/1121))
+- generate python bindings with uniffi ([#1046](https://github.com/agntcy/slim/pull/1046))
+- *(bindings)* configuration file support ([#1099](https://github.com/agntcy/slim/pull/1099))
+- *(bindings)* expose participant list to the application ([#1089](https://github.com/agntcy/slim/pull/1089))
+- Go bindings generation using uniffi ([#979](https://github.com/agntcy/slim/pull/979))
+- make backoff retry configurable ([#991](https://github.com/agntcy/slim/pull/991))
+
+### Fixed
+
+- *(session)* route dataplane errors to correct session ([#1056](https://github.com/agntcy/slim/pull/1056))
+- *(controller)* start the controller service only if the related config is provided ([#1054](https://github.com/agntcy/slim/pull/1054))
+- *(bindings)* improve identity error handling ([#1042](https://github.com/agntcy/slim/pull/1042))
+
+### Other
+
+- *(bindings)* do not expose tokio-specific APIs to foreign async calls ([#1110](https://github.com/agntcy/slim/pull/1110))
+- *(bindings)* allow multiple global services ([#1106](https://github.com/agntcy/slim/pull/1106))
+- feature flag for session layer ([#1102](https://github.com/agntcy/slim/pull/1102))
+- unified typed error handling across core crates ([#976](https://github.com/agntcy/slim/pull/976))
+
 ## [0.8.2](https://github.com/agntcy/slim/compare/slim-service-v0.8.1...slim-service-v0.8.2) - 2025-11-21
 
 ### Added

--- a/data-plane/core/service/Cargo.toml
+++ b/data-plane/core/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-service"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.8.2"
+version = "0.8.3"
 description = "Main service and public API to interact with SLIM data plane."
 
 [lib]

--- a/data-plane/core/session/CHANGELOG.md
+++ b/data-plane/core/session/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/agntcy/slim/compare/slim-session-v0.1.2...slim-session-v0.1.3) - 2026-01-29
+
+### Added
+
+- add reference count to subscription table ([#1143](https://github.com/agntcy/slim/pull/1143))
+- *(session)* Add direction to slim app to control message flow ([#1121](https://github.com/agntcy/slim/pull/1121))
+- generate python bindings with uniffi ([#1046](https://github.com/agntcy/slim/pull/1046))
+- *(bindings)* expose participant list to the application ([#1089](https://github.com/agntcy/slim/pull/1089))
+- send group acknowledge from the session ([#1050](https://github.com/agntcy/slim/pull/1050))
+- *(bindings)* expose complete configuration for auth and creating clients, servers ([#1084](https://github.com/agntcy/slim/pull/1084))
+- *(session)* handle moderator unexpected stop ([#1024](https://github.com/agntcy/slim/pull/1024))
+- Update group state on unexpected application stop ([#1014](https://github.com/agntcy/slim/pull/1014))
+- detect and handle unexpected participant disconnections ([#1004](https://github.com/agntcy/slim/pull/1004))
+
+### Fixed
+
+- add missing routes to participants ([#1131](https://github.com/agntcy/slim/pull/1131))
+- check if a participant is already in the group before invite ([#1085](https://github.com/agntcy/slim/pull/1085))
+- *(session)* send ping messages to the right destination ([#1066](https://github.com/agntcy/slim/pull/1066))
+- *(session)* route dataplane errors to correct session ([#1056](https://github.com/agntcy/slim/pull/1056))
+- *(session)* remove participants from the group list ([#1059](https://github.com/agntcy/slim/pull/1059))
+- *(bindings)* improve identity error handling ([#1042](https://github.com/agntcy/slim/pull/1042))
+- *(session)* correctly remove routes on session close ([#1039](https://github.com/agntcy/slim/pull/1039))
+- *(moderator_task.rs)* typo ([#1008](https://github.com/agntcy/slim/pull/1008))
+
+### Other
+
+- unified typed error handling across core crates ([#976](https://github.com/agntcy/slim/pull/976))
+
 ## [0.1.2](https://github.com/agntcy/slim/compare/slim-session-v0.1.1...slim-session-v0.1.2) - 2025-11-21
 
 ### Added

--- a/data-plane/core/session/Cargo.toml
+++ b/data-plane/core/session/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-session"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.2"
+version = "0.1.3"
 description = "SLIM session internal implementation."
 
 [lib]

--- a/data-plane/core/signal/CHANGELOG.md
+++ b/data-plane/core/signal/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/agntcy/slim/compare/slim-signal-v0.1.3...slim-signal-v0.1.4) - 2026-01-29
+
+### Other
+
+- unified typed error handling across core crates ([#976](https://github.com/agntcy/slim/pull/976))
+
 ## [0.1.3](https://github.com/agntcy/slim/compare/slim-signal-v0.1.2...slim-signal-v0.1.3) - 2025-07-31
 
 ### Other

--- a/data-plane/core/signal/Cargo.toml
+++ b/data-plane/core/signal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-signal"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.3"
+version = "0.1.4"
 description = "Small library to handle OS signals."
 
 [lib]

--- a/data-plane/core/slim/CHANGELOG.md
+++ b/data-plane/core/slim/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2](https://github.com/agntcy/slim/compare/slim-v0.7.1...slim-v0.7.2) - 2026-01-29
+
+### Added
+
+- *(bindings)* configuration file support ([#1099](https://github.com/agntcy/slim/pull/1099))
+
+### Fixed
+
+- revert release SLIM 1.0.0-rc.0 ([#1153](https://github.com/agntcy/slim/pull/1153))
+
+### Other
+
+- release SLIM 1.0.0-rc.0 ([#1151](https://github.com/agntcy/slim/pull/1151))
+- *(bindings)* do not expose tokio-specific APIs to foreign async calls ([#1110](https://github.com/agntcy/slim/pull/1110))
+- *(bindings)* allow multiple global services ([#1106](https://github.com/agntcy/slim/pull/1106))
+- unified typed error handling across core crates ([#976](https://github.com/agntcy/slim/pull/976))
+
 ## [0.7.1](https://github.com/agntcy/slim/compare/slim-v0.7.0...slim-v0.7.1) - 2025-11-21
 
 ### Fixed

--- a/data-plane/core/slim/Cargo.toml
+++ b/data-plane/core/slim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim"
-version = "0.7.1"
+version = "0.7.2"
 edition = { workspace = true }
 license = { workspace = true }
 description = "The main SLIM executable."

--- a/data-plane/core/tracing/CHANGELOG.md
+++ b/data-plane/core/tracing/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/agntcy/slim/compare/slim-tracing-v0.2.7...slim-tracing-v0.3.0) - 2026-01-29
+
+### Added
+
+- *(bindings)* configuration file support ([#1099](https://github.com/agntcy/slim/pull/1099))
+
+### Other
+
+- unified typed error handling across core crates ([#976](https://github.com/agntcy/slim/pull/976))
+
 ## [0.2.7](https://github.com/agntcy/slim/compare/slim-tracing-v0.2.6...slim-tracing-v0.2.7) - 2025-11-21
 
 ### Other

--- a/data-plane/core/tracing/Cargo.toml
+++ b/data-plane/core/tracing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-tracing"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.2.7"
+version = "0.3.0"
 description = "Observability for SLIM data plane: logs, traces and metrics infrastructure."
 
 [lib]

--- a/data-plane/slimrpc-compiler/CHANGELOG.md
+++ b/data-plane/slimrpc-compiler/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/agntcy/slim/compare/protoc-slimrpc-plugin-v0.1.1...protoc-slimrpc-plugin-v0.1.2) - 2026-01-29
+
+### Added
+
+- *(slimrpc,slima2a,slim-mcp)* Upgrade to v0.7.1 slim_bindings ([#839](https://github.com/agntcy/slim/pull/839))
+
 ## [0.1.1](https://github.com/agntcy/slim/compare/protoc-slimrpc-plugin-v0.1.0...protoc-slimrpc-plugin-v0.1.1) - 2025-10-17
 
 ### Other

--- a/data-plane/slimrpc-compiler/Cargo.toml
+++ b/data-plane/slimrpc-compiler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "agntcy-protoc-slimrpc-plugin"
 description = "A protoc plugin for generating SRPC (Slim RPC) code"
-version = "0.1.1"
+version = "0.1.2"
 license.workspace = true
 edition.workspace = true
 


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-auth`: 0.4.1 -> 0.5.0 (⚠ API breaking changes)
* `agntcy-slim-config`: 0.4.3 -> 0.5.0 (⚠ API breaking changes)
* `agntcy-slim-tracing`: 0.2.7 -> 0.3.0 (⚠ API breaking changes)
* `agntcy-slim-datapath`: 0.10.3 -> 0.11.0 (⚠ API breaking changes)
* `agntcy-slim-mls`: 0.1.5 -> 0.1.6 (✓ API compatible changes)
* `agntcy-slim-session`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `agntcy-slim-signal`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `agntcy-slim-controller`: 0.4.3 -> 0.4.4 (✓ API compatible changes)
* `agntcy-slim-service`: 0.8.2 -> 0.8.3 (✓ API compatible changes)
* `agntcy-slim`: 0.7.1 -> 0.7.2 (✓ API compatible changes)
* `agntcy-slim-bindings`: 1.0.0-rc.0
* `agntcy-protoc-slimrpc-plugin`: 0.1.1 -> 0.1.2

### ⚠ `agntcy-slim-auth` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type FileWatcherError is no longer UnwindSafe, in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/file_watcher.rs:15
  type FileWatcherError is no longer RefUnwindSafe, in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/file_watcher.rs:15

--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type FileWatcherError no longer derives PartialEq, in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/file_watcher.rs:15

--- failure enum_tuple_variant_changed_kind: An enum tuple variant changed kind ---

Description:
A public enum's exhaustive tuple variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_tuple_variant_changed_kind.ron

Failed in:
  variant AuthError::TokenInvalid in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:83
  variant AuthError::GetTokenError in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:81

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant AuthError:JwtUnsupportedKeyAlgorithm in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:19
  variant AuthError:JwtMissingKeyAlgorithm in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:21
  variant AuthError:JwtMissingPrivateKey in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:23
  variant AuthError:JwtMissingDecodingKeyOrKeyResolver in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:25
  variant AuthError:JwtMissingIssuer in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:27
  variant AuthError:JwtNoKeyResolver in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:29
  variant AuthError:JwtNoStaticTokenConfigured in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:31
  variant AuthError:JwtJwkFormatNotSupportedForEncoding in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:33
  variant AuthError:JwtFetchJwksFailed in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:35
  variant AuthError:JwtStaticUnsupportedCustomClaims in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:37
  variant AuthError:OidcDiscoveryMissingTokenEndpoint in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:41
  variant AuthError:OidcKeyNotFound in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:43
  variant AuthError:OidcMissingKidWithMultipleKeys in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:45
  variant AuthError:OidcUnsupportedCustomClaims in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:47
  variant AuthError:OAuth2Request in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:49
  variant AuthError:HmacKeyTooShort in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:57
  variant AuthError:HmacKeyMissing in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:59
  variant AuthError:TimeError in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:63
  variant AuthError:UrlParseError in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:67
  variant AuthError:HeaderNameError in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:71
  variant AuthError:HeaderValueError in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:73
  variant AuthError:FileWatcherError in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:77
  variant AuthError:TokenMalformed in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:85
  variant AuthError:TokenInvalidMissingSub in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:87
  variant AuthError:TokenInvalidReplay in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:89
  variant AuthError:JwtTokenInvalid in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:91
  variant AuthError:TokenInvalidMissingExp in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:93
  variant AuthError:JwksParse in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:101
  variant AuthError:JwksNoSuitableKey in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:103
  variant AuthError:JwksCacheMiss in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:105
  variant AuthError:OidcDiscoveryMissingJwksUri in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:107
  variant AuthError:JwksCacheExpired in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:109
  variant AuthError:SpireUnsupportedOnWindows in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:113
  variant AuthError:SpiffeCustomClaimsSerialize in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:116
  variant AuthError:SpiffeError in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:119
  variant AuthError:SpiffeGrpcError in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:122
  variant AuthError:SpiffeWorkloadApiUnavailable in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:125
  variant AuthError:SpiffeX509SourceError in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:128
  variant AuthError:SpiffeJwtSourceNotInitialized in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:131
  variant AuthError:SpiffeJwtSvidMissing in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:134
  variant AuthError:SpiffeJwtBundleMissing in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:137
  variant AuthError:SpiffeInvalidJwtSvid in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:140
  variant AuthError:SpiffeX509SvidMissing in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:143
  variant AuthError:SpiffeX509SourceNotInitialized in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:146
  variant AuthError:SpiffeX509BundleMissing in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:149
  variant AuthError:SpiffeX509SvidFetch in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:152
  variant AuthError:SpiffeX509BundleFetch in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:157
  variant AuthError:SpiffeX509EmptyCertChain in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:162
  variant AuthError:SpiffeCustomAudiencesJwtSourceClosed in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:165
  variant AuthError:SpiffeCustomAudiencesError in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:168
  variant AuthError:Base64DecodeError in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/errors.rs:174

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant AuthError::ConfigError, previously in file /tmp/.tmpHemK75/agntcy-slim-auth/src/errors.rs:9
  variant AuthError::TokenExpired, previously in file /tmp/.tmpHemK75/agntcy-slim-auth/src/errors.rs:12
  variant AuthError::SigningError, previously in file /tmp/.tmpHemK75/agntcy-slim-auth/src/errors.rs:18
  variant AuthError::VerificationError, previously in file /tmp/.tmpHemK75/agntcy-slim-auth/src/errors.rs:24
  variant AuthError::InvalidHeader, previously in file /tmp/.tmpHemK75/agntcy-slim-auth/src/errors.rs:27
  variant AuthError::JwtAwsLcError, previously in file /tmp/.tmpHemK75/agntcy-slim-auth/src/errors.rs:30
  variant AuthError::UnsupportedOperation, previously in file /tmp/.tmpHemK75/agntcy-slim-auth/src/errors.rs:33
  variant AuthError::OAuth2Error, previously in file /tmp/.tmpHemK75/agntcy-slim-auth/src/errors.rs:42
  variant AuthError::TokenRefreshFailed, previously in file /tmp/.tmpHemK75/agntcy-slim-auth/src/errors.rs:51
  variant AuthError::InvalidIssuerEndpoint, previously in file /tmp/.tmpHemK75/agntcy-slim-auth/src/errors.rs:54

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  slim_auth::jwt_middleware::AddJwtLayer::new now takes 1 parameters instead of 2, in /tmp/.tmpyiy6Mo/slim/data-plane/core/auth/src/jwt_middleware.rs:32
```

### ⚠ `agntcy-slim-config` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type ProviderError is no longer UnwindSafe, in /tmp/.tmpyiy6Mo/slim/data-plane/core/config/src/provider.rs:14
  type ProviderError is no longer RefUnwindSafe, in /tmp/.tmpyiy6Mo/slim/data-plane/core/config/src/provider.rs:14
  type ConfigError is no longer UnwindSafe, in /tmp/.tmpyiy6Mo/slim/data-plane/core/config/src/grpc/errors.rs:12
  type ConfigError is no longer RefUnwindSafe, in /tmp/.tmpyiy6Mo/slim/data-plane/core/config/src/grpc/errors.rs:12

--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ClientConfig.backoff in /tmp/.tmpyiy6Mo/slim/data-plane/core/config/src/grpc/client.rs:313

--- failure enum_discriminants_undefined_non_unit_variant: enum's variants no longer have defined discriminants due to non-unit variant ---

Description:
An enum's variants no longer have well-defined discriminant values due to a tuple or struct variant in the enum. This breaks downstream code that accesses discriminants via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_discriminants_undefined_non_unit_variant.ron

Failed in:
  enum ProviderError in /tmp/.tmpyiy6Mo/slim/data-plane/core/config/src/provider.rs:14

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_missing.ron

Failed in:
  enum slim_config::auth::AuthError, previously in file /tmp/.tmpHemK75/agntcy-slim-config/src/auth.rs:14
  enum slim_config::component::configuration::ConfigurationError, previously in file /tmp/.tmpHemK75/agntcy-slim-config/src/component/configuration.rs:7
  enum slim_config::component::ComponentError, previously in file /tmp/.tmpHemK75/agntcy-slim-config/src/component.rs:11
  enum slim_config::tls::common::ConfigError, previously in file /tmp/.tmpHemK75/agntcy-slim-config/src/tls/common.rs:300

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant ProviderError:EnvVarError in /tmp/.tmpyiy6Mo/slim/data-plane/core/config/src/provider.rs:23
  variant ProviderError:FileError in /tmp/.tmpyiy6Mo/slim/data-plane/core/config/src/provider.rs:26
  variant ConfigError:EndpointParse in /tmp/.tmpyiy6Mo/slim/data-plane/core/config/src/grpc/errors.rs:21
  variant ConfigError:UriParse in /tmp/.tmpyiy6Mo/slim/data-plane/core/config/src/grpc/errors.rs:23
  variant ConfigError:TransportError in /tmp/.tmpyiy6Mo/slim/data-plane/core/config/src/grpc/errors.rs:27
  variant ConfigError:Bind in /tmp/.tmpyiy6Mo/slim/data-plane/core/config/src/grpc/errors.rs:29
  variant ConfigError:HeaderNameParse in /tmp/.tmpyiy6Mo/slim/data-plane/core/config/src/grpc/errors.rs:33
  variant ConfigError:HeaderValueParse in /tmp/.tmpyiy6Mo/slim/data-plane/core/config/src/grpc/errors.rs:35
  variant ConfigError:RateLimitParse in /tmp/.tmpyiy6Mo/slim/data-plane/core/config/src/grpc/errors.rs:39
  variant ConfigError:TlsConfig in /tmp/.tmpyiy6Mo/slim/data-plane/core/config/src/grpc/errors.rs:43
  variant ConfigError:AuthError in /tmp/.tmpyiy6Mo/slim/data-plane/core/config/src/grpc/errors.rs:47

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant IdError::Unknown, previously in file /tmp/.tmpHemK75/agntcy-slim-config/src/component/id.rs:17
  variant ConfigError::EndpointParseError, previously in file /tmp/.tmpHemK75/agntcy-slim-config/src/grpc/errors.rs:16
  variant ConfigError::TcpIncomingError, previously in file /tmp/.tmpHemK75/agntcy-slim-config/src/grpc/errors.rs:18
  variant ConfigError::UriParseError, previously in file /tmp/.tmpHemK75/agntcy-slim-config/src/grpc/errors.rs:20
  variant ConfigError::HeaderParseError, previously in file /tmp/.tmpHemK75/agntcy-slim-config/src/grpc/errors.rs:22
  variant ConfigError::RateLimitParseError, previously in file /tmp/.tmpHemK75/agntcy-slim-config/src/grpc/errors.rs:24
  variant ConfigError::TLSSettingError, previously in file /tmp/.tmpHemK75/agntcy-slim-config/src/grpc/errors.rs:26
  variant ConfigError::InvalidUri, previously in file /tmp/.tmpHemK75/agntcy-slim-config/src/grpc/errors.rs:32

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  Config::create_provider, previously in file /tmp/.tmpHemK75/agntcy-slim-config/src/auth/oidc.rs:184
  Config::create_verifier, previously in file /tmp/.tmpHemK75/agntcy-slim-config/src/auth/oidc.rs:196
  SpireConfig::create_jwt_verifier, previously in file /tmp/.tmpHemK75/agntcy-slim-config/src/auth/spire.rs:130
  SpireConfig::get_client_layer_async, previously in file /tmp/.tmpHemK75/agntcy-slim-config/src/auth/spire.rs:162
  SpireConfig::get_server_layer_async, previously in file /tmp/.tmpHemK75/agntcy-slim-config/src/auth/spire.rs:171

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct slim_config::auth::oidc::OidcVerifierLayer, previously in file /tmp/.tmpHemK75/agntcy-slim-config/src/auth/oidc.rs:225
  struct slim_config::auth::oidc::OidcProviderLayer, previously in file /tmp/.tmpHemK75/agntcy-slim-config/src/auth/oidc.rs:211

--- failure trait_associated_type_added: non-sealed public trait added associated type without default value ---

Description:
A non-sealed trait has gained an associated type without a default value, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_associated_type_added.ron

Failed in:
  trait associated type slim_config::component::configuration::Configuration::Error in file /tmp/.tmpyiy6Mo/slim/data-plane/core/config/src/component/configuration.rs:5
  trait associated type slim_config::component::Component::Error in file /tmp/.tmpyiy6Mo/slim/data-plane/core/config/src/component.rs:10
```

### ⚠ `agntcy-slim-tracing` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant ConfigError:OpenTelemetryInitError in /tmp/.tmpyiy6Mo/slim/data-plane/core/tracing/src/lib.rs:36
  variant ConfigError:TracingSetupError in /tmp/.tmpyiy6Mo/slim/data-plane/core/tracing/src/lib.rs:44
```

### ⚠ `agntcy-slim-datapath` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type DataPathError is no longer UnwindSafe, in /tmp/.tmpyiy6Mo/slim/data-plane/core/datapath/src/errors.rs:12
  type DataPathError is no longer RefUnwindSafe, in /tmp/.tmpyiy6Mo/slim/data-plane/core/datapath/src/errors.rs:12

--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type DataPathError no longer derives PartialEq, in /tmp/.tmpyiy6Mo/slim/data-plane/core/datapath/src/errors.rs:12

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_missing.ron

Failed in:
  enum slim_datapath::tables::errors::SubscriptionTableError, previously in file /tmp/.tmpHemK75/agntcy-slim-datapath/src/tables/errors.rs:7

--- failure enum_tuple_variant_changed_kind: An enum tuple variant changed kind ---

Description:
A public enum's exhaustive tuple variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_tuple_variant_changed_kind.ron

Failed in:
  variant DataPathError::ConnectionError in /tmp/.tmpyiy6Mo/slim/data-plane/core/datapath/src/errors.rs:15
  variant DataPathError::UnknownMsgType in /tmp/.tmpyiy6Mo/slim/data-plane/core/datapath/src/errors.rs:23

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant SessionMessageType:Ping in /tmp/.tmpyiy6Mo/slim/data-plane/core/datapath/src/api/gen/dataplane.proto.v1.rs:353
  variant DataPathError:GrpcError in /tmp/.tmpyiy6Mo/slim/data-plane/core/datapath/src/errors.rs:19
  variant DataPathError:NoMatch in /tmp/.tmpyiy6Mo/slim/data-plane/core/datapath/src/errors.rs:29
  variant DataPathError:SubscriptionNotFound in /tmp/.tmpyiy6Mo/slim/data-plane/core/datapath/src/errors.rs:31
  variant DataPathError:IdNotFound in /tmp/.tmpyiy6Mo/slim/data-plane/core/datapath/src/errors.rs:33
  variant DataPathError:ConnectionIdNotFound in /tmp/.tmpyiy6Mo/slim/data-plane/core/datapath/src/errors.rs:39
  variant DataPathError:MalformedMessage in /tmp/.tmpyiy6Mo/slim/data-plane/core/datapath/src/errors.rs:43
  variant DataPathError:ConnectionTableAddError in /tmp/.tmpyiy6Mo/slim/data-plane/core/datapath/src/errors.rs:47
  variant DataPathError:MessageProcessingError in /tmp/.tmpyiy6Mo/slim/data-plane/core/datapath/src/errors.rs:49
  variant DataPathError:ConfigurationError in /tmp/.tmpyiy6Mo/slim/data-plane/core/datapath/src/errors.rs:57
  variant DataPathError:AlreadyClosedError in /tmp/.tmpyiy6Mo/slim/data-plane/core/datapath/src/errors.rs:61
  variant DataPathError:ShuttingDownError in /tmp/.tmpyiy6Mo/slim/data-plane/core/datapath/src/errors.rs:63
  variant DataPathError:ShutdownTimeoutError in /tmp/.tmpyiy6Mo/slim/data-plane/core/datapath/src/errors.rs:65
  variant MessageError:BuilderErrorSourceRequired in /tmp/.tmpyiy6Mo/slim/data-plane/core/datapath/src/messages/utils.rs:89
  variant MessageError:BuilderErrorDestinationRequired in /tmp/.tmpyiy6Mo/slim/data-plane/core/datapath/src/messages/utils.rs:91

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant DataPathError::ErrorSettingInConnection, previously in file /tmp/.tmpHemK75/agntcy-slim-datapath/src/errors.rs:17
  variant DataPathError::SubscriptionError, previously in file /tmp/.tmpHemK75/agntcy-slim-datapath/src/errors.rs:19
  variant DataPathError::UnsubscriptionError, previously in file /tmp/.tmpHemK75/agntcy-slim-datapath/src/errors.rs:21
  variant DataPathError::PublicationError, previously in file /tmp/.tmpHemK75/agntcy-slim-datapath/src/errors.rs:23
  variant DataPathError::CommandError, previously in file /tmp/.tmpHemK75/agntcy-slim-datapath/src/errors.rs:25
  variant DataPathError::WrongChannelType, previously in file /tmp/.tmpHemK75/agntcy-slim-datapath/src/errors.rs:29
  variant DataPathError::MessageSendError, previously in file /tmp/.tmpHemK75/agntcy-slim-datapath/src/errors.rs:31
  variant DataPathError::StreamError, previously in file /tmp/.tmpHemK75/agntcy-slim-datapath/src/errors.rs:33
  variant DataPathError::AlreadyCloseError, previously in file /tmp/.tmpHemK75/agntcy-slim-datapath/src/errors.rs:35
  variant DataPathError::CloseTimeoutError, previously in file /tmp/.tmpHemK75/agntcy-slim-datapath/src/errors.rs:37
  variant MessageError::BuilderError, previously in file /tmp/.tmpHemK75/agntcy-slim-datapath/src/messages/utils.rs:57

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  slim_datapath::message_processing::MessageProcessor::connect now takes 3 parameters instead of 4, in /tmp/.tmpyiy6Mo/slim/data-plane/core/datapath/src/message_processing.rs:274

--- failure method_requires_different_generic_type_params: method now requires a different number of generic type parameters ---

Description:
A method now requires a different number of generic type parameters than it used to. Uses of this method that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_requires_different_generic_type_params.ron

Failed in:
  slim_datapath::message_processing::MessageProcessor::connect takes 0 generic types instead of 1, in /tmp/.tmpyiy6Mo/slim/data-plane/core/datapath/src/message_processing.rs:274

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/module_missing.ron

Failed in:
  mod slim_datapath::tables::errors, previously in file /tmp/.tmpHemK75/agntcy-slim-datapath/src/tables/errors.rs:4

--- failure trait_associated_type_added: non-sealed public trait added associated type without default value ---

Description:
A non-sealed trait has gained an associated type without a default value, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_associated_type_added.ron

Failed in:
  trait associated type slim_datapath::tables::SubscriptionTable::Error in file /tmp/.tmpyiy6Mo/slim/data-plane/core/datapath/src/tables.rs:18
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `agntcy-slim-auth`

<blockquote>

## [0.5.0](https://github.com/agntcy/slim/compare/slim-auth-v0.4.1...slim-auth-v0.5.0) - 2026-01-29

### Added

- Support different trust domains in auto route setup ([#1001](https://github.com/agntcy/slim/pull/1001))

### Fixed

- *(bindings)* improve identity error handling ([#1042](https://github.com/agntcy/slim/pull/1042))

### Other

- unified typed error handling across core crates ([#976](https://github.com/agntcy/slim/pull/976))
</blockquote>

## `agntcy-slim-config`

<blockquote>

## [0.5.0](https://github.com/agntcy/slim/compare/slim-config-v0.4.3...slim-config-v0.5.0) - 2026-01-29

### Added

- Support different trust domains in auto route setup ([#1001](https://github.com/agntcy/slim/pull/1001))
- *(bindings)* expose identity configuration ([#1092](https://github.com/agntcy/slim/pull/1092))
- *(bindings)* expose complete configuration for auth and creating clients, servers ([#1084](https://github.com/agntcy/slim/pull/1084))
- make backoff retry configurable ([#991](https://github.com/agntcy/slim/pull/991))

### Other

- unified typed error handling across core crates ([#976](https://github.com/agntcy/slim/pull/976))
</blockquote>

## `agntcy-slim-tracing`

<blockquote>

## [0.3.0](https://github.com/agntcy/slim/compare/slim-tracing-v0.2.7...slim-tracing-v0.3.0) - 2026-01-29

### Added

- *(bindings)* configuration file support ([#1099](https://github.com/agntcy/slim/pull/1099))

### Other

- unified typed error handling across core crates ([#976](https://github.com/agntcy/slim/pull/976))
</blockquote>

## `agntcy-slim-datapath`

<blockquote>

## [0.11.0](https://github.com/agntcy/slim/compare/slim-datapath-v0.10.3...slim-datapath-v0.11.0) - 2026-01-29

### Added

- add reference count to subscription table ([#1143](https://github.com/agntcy/slim/pull/1143))
- generate python bindings with uniffi ([#1046](https://github.com/agntcy/slim/pull/1046))
- *(bindings)* configuration file support ([#1099](https://github.com/agntcy/slim/pull/1099))
- *(bindings)* expose participant list to the application ([#1089](https://github.com/agntcy/slim/pull/1089))
- *(session)* handle moderator unexpected stop ([#1024](https://github.com/agntcy/slim/pull/1024))
- make backoff retry configurable ([#991](https://github.com/agntcy/slim/pull/991))
- Update group state on unexpected application stop ([#1014](https://github.com/agntcy/slim/pull/1014))
- detect and handle unexpected participant disconnections ([#1004](https://github.com/agntcy/slim/pull/1004))

### Fixed

- match all function send only to local applications ([#1132](https://github.com/agntcy/slim/pull/1132))
- *(session)* route dataplane errors to correct session ([#1056](https://github.com/agntcy/slim/pull/1056))
- *(session)* correctly remove routes on session close ([#1039](https://github.com/agntcy/slim/pull/1039))

### Other

- *(bindings)* do not expose tokio-specific APIs to foreign async calls ([#1110](https://github.com/agntcy/slim/pull/1110))
- *(lint)* use latest version of tools ([#1067](https://github.com/agntcy/slim/pull/1067))
- unified typed error handling across core crates ([#976](https://github.com/agntcy/slim/pull/976))
</blockquote>

## `agntcy-slim-mls`

<blockquote>

## [0.1.6](https://github.com/agntcy/slim/compare/slim-mls-v0.1.5...slim-mls-v0.1.6) - 2026-01-29

### Fixed

- *(bindings)* improve identity error handling ([#1042](https://github.com/agntcy/slim/pull/1042))

### Other

- unified typed error handling across core crates ([#976](https://github.com/agntcy/slim/pull/976))
</blockquote>

## `agntcy-slim-session`

<blockquote>

## [0.1.3](https://github.com/agntcy/slim/compare/slim-session-v0.1.2...slim-session-v0.1.3) - 2026-01-29

### Added

- add reference count to subscription table ([#1143](https://github.com/agntcy/slim/pull/1143))
- *(session)* Add direction to slim app to control message flow ([#1121](https://github.com/agntcy/slim/pull/1121))
- generate python bindings with uniffi ([#1046](https://github.com/agntcy/slim/pull/1046))
- *(bindings)* expose participant list to the application ([#1089](https://github.com/agntcy/slim/pull/1089))
- send group acknowledge from the session ([#1050](https://github.com/agntcy/slim/pull/1050))
- *(bindings)* expose complete configuration for auth and creating clients, servers ([#1084](https://github.com/agntcy/slim/pull/1084))
- *(session)* handle moderator unexpected stop ([#1024](https://github.com/agntcy/slim/pull/1024))
- Update group state on unexpected application stop ([#1014](https://github.com/agntcy/slim/pull/1014))
- detect and handle unexpected participant disconnections ([#1004](https://github.com/agntcy/slim/pull/1004))

### Fixed

- add missing routes to participants ([#1131](https://github.com/agntcy/slim/pull/1131))
- check if a participant is already in the group before invite ([#1085](https://github.com/agntcy/slim/pull/1085))
- *(session)* send ping messages to the right destination ([#1066](https://github.com/agntcy/slim/pull/1066))
- *(session)* route dataplane errors to correct session ([#1056](https://github.com/agntcy/slim/pull/1056))
- *(session)* remove participants from the group list ([#1059](https://github.com/agntcy/slim/pull/1059))
- *(bindings)* improve identity error handling ([#1042](https://github.com/agntcy/slim/pull/1042))
- *(session)* correctly remove routes on session close ([#1039](https://github.com/agntcy/slim/pull/1039))
- *(moderator_task.rs)* typo ([#1008](https://github.com/agntcy/slim/pull/1008))

### Other

- unified typed error handling across core crates ([#976](https://github.com/agntcy/slim/pull/976))
</blockquote>

## `agntcy-slim-signal`

<blockquote>

## [0.1.4](https://github.com/agntcy/slim/compare/slim-signal-v0.1.3...slim-signal-v0.1.4) - 2026-01-29

### Other

- unified typed error handling across core crates ([#976](https://github.com/agntcy/slim/pull/976))
</blockquote>

## `agntcy-slim-controller`

<blockquote>

## [0.4.4](https://github.com/agntcy/slim/compare/slim-controller-v0.4.3...slim-controller-v0.4.4) - 2026-01-29

### Added

- Support different trust domains in auto route setup ([#1001](https://github.com/agntcy/slim/pull/1001))
- *(bindings)* expose identity configuration ([#1092](https://github.com/agntcy/slim/pull/1092))
- send group acknowledge from the session ([#1050](https://github.com/agntcy/slim/pull/1050))
- make backoff retry configurable ([#991](https://github.com/agntcy/slim/pull/991))

### Fixed

- *(controller)* start the controller service only if the related config is provided ([#1054](https://github.com/agntcy/slim/pull/1054))
- *(bindings)* improve identity error handling ([#1042](https://github.com/agntcy/slim/pull/1042))

### Other

- *(bindings)* do not expose tokio-specific APIs to foreign async calls ([#1110](https://github.com/agntcy/slim/pull/1110))
- *(lint)* use latest version of tools ([#1067](https://github.com/agntcy/slim/pull/1067))
- unified typed error handling across core crates ([#976](https://github.com/agntcy/slim/pull/976))
</blockquote>

## `agntcy-slim-service`

<blockquote>

## [0.8.3](https://github.com/agntcy/slim/compare/slim-service-v0.8.2...slim-service-v0.8.3) - 2026-01-29

### Added

- *(session)* Add direction to slim app to control message flow ([#1121](https://github.com/agntcy/slim/pull/1121))
- generate python bindings with uniffi ([#1046](https://github.com/agntcy/slim/pull/1046))
- *(bindings)* configuration file support ([#1099](https://github.com/agntcy/slim/pull/1099))
- *(bindings)* expose participant list to the application ([#1089](https://github.com/agntcy/slim/pull/1089))
- Go bindings generation using uniffi ([#979](https://github.com/agntcy/slim/pull/979))
- make backoff retry configurable ([#991](https://github.com/agntcy/slim/pull/991))

### Fixed

- *(session)* route dataplane errors to correct session ([#1056](https://github.com/agntcy/slim/pull/1056))
- *(controller)* start the controller service only if the related config is provided ([#1054](https://github.com/agntcy/slim/pull/1054))
- *(bindings)* improve identity error handling ([#1042](https://github.com/agntcy/slim/pull/1042))

### Other

- *(bindings)* do not expose tokio-specific APIs to foreign async calls ([#1110](https://github.com/agntcy/slim/pull/1110))
- *(bindings)* allow multiple global services ([#1106](https://github.com/agntcy/slim/pull/1106))
- feature flag for session layer ([#1102](https://github.com/agntcy/slim/pull/1102))
- unified typed error handling across core crates ([#976](https://github.com/agntcy/slim/pull/976))
</blockquote>

## `agntcy-slim`

<blockquote>

## [0.7.2](https://github.com/agntcy/slim/compare/slim-v0.7.1...slim-v0.7.2) - 2026-01-29

### Added

- *(bindings)* configuration file support ([#1099](https://github.com/agntcy/slim/pull/1099))

### Fixed

- revert release SLIM 1.0.0-rc.0 ([#1153](https://github.com/agntcy/slim/pull/1153))

### Other

- release SLIM 1.0.0-rc.0 ([#1151](https://github.com/agntcy/slim/pull/1151))
- *(bindings)* do not expose tokio-specific APIs to foreign async calls ([#1110](https://github.com/agntcy/slim/pull/1110))
- *(bindings)* allow multiple global services ([#1106](https://github.com/agntcy/slim/pull/1106))
- unified typed error handling across core crates ([#976](https://github.com/agntcy/slim/pull/976))
</blockquote>

## `agntcy-slim-bindings`

<blockquote>

## [1.0.0-rc.0](https://github.com/agntcy/slim/releases/tag/slim-bindings-v1.0.0-rc.0) - 2026-01-29

### Added

- *(bindings)* set release candidate 1.0.0-rc.0 ([#1135](https://github.com/agntcy/slim/pull/1135))
- *(bindings)* move to new python bindings ([#1116](https://github.com/agntcy/slim/pull/1116))
- *(session)* Add direction to slim app to control message flow ([#1121](https://github.com/agntcy/slim/pull/1121))
- generate python bindings with uniffi ([#1046](https://github.com/agntcy/slim/pull/1046))

### Other

- *(Taskfile)* move zig installation to global tools ([#1120](https://github.com/agntcy/slim/pull/1120))
- *(bindings)* do not expose tokio-specific APIs to foreign async calls ([#1110](https://github.com/agntcy/slim/pull/1110))
- *(bindings)* allow multiple global services ([#1106](https://github.com/agntcy/slim/pull/1106))
- *(bindings)* rename BindingsAdapter into App and BindingsSessionContext into Session ([#1104](https://github.com/agntcy/slim/pull/1104))
</blockquote>

## `agntcy-protoc-slimrpc-plugin`

<blockquote>

## [0.1.2](https://github.com/agntcy/slim/compare/protoc-slimrpc-plugin-v0.1.1...protoc-slimrpc-plugin-v0.1.2) - 2026-01-29

### Added

- *(slimrpc,slima2a,slim-mcp)* Upgrade to v0.7.1 slim_bindings ([#839](https://github.com/agntcy/slim/pull/839))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).