### PR TITLE
refactor(bindings): move error logic to errors module

### DIFF
--- a/data-plane/bindings/adapter/src/adapter.rs
+++ b/data-plane/bindings/adapter/src/adapter.rs
@@ -17,10 +17,14 @@ use std::sync::Arc;
 use tokio::sync::{RwLock, mpsc};
 use uniffi;
 
-use slim_auth::traits::Verifier;
+use crate::errors::SlimError;
+use crate::name::Name;
+use crate::runtime;
+use crate::service_ref::{ServiceRef, get_or_init_global_service};
 use slim_auth::auth_provider::{AuthProvider, AuthVerifier};
 use slim_auth::shared_secret::SharedSecret;
 use slim_auth::traits::TokenProvider; // For get_token() and get_id()
+use slim_auth::traits::Verifier;
 use slim_config::component::ComponentBuilder;
 use slim_datapath::api::ProtoSessionType;
 use slim_datapath::messages::Name as SlimName;
@@ -29,10 +33,6 @@ use slim_service::app::App;
 use slim_session::SessionConfig as SlimSessionConfig;
 use slim_session::session_controller::SessionController;
 use slim_session::{Notification, SessionError as SlimSessionError};
-use crate::name::Name;
-use crate::runtime;
-use crate::service_ref::{ServiceRef, get_or_init_global_service};
-use crate::errors::SlimError;
 
 // ============================================================================
 // UniFFI Type Definitions

--- a/data-plane/bindings/adapter/src/errors.rs
+++ b/data-plane/bindings/adapter/src/errors.rs
@@ -3,9 +3,9 @@
 
 use display_error_chain::ErrorChainExt;
 
+use slim_auth::errors::AuthError;
 use slim_service::errors::ServiceError;
 use slim_session::errors::SessionError;
-use slim_auth::errors::AuthError;
 
 /// Error types for SLIM operations
 #[derive(Debug, thiserror::Error, uniffi::Error)]

--- a/data-plane/bindings/adapter/src/lib.rs
+++ b/data-plane/bindings/adapter/src/lib.rs
@@ -42,21 +42,20 @@
 // Module declarations
 pub mod adapter;
 pub mod common;
+pub mod errors;
 mod message_context;
 pub mod name;
 pub mod runtime;
-pub mod errors;
 mod service_ref;
 pub mod session_context;
 
 // Public re-exports
 pub use adapter::{
     BindingsAdapter, BuildInfo, ClientConfig, FfiCompletionHandle, ReceivedMessage, ServerConfig,
-    SessionConfig, SessionType, TlsConfig, create_app_with_secret, get_build_info,
-    get_version,
+    SessionConfig, SessionType, TlsConfig, create_app_with_secret, get_build_info, get_version,
 };
-pub use errors::SlimError;
 pub use common::initialize_crypto_provider;
+pub use errors::SlimError;
 pub use message_context::MessageContext;
 pub use name::Name;
 pub use runtime::get_runtime;

--- a/data-plane/bindings/adapter/src/session_context.rs
+++ b/data-plane/bindings/adapter/src/session_context.rs
@@ -13,9 +13,9 @@ use slim_datapath::messages::utils::{PUBLISH_TO, SlimHeaderFlags, TRUE_VAL};
 use slim_session::SessionError;
 use slim_session::context::SessionContext;
 
-use crate::{Name, SlimError};
 use crate::adapter::{FfiCompletionHandle, ReceivedMessage, SessionType};
 use crate::message_context::MessageContext;
+use crate::{Name, SlimError};
 
 /// Session context for language bindings (UniFFI-compatible)
 ///


### PR DESCRIPTION
# Description

This PR continues the modularization effort by extracting
error definitions and related tests from the `adapter` module
into a dedicated `errors` module, improving code organization
in the SLIM bindings adapter.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
