### PR TITLE
fix: use valid-length shared_secret in Python examples and tests

### DIFF
--- a/data-plane/python/integrations/slim-mcp/tests/conftest.py
+++ b/data-plane/python/integrations/slim-mcp/tests/conftest.py
@@ -17,10 +17,10 @@ async def server(request):
 
     name = slim_bindings.Name("agntcy", "default", "server")
     provider = slim_bindings.IdentityProvider.SharedSecret(
-        identity="server", shared_secret="secret"
+        identity="server", shared_secret="demo-shared-secret-min-32-chars!!"
     )
     verifier = slim_bindings.IdentityVerifier.SharedSecret(
-        identity="server", shared_secret="secret"
+        identity="server", shared_secret="demo-shared-secret-min-32-chars!!"
     )
 
     svc_server = await slim_bindings.create_pyservice(name, provider, verifier)

--- a/data-plane/python/integrations/slima2a/examples/travel_planner_agent/client.py
+++ b/data-plane/python/integrations/slima2a/examples/travel_planner_agent/client.py
@@ -88,7 +88,7 @@ async def main() -> None:
                     "insecure": True,
                 },
             },
-            shared_secret="secret",
+            shared_secret="demo-shared-secret-min-32-chars!!",
         )
     )
 

--- a/data-plane/python/integrations/slima2a/examples/travel_planner_agent/server.py
+++ b/data-plane/python/integrations/slima2a/examples/travel_planner_agent/server.py
@@ -55,7 +55,7 @@ async def main() -> None:
                     "insecure": True,
                 },
             },
-            shared_secret="secret",
+            shared_secret="demo-shared-secret-min-32-chars!!",
         )
     )
     add_A2AServiceServicer_to_server(


### PR DESCRIPTION
The shared_secret="secret" was only 6 characters, violating the 32-character minimum required by SharedSecret validation. This would cause runtime failures with AuthError::HmacKeyTooShort.

# Description

Please provide a meaningful description of what this change will do, or is for.
Bonus points for including links to related issues, other PRs, or technical
references.

Note that by _not_ including a description, you are asking reviewers to do extra
work to understand the context of this change, which may lead to your PR taking
much longer to review, or result in it not being reviewed at all.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
