### PR TITLE
feat: release slimctl built with cgo

### DIFF
--- a/.github/workflows/release-slimctl.yaml
+++ b/.github/workflows/release-slimctl.yaml
@@ -14,9 +14,44 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  build-and-release:
+  prepare:
     runs-on: ubuntu-latest
+    
+    permissions:
+      contents: write
+    
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
+      - name: Create GitHub Release
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          gh release create "$TAG" --title "$TAG" --notes "Release $TAG" || echo "Release already exists"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-binaries:
+    uses: ./.github/workflows/reusable-go-build-and-test.yaml
+    with:
+      # Skip lint, test, and coverage - only build binaries
+      go-lint: false
+      go-vuln: false
+      go-test: false
+      go-test-coverage: false
+      # Enable cross-build with CGO for slimctl
+      go-cross-build: true
+      cgo-enabled: '1'
+      # Enable artifact upload for release
+      upload-artifacts: true
+
+  goreleaser-publish:
+    runs-on: ubuntu-latest
+    
+    needs: [prepare, build-binaries]
+    
     permissions:
       contents: write
       pull-requests: write
@@ -28,50 +63,126 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
-
-      - name: Generate Go protobuf and gRPC code
-        run: task control-plane:proto:generate
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
         with:
-          # either 'goreleaser' (default) or 'goreleaser-pro'
-          distribution: goreleaser
-          # 'latest', 'nightly', or a semver
-          version: "~> v2"
+          fetch-depth: 0
 
-          # the --snapshot flag is required to release on custom tag patterns (not plain semver)
-          # as a result artifacts won't be uploaded to GitHub Releases automatically
-          args: release --clean  --snapshot --verbose
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts/
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          # Extract version from tag (e.g., slimctl-v1.0.0 -> 1.0.0)
+          VERSION=${TAG#slimctl-v}
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION"
+
+      - name: Create archives and checksums
+        run: |
+          mkdir -p .dist/archives
+          VERSION="${{ steps.version.outputs.version }}"
+          
+          # Get absolute path to archives directory
+          ARCHIVES_DIR="$(pwd)/.dist/archives"
+          
+          # Process each platform's binary
+          for artifact_dir in artifacts/slimctl-*; do
+            if [ -d "$artifact_dir" ]; then
+              dir_name=$(basename "$artifact_dir")
+              os=$(echo "$dir_name" | cut -d'-' -f2)
+              arch=$(echo "$dir_name" | cut -d'-' -f3)
+              
+              archive_name="slimctl_${VERSION}_${os}_${arch}"
+              
+              # Create archives based on platform
+              if [ "$os" = "windows" ]; then
+                # Create zip for Windows
+                if [ -f "$artifact_dir/slimctl.exe" ]; then
+                  (cd "$artifact_dir" && zip "${ARCHIVES_DIR}/${archive_name}.zip" slimctl.exe)
+                  echo "✓ Created ${archive_name}.zip"
+                fi
+              else
+                # Create tar.gz for Unix systems (darwin, linux)
+                if [ -f "$artifact_dir/slimctl" ]; then
+                  tar -czf "${ARCHIVES_DIR}/${archive_name}.tar.gz" -C "$artifact_dir" slimctl
+                  echo "✓ Created ${archive_name}.tar.gz"
+                fi
+              fi
+            fi
+          done
+          
+          # Generate checksums
+          cd .dist/archives
+          shasum -a 256 * > slimctl_checksums.txt
+          echo ""
+          echo "✓ Generated checksums:"
+          cat slimctl_checksums.txt
+          
+          echo ""
+          echo "Archives created:"
+          ls -lh
+
+      - name: Create Homebrew cask
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="${{ steps.version.outputs.tag }}"
+          
+          # Calculate SHA256 for darwin amd64
+          AMD64_SHA=$(shasum -a 256 .dist/archives/slimctl_${VERSION}_darwin_amd64.tar.gz | cut -d' ' -f1)
+          ARM64_SHA=$(shasum -a 256 .dist/archives/slimctl_${VERSION}_darwin_arm64.tar.gz | cut -d' ' -f1)
+          
+          mkdir -p ./Casks
+          
+          cat > ./Casks/slimctl.rb << EOF
+          cask "slimctl" do
+            version "${VERSION}"
+            
+            if Hardware::CPU.intel?
+              sha256 "${AMD64_SHA}"
+              url "https://github.com/agntcy/slim/releases/download/${TAG}/slimctl_${VERSION}_darwin_amd64.tar.gz"
+            else
+              sha256 "${ARM64_SHA}"
+              url "https://github.com/agntcy/slim/releases/download/${TAG}/slimctl_${VERSION}_darwin_arm64.tar.gz"
+            end
+            
+            name "slimctl"
+            desc "A CLI tool for managing SLIM Devices"
+            homepage "https://github.com/agntcy/slim"
+            
+            binary "slimctl"
+            
+            postflight do
+              system "chmod", "+x", "#{staged_path}/slimctl"
+              system "/usr/bin/xattr", "-dr", "com.apple.quarantine", "#{staged_path}/slimctl" if MacOS.version >= :catalina
+            end
+          end
+          EOF
+          
+          echo "✓ Created Homebrew cask"
+          cat ./Casks/slimctl.rb
+
+      - name: Upload archives to release
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          echo "Uploading archives to release $TAG"
+          
+          # Upload all archives and checksums
+          gh release upload "$TAG" .dist/archives/* --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Authenticate
-        run: gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
-
-      - name: Upload to existing release
-        run: |
-          TAG=${GITHUB_REF#refs/tags/}
-          echo "Uploading artifacts to release $TAG"
-          gh release upload "$TAG" $(find .dist/slimctl -type f -name '*.tar.gz') --clobber
-
-      - name: Copy cask to tap
-        run: |
-          # ensure the Casks directory  exists        
-          mkdir -p ./Casks
-          cp .dist/slimctl/homebrew/Casks/slimctl.rb ./Casks/slimctl.rb
-
-      - name: Create Pull Request
+      - name: Create Pull Request for Homebrew cask
         uses: peter-evans/create-pull-request@v7
         with:
-          commit-message: Update cask for slimctl
+          commit-message: Update Homebrew cask for slimctl
           title: Update slimctl cask to latest version
-          body: Update cask to reflect release changes
-          branch: update-cask
+          body: |
+            Update Homebrew cask to reflect release changes
+            
+            Release: ${{ github.ref_name }}
+          branch: update-slimctl-cask
           base: main
-      
-
-

--- a/.github/workflows/reusable-go-build-and-test.yaml
+++ b/.github/workflows/reusable-go-build-and-test.yaml
@@ -71,6 +71,11 @@ on:
         required: false
         type: boolean
         default: false
+      upload-artifacts:
+        description: Whether to upload build artifacts (for releases)
+        required: false
+        type: boolean
+        default: false
       working-directory:
         description: The working directory to run the task
         required: false
@@ -299,3 +304,12 @@ jobs:
           go env
 
           task control-plane:build
+
+      - name: Upload slimctl artifact
+        if: ${{ inputs.upload-artifacts }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: slimctl-${{ matrix.os }}-${{ matrix.arch }}
+          path: .dist/bin/slimctl${{ matrix.os == 'windows' && '.exe' || '' }}
+          if-no-files-found: error
+          retention-days: 1

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,39 +2,18 @@ version: 2
 
 dist: .dist/slimctl
 
+# Skip builds - binaries are pre-built by the reusable workflow
+# We'll create archives manually in the GitHub Actions workflow
 builds:
-  - main: cmd/main.go
-    id: slimctl
-    binary: slimctl
-    dir: control-plane/slimctl
-    goos:
-      - darwin
-      - linux
-      - windows
-    goarch:
-      - amd64
-      - arm64
-      - 386
+  - skip: true
 
-    ldflags:
-      - -X github.com/agntcy/slim/control-plane/slimctl/internal/cmd/version.semVersion={{.Version}}
-      - -X github.com/agntcy/slim/control-plane/slimctl/internal/cmd/version.gitCommit={{.Commit}}
-      - -X github.com/agntcy/slim/control-plane/slimctl/internal/cmd/version.buildDate={{.Date}}
-
-    hooks:
-      pre:
-        - cmd: go mod tidy
-          dir: control-plane/slimctl
-          output: true
-        - cmd: task control-plane:gogen
-          dir: control-plane
-          output: true
-
+# Disable archives since we're creating them manually
 archives:
-  - name_template: "slimctl_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  - format: binary
 
+# Disable checksums since we're creating them manually  
 checksum:
-  name_template: "slimctl_checksums.txt"
+  disable: true
 
 changelog:
   disable: true


### PR DESCRIPTION
## Release Workflow: Native Builds with Pre-built Binaries

### Objective
Build binaries on native runners instead of cross-compilation with Docker/goreleaser-cross.

### Architecture
- **Build Phase**: Parallel builds on platform-specific runners via reusable workflow
  - `darwin/amd64` → `macos-15-intel`
  - `darwin/arm64` → `macos-15`
  - `linux/amd64` → `ubuntu-latest`
  - `linux/arm64` → `ubuntu-24.04-arm` (native ARM)
  - `windows/amd64` → `ubuntu-latest` (Zig cross-compile)

- **Package Phase**: Sequential packaging and release
  - Download artifacts from build jobs
  - Create archives (`.tar.gz` for Unix, `.zip` for Windows)
  - Generate SHA256 checksums
  - Generate Homebrew cask
  - Upload to GitHub release + create Homebrew PR

### Key Changes
- Added `upload-artifacts` parameter to reusable workflow
- Manual archive creation via shell scripts (no GoReleaser dependency)
- Simplified `.goreleaser.yaml` to `builds: [skip: true]`

### Benefits
- Native compilation (faster, simpler)
- Parallel builds across platforms
- No Docker/goreleaser-cross overhead
- No GoReleaser Pro features required
- Standard GitHub Actions runners only