### PR TITLE
ci: drop slim-bindings-libs- tag and move to slim-bindings-

### DIFF
--- a/.github/workflows/release-bindings.yaml
+++ b/.github/workflows/release-bindings.yaml
@@ -7,7 +7,7 @@ name: Release Bindings
 on:
   push:
     tags:
-      - 'slim-bindings-libs-*'
+      - 'slim-bindings-*'
 
 env:
   LIBRARY_NAME: slim_bindings

--- a/.github/workflows/reusable-go-bindings-release.yaml
+++ b/.github/workflows/reusable-go-bindings-release.yaml
@@ -109,9 +109,9 @@ jobs:
         run: |
           pushd ./target-repo
 
-          # Extract version from tag name (remove 'slim-bindings-libs-' prefix)
+          # Extract version from tag name (remove 'slim-bindings-' prefix)
           VERSION="${{ github.ref_name }}"
-          VERSION="${VERSION#slim-bindings-libs-}"
+          VERSION="${VERSION#slim-bindings-}"
           echo "📦 Extracted version: $VERSION"
 
           # Create pre-release branch name
@@ -162,7 +162,7 @@ jobs:
     name: Test Go Bindings (${{ matrix.platform.target }})
     runs-on: ${{ matrix.platform.runner }}
     needs: release-go-bindings
-    if: startsWith(github.ref, 'refs/tags/slim-bindings-libs-')
+    if: startsWith(github.ref, 'refs/tags/slim-bindings-')
     strategy:
       fail-fast: false
       matrix:
@@ -225,7 +225,7 @@ jobs:
         run: |
           # Extract version from tag name
           VERSION="${{ github.ref_name }}"
-          VERSION="${VERSION#slim-bindings-libs-}"
+          VERSION="${VERSION#slim-bindings-}"
           echo "📦 Testing version: $VERSION"
           echo "🖥️  Platform: ${{ matrix.platform.target }}"
           echo "🔧 Using QEMU ARM64 emulation"
@@ -290,7 +290,7 @@ jobs:
         run: |
           # Extract version from tag name
           VERSION="${{ github.ref_name }}"
-          VERSION="${VERSION#slim-bindings-libs-}"
+          VERSION="${VERSION#slim-bindings-}"
           echo "📦 Testing version: $VERSION"
 
           # Create a temporary test directory
@@ -346,7 +346,7 @@ jobs:
     name: Finalize Release
     runs-on: ubuntu-latest
     needs: test-go-bindings
-    if: startsWith(github.ref, 'refs/tags/slim-bindings-libs-')
+    if: startsWith(github.ref, 'refs/tags/slim-bindings-')
     steps:
       - name: Clone target repository
         run: |
@@ -362,7 +362,7 @@ jobs:
 
           # Extract version from tag name
           VERSION="${{ github.ref_name }}"
-          VERSION="${VERSION#slim-bindings-libs-}"
+          VERSION="${VERSION#slim-bindings-}"
           PRE_RELEASE_BRANCH="pre-release-$VERSION"
 
           echo "📦 Version: $VERSION"
@@ -393,7 +393,7 @@ jobs:
 
           # Extract version from tag name
           VERSION="${{ github.ref_name }}"
-          VERSION="${VERSION#slim-bindings-libs-}"
+          VERSION="${VERSION#slim-bindings-}"
           PRE_RELEASE_BRANCH="pre-release-$VERSION"
 
           echo "🧹 Cleaning up pre-release artifacts..."
@@ -421,7 +421,7 @@ jobs:
       - name: Release complete
         run: |
           VERSION="${{ github.ref_name }}"
-          VERSION="${VERSION#slim-bindings-libs-}"
+          VERSION="${VERSION#slim-bindings-}"
           echo ""
           echo "🎉 Release $VERSION complete!"
           echo "✅ Go bindings published to https://github.com/${{ env.GO_BINDINGS_REPO }}"

--- a/data-plane/bindings/go/release-files/cmd/slim-bindings-setup/main.go
+++ b/data-plane/bindings/go/release-files/cmd/slim-bindings-setup/main.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	// GitHub release URL pattern - downloads from agntcy/slim releases
-	releaseURLTemplate = "https://github.com/agntcy/slim/releases/download/slim-bindings-libs-%s/slim-bindings-%s.zip"
+	releaseURLTemplate = "https://github.com/agntcy/slim/releases/download/slim-bindings-%s/slim-bindings-%s.zip"
 	// Cache directory name
 	cacheDirName = "slim-bindings"
 )


### PR DESCRIPTION
# Description

Use the slim-bindings-* tag in place of slim-bindings-libs-*
for the language bindings.

slim-bindings-libs has been introduced temporarily when old bindings
and new bindings were coexisting.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] CI

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
