### PR TITLE
fix: p2p integration test

### DIFF
--- a/data-plane/testing/src/bin/test_p2p.rs
+++ b/data-plane/testing/src/bin/test_p2p.rs
@@ -168,7 +168,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // start clients
-    let tot_clients = apps;
+    let mut tot_clients = apps;
+    if !multiple_remotes {
+        // if create a single replica of each client
+        tot_clients = 1;
+    }
     let mut clients = vec![];
     let client_1_name = Name::from_strings(["org", "ns", "client-1"]);
     let client_2_name = Name::from_strings(["org", "ns", "client-2"]);
@@ -217,9 +221,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .expect("an error occurred while adding a route");
     }
 
+    // wait for the creation of all the clients
+    tokio::time::sleep(tokio::time::Duration::from_millis(2000)).await;
+
     let mut sessions = vec![];
     if multiple_remotes {
-        // connect to two different clients using the disocvery process
+        // connect to two different clients using the discovery process
         // in the session layer
         for name in clients.iter().take(2) {
             let (session_ctx, completion_handle) = app
@@ -235,7 +242,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // connect to the same client using multiple sessions
         for _ in 0..2 {
             let (session_ctx, completion_handle) = app
-                .create_session(conf.clone(), client_1_name.clone().with_id(0), None)
+                .create_session(conf.clone(), client_1_name.clone(), None)
                 .await
                 .expect("error creating session");
 


### PR DESCRIPTION
# Description

This PR fixes an issue with parallel p2p session tests. Now, if the test is configured to connect to multiple remote applications, it runs multiple clients for each name to test the discovery process. Otherwise, only one client is spawned so that the name of the remote endpoint is known upfront.

Fix #1048 

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
