### PR TITLE
fix: temporarily disable slim-bindings crate publish

### DIFF
--- a/data-plane/.release-plz.toml
+++ b/data-plane/.release-plz.toml
@@ -78,10 +78,3 @@ name = "agntcy-protoc-slimrpc-plugin"
 publish = true
 release = true
 changelog_update = true
-
-[[package]]
-name = "agntcy-slim-bindings"
-publish = true
-release = true
-changelog_update = true
-git_tag_name = "slim-bindings-libs-v{{ version }}"


### PR DESCRIPTION
# Description

Temporarily disable slim-bindings crate until bindings
are ready to be published.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
