### PR TITLE
chore: release

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agntcy-protoc-slimrpc-plugin"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-service",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-testing",
@@ -151,7 +151,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -184,7 +184,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-tracing",
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -261,7 +261,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "agntcy-slim-config",
  "once_cell",

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -34,18 +34,18 @@ resolver = "2"
 
 [workspace.dependencies]
 # Local dependencies
-agntcy-slim = { path = "core/slim", version = "1.0.0" }
+agntcy-slim = { path = "core/slim", version = "1.0.1" }
 agntcy-slim-auth = { path = "core/auth", version = "0.5.0" }
 agntcy-slim-bindings = { path = "bindings/rust", version = "1.0.0" }
-agntcy-slim-config = { path = "core/config", version = "0.6.0" }
-agntcy-slim-controller = { path = "core/controller", version = "0.4.5" }
-agntcy-slim-datapath = { path = "core/datapath", version = "0.11.1" }
-agntcy-slim-mls = { path = "core/mls", version = "0.1.7" }
-agntcy-slim-service = { path = "core/service", version = "0.8.4", default-features = false }
-agntcy-slim-session = { path = "core/session", version = "0.1.4" }
+agntcy-slim-config = { path = "core/config", version = "0.6.1" }
+agntcy-slim-controller = { path = "core/controller", version = "0.4.6" }
+agntcy-slim-datapath = { path = "core/datapath", version = "0.11.2" }
+agntcy-slim-mls = { path = "core/mls", version = "0.1.8" }
+agntcy-slim-service = { path = "core/service", version = "0.8.5", default-features = false }
+agntcy-slim-session = { path = "core/session", version = "0.1.5" }
 agntcy-slim-signal = { path = "core/signal", version = "0.1.4" }
 agntcy-slim-testing = { path = "testing" }
-agntcy-slim-tracing = { path = "core/tracing", version = "0.3.1" }
+agntcy-slim-tracing = { path = "core/tracing", version = "0.3.2" }
 
 anyhow = "1.0.98"
 

--- a/data-plane/bindings/rust/CHANGELOG.md
+++ b/data-plane/bindings/rust/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0](https://github.com/agntcy/slim/releases/tag/slim-bindings-v1.0.0) - 2026-02-06
+
+### Added
+
+- *(bindings)* set release candidate 1.0.0-rc.0 ([#1135](https://github.com/agntcy/slim/pull/1135))
+- *(bindings)* move to new python bindings ([#1116](https://github.com/agntcy/slim/pull/1116))
+- *(session)* Add direction to slim app to control message flow ([#1121](https://github.com/agntcy/slim/pull/1121))
+- generate python bindings with uniffi ([#1046](https://github.com/agntcy/slim/pull/1046))
+
+### Fixed
+
+- *(bindings)* automatically convert internal errors to exposed errors ([#1154](https://github.com/agntcy/slim/pull/1154))
+
+### Other
+
+- release ([#1156](https://github.com/agntcy/slim/pull/1156))
+- release ([#1011](https://github.com/agntcy/slim/pull/1011))
+- *(Taskfile)* move zig installation to global tools ([#1120](https://github.com/agntcy/slim/pull/1120))
+- *(bindings)* do not expose tokio-specific APIs to foreign async calls ([#1110](https://github.com/agntcy/slim/pull/1110))
+- *(bindings)* allow multiple global services ([#1106](https://github.com/agntcy/slim/pull/1106))
+- *(bindings)* rename BindingsAdapter into App and BindingsSessionContext into Session ([#1104](https://github.com/agntcy/slim/pull/1104))
+
 ## [1.0.0-rc.0](https://github.com/agntcy/slim/releases/tag/slim-bindings-v1.0.0-rc.0) - 2026-01-29
 
 ### Added

--- a/data-plane/core/config/CHANGELOG.md
+++ b/data-plane/core/config/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/agntcy/slim/compare/slim-config-v0.6.0...slim-config-v0.6.1) - 2026-02-06
+
+### Other
+
+- *(data-plane)* upgrade to rust 1.93 ([#1190](https://github.com/agntcy/slim/pull/1190))
+
 ## [0.6.0](https://github.com/agntcy/slim/compare/slim-config-v0.5.0...slim-config-v0.6.0) - 2026-01-30
 
 ### Added

--- a/data-plane/core/config/Cargo.toml
+++ b/data-plane/core/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-config"
-version = "0.6.0"
+version = "0.6.1"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Configuration utilities"

--- a/data-plane/core/controller/CHANGELOG.md
+++ b/data-plane/core/controller/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.6](https://github.com/agntcy/slim/compare/slim-controller-v0.4.5...slim-controller-v0.4.6) - 2026-02-06
+
+### Other
+
+- updated the following local packages: agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-tracing
+
 ## [0.4.5](https://github.com/agntcy/slim/compare/slim-controller-v0.4.4...slim-controller-v0.4.5) - 2026-01-30
 
 ### Other

--- a/data-plane/core/controller/Cargo.toml
+++ b/data-plane/core/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-controller"
-version = "0.4.5"
+version = "0.4.6"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Controller service and control API to configure the SLIM data plane through the control plane."

--- a/data-plane/core/datapath/CHANGELOG.md
+++ b/data-plane/core/datapath/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.2](https://github.com/agntcy/slim/compare/slim-datapath-v0.11.1...slim-datapath-v0.11.2) - 2026-02-06
+
+### Other
+
+- *(data-plane)* upgrade to rust 1.93 ([#1190](https://github.com/agntcy/slim/pull/1190))
+
 ## [0.11.1](https://github.com/agntcy/slim/compare/slim-datapath-v0.11.0...slim-datapath-v0.11.1) - 2026-01-30
 
 ### Other

--- a/data-plane/core/datapath/Cargo.toml
+++ b/data-plane/core/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-datapath"
-version = "0.11.1"
+version = "0.11.2"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Core data plane functionality for SLIM"

--- a/data-plane/core/mls/CHANGELOG.md
+++ b/data-plane/core/mls/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/agntcy/slim/compare/slim-mls-v0.1.7...slim-mls-v0.1.8) - 2026-02-06
+
+### Other
+
+- updated the following local packages: agntcy-slim-datapath
+
 ## [0.1.7](https://github.com/agntcy/slim/compare/slim-mls-v0.1.6...slim-mls-v0.1.7) - 2026-01-30
 
 ### Other

--- a/data-plane/core/mls/Cargo.toml
+++ b/data-plane/core/mls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-mls"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.7"
+version = "0.1.8"
 description = "Messaging Layer Security for SLIM data plane."
 
 [lib]

--- a/data-plane/core/service/CHANGELOG.md
+++ b/data-plane/core/service/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.5](https://github.com/agntcy/slim/compare/slim-service-v0.8.4...slim-service-v0.8.5) - 2026-02-06
+
+### Added
+
+- remove lock from mls state ([#1203](https://github.com/agntcy/slim/pull/1203))
+
 ## [0.8.4](https://github.com/agntcy/slim/compare/slim-service-v0.8.3...slim-service-v0.8.4) - 2026-01-30
 
 ### Other

--- a/data-plane/core/service/Cargo.toml
+++ b/data-plane/core/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-service"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.8.4"
+version = "0.8.5"
 description = "Main service and public API to interact with SLIM data plane."
 
 [lib]

--- a/data-plane/core/session/CHANGELOG.md
+++ b/data-plane/core/session/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/agntcy/slim/compare/slim-session-v0.1.4...slim-session-v0.1.5) - 2026-02-06
+
+### Added
+
+- remove lock from mls state ([#1203](https://github.com/agntcy/slim/pull/1203))
+
+### Other
+
+- *(data-plane)* upgrade to rust 1.93 ([#1190](https://github.com/agntcy/slim/pull/1190))
+
 ## [0.1.4](https://github.com/agntcy/slim/compare/slim-session-v0.1.3...slim-session-v0.1.4) - 2026-01-30
 
 ### Other

--- a/data-plane/core/session/Cargo.toml
+++ b/data-plane/core/session/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-session"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.4"
+version = "0.1.5"
 description = "SLIM session internal implementation."
 
 [lib]

--- a/data-plane/core/slim/CHANGELOG.md
+++ b/data-plane/core/slim/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1](https://github.com/agntcy/slim/compare/slim-v1.0.0...slim-v1.0.1) - 2026-02-06
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [1.0.0](https://github.com/agntcy/slim/compare/slim-v0.7.2...slim-v1.0.0) - 2026-01-30
 
 ### Other

--- a/data-plane/core/slim/Cargo.toml
+++ b/data-plane/core/slim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim"
-version = "1.0.0"
+version = "1.0.1"
 edition = { workspace = true }
 license = { workspace = true }
 description = "The main SLIM executable."

--- a/data-plane/core/tracing/CHANGELOG.md
+++ b/data-plane/core/tracing/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/agntcy/slim/compare/slim-tracing-v0.3.1...slim-tracing-v0.3.2) - 2026-02-06
+
+### Other
+
+- updated the following local packages: agntcy-slim-config
+
 ## [0.3.1](https://github.com/agntcy/slim/compare/slim-tracing-v0.3.0...slim-tracing-v0.3.1) - 2026-01-30
 
 ### Other

--- a/data-plane/core/tracing/Cargo.toml
+++ b/data-plane/core/tracing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-tracing"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.1"
+version = "0.3.2"
 description = "Observability for SLIM data plane: logs, traces and metrics infrastructure."
 
 [lib]

--- a/data-plane/slimrpc-compiler/CHANGELOG.md
+++ b/data-plane/slimrpc-compiler/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/agntcy/slim/compare/protoc-slimrpc-plugin-v0.1.2...protoc-slimrpc-plugin-v0.1.3) - 2026-02-06
+
+### Other
+
+- *(data-plane)* upgrade to rust 1.93 ([#1190](https://github.com/agntcy/slim/pull/1190))
+
 ## [0.1.2](https://github.com/agntcy/slim/compare/protoc-slimrpc-plugin-v0.1.1...protoc-slimrpc-plugin-v0.1.2) - 2026-01-29
 
 ### Added

--- a/data-plane/slimrpc-compiler/Cargo.toml
+++ b/data-plane/slimrpc-compiler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "agntcy-protoc-slimrpc-plugin"
 description = "A protoc plugin for generating SRPC (Slim RPC) code"
-version = "0.1.2"
+version = "0.1.3"
 license.workspace = true
 edition.workspace = true
 


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-config`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `agntcy-slim-datapath`: 0.11.1 -> 0.11.2 (✓ API compatible changes)
* `agntcy-slim-session`: 0.1.4 -> 0.1.5 (✓ API compatible changes)
* `agntcy-slim-service`: 0.8.4 -> 0.8.5 (✓ API compatible changes)
* `agntcy-slim`: 1.0.0 -> 1.0.1 (✓ API compatible changes)
* `agntcy-slim-bindings`: 1.0.0
* `agntcy-protoc-slimrpc-plugin`: 0.1.2 -> 0.1.3
* `agntcy-slim-tracing`: 0.3.1 -> 0.3.2
* `agntcy-slim-mls`: 0.1.7 -> 0.1.8
* `agntcy-slim-controller`: 0.4.5 -> 0.4.6

<details><summary><i><b>Changelog</b></i></summary><p>

## `agntcy-slim-config`

<blockquote>

## [0.6.1](https://github.com/agntcy/slim/compare/slim-config-v0.6.0...slim-config-v0.6.1) - 2026-02-06

### Other

- *(data-plane)* upgrade to rust 1.93 ([#1190](https://github.com/agntcy/slim/pull/1190))
</blockquote>

## `agntcy-slim-datapath`

<blockquote>

## [0.11.2](https://github.com/agntcy/slim/compare/slim-datapath-v0.11.1...slim-datapath-v0.11.2) - 2026-02-06

### Other

- *(data-plane)* upgrade to rust 1.93 ([#1190](https://github.com/agntcy/slim/pull/1190))
</blockquote>

## `agntcy-slim-session`

<blockquote>

## [0.1.5](https://github.com/agntcy/slim/compare/slim-session-v0.1.4...slim-session-v0.1.5) - 2026-02-06

### Added

- remove lock from mls state ([#1203](https://github.com/agntcy/slim/pull/1203))

### Other

- *(data-plane)* upgrade to rust 1.93 ([#1190](https://github.com/agntcy/slim/pull/1190))
</blockquote>

## `agntcy-slim-service`

<blockquote>

## [0.8.5](https://github.com/agntcy/slim/compare/slim-service-v0.8.4...slim-service-v0.8.5) - 2026-02-06

### Added

- remove lock from mls state ([#1203](https://github.com/agntcy/slim/pull/1203))
</blockquote>

## `agntcy-slim`

<blockquote>

## [1.0.1](https://github.com/agntcy/slim/compare/slim-v1.0.0...slim-v1.0.1) - 2026-02-06

### Other

- update Cargo.lock dependencies
</blockquote>

## `agntcy-slim-bindings`

<blockquote>

## [1.0.0](https://github.com/agntcy/slim/releases/tag/slim-bindings-v1.0.0) - 2026-02-06

### Added

- *(bindings)* set release candidate 1.0.0-rc.0 ([#1135](https://github.com/agntcy/slim/pull/1135))
- *(bindings)* move to new python bindings ([#1116](https://github.com/agntcy/slim/pull/1116))
- *(session)* Add direction to slim app to control message flow ([#1121](https://github.com/agntcy/slim/pull/1121))
- generate python bindings with uniffi ([#1046](https://github.com/agntcy/slim/pull/1046))

### Fixed

- *(bindings)* automatically convert internal errors to exposed errors ([#1154](https://github.com/agntcy/slim/pull/1154))

### Other

- release ([#1156](https://github.com/agntcy/slim/pull/1156))
- release ([#1011](https://github.com/agntcy/slim/pull/1011))
- *(Taskfile)* move zig installation to global tools ([#1120](https://github.com/agntcy/slim/pull/1120))
- *(bindings)* do not expose tokio-specific APIs to foreign async calls ([#1110](https://github.com/agntcy/slim/pull/1110))
- *(bindings)* allow multiple global services ([#1106](https://github.com/agntcy/slim/pull/1106))
- *(bindings)* rename BindingsAdapter into App and BindingsSessionContext into Session ([#1104](https://github.com/agntcy/slim/pull/1104))
</blockquote>

## `agntcy-protoc-slimrpc-plugin`

<blockquote>

## [0.1.3](https://github.com/agntcy/slim/compare/protoc-slimrpc-plugin-v0.1.2...protoc-slimrpc-plugin-v0.1.3) - 2026-02-06

### Other

- *(data-plane)* upgrade to rust 1.93 ([#1190](https://github.com/agntcy/slim/pull/1190))
</blockquote>

## `agntcy-slim-tracing`

<blockquote>

## [0.3.2](https://github.com/agntcy/slim/compare/slim-tracing-v0.3.1...slim-tracing-v0.3.2) - 2026-02-06

### Other

- updated the following local packages: agntcy-slim-config
</blockquote>

## `agntcy-slim-mls`

<blockquote>

## [0.1.8](https://github.com/agntcy/slim/compare/slim-mls-v0.1.7...slim-mls-v0.1.8) - 2026-02-06

### Other

- updated the following local packages: agntcy-slim-datapath
</blockquote>

## `agntcy-slim-controller`

<blockquote>

## [0.4.6](https://github.com/agntcy/slim/compare/slim-controller-v0.4.5...slim-controller-v0.4.6) - 2026-02-06

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-tracing
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).