### PR TITLE
ci(slimrpc-compiler): remove windows gnu from targets

### DIFF
--- a/.github/workflows/release-slimrpc-compiler.yaml
+++ b/.github/workflows/release-slimrpc-compiler.yaml
@@ -52,10 +52,6 @@ jobs:
             os: windows
             target: x86_64-pc-windows-msvc
             archive: windows-x86_64
-          - runner: ubuntu-24.04
-            os: linux
-            target: x86_64-pc-windows-gnu
-            archive: windows-x86_64
           - runner: windows-11-arm
             os: windows
             target: aarch64-pc-windows-msvc


### PR DESCRIPTION
# Description

As we are already distributing a windows version compiled with msvc,
we don't need to also distribute a version compiled with mingw.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
