### PR TITLE
chore: release

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agntcy-protoc-slimrpc-plugin"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-bindings"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -36,7 +36,7 @@ resolver = "2"
 # Local dependencies
 agntcy-slim = { path = "core/slim", version = "1.0.2" }
 agntcy-slim-auth = { path = "core/auth", version = "0.5.0" }
-agntcy-slim-bindings = { path = "bindings/rust", version = "1.1.0" }
+agntcy-slim-bindings = { path = "bindings/rust", version = "1.1.1" }
 agntcy-slim-config = { path = "core/config", version = "0.6.2" }
 agntcy-slim-controller = { path = "core/controller", version = "0.4.7" }
 agntcy-slim-datapath = { path = "core/datapath", version = "0.11.3" }

--- a/data-plane/bindings/rust/CHANGELOG.md
+++ b/data-plane/bindings/rust/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1](https://github.com/agntcy/slim/compare/slim-bindings-v1.1.0...slim-bindings-v1.1.1) - 2026-02-13
+
+### Fixed
+
+- *(slimrpc-compiler)* correctly process errors from handlers ([#1229](https://github.com/agntcy/slim/pull/1229))
+
 ## [1.1.0](https://github.com/agntcy/slim/releases/tag/slim-bindings-v1.0.1) - 2026-02-06
 
 ### Added

--- a/data-plane/bindings/rust/Cargo.toml
+++ b/data-plane/bindings/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-bindings"
-version = "1.1.0"
+version = "1.1.1"
 edition = { workspace = true }
 license = { workspace = true }
 description = "UniFFI bindings and FFI adapter for SLIM data plane - enables language integrations (Go, Swift, Kotlin, etc.)"

--- a/data-plane/slimrpc-compiler/CHANGELOG.md
+++ b/data-plane/slimrpc-compiler/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2](https://github.com/agntcy/slim/compare/protoc-slimrpc-plugin-v1.0.1...protoc-slimrpc-plugin-v1.0.2) - 2026-02-13
+
+### Fixed
+
+- *(slimrpc-compiler)* correctly process errors from handlers ([#1229](https://github.com/agntcy/slim/pull/1229))
+
 ## [1.0.1](https://github.com/agntcy/slim/compare/protoc-slimrpc-plugin-v1.0.0...protoc-slimrpc-plugin-v1.0.1) - 2026-02-12
 
 ### Fixed

--- a/data-plane/slimrpc-compiler/Cargo.toml
+++ b/data-plane/slimrpc-compiler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "agntcy-protoc-slimrpc-plugin"
 description = "A protoc plugin for generating slimrpc code"
-version = "1.0.1"
+version = "1.0.2"
 license.workspace = true
 edition.workspace = true
 


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-bindings`: 1.1.0 -> 1.1.1 (✓ API compatible changes)
* `agntcy-protoc-slimrpc-plugin`: 1.0.1 -> 1.0.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `agntcy-slim-bindings`

<blockquote>

## [1.1.1](https://github.com/agntcy/slim/compare/slim-bindings-v1.1.0...slim-bindings-v1.1.1) - 2026-02-13

### Fixed

- *(slimrpc-compiler)* correctly process errors from handlers ([#1229](https://github.com/agntcy/slim/pull/1229))
</blockquote>

## `agntcy-protoc-slimrpc-plugin`

<blockquote>

## [1.0.2](https://github.com/agntcy/slim/compare/protoc-slimrpc-plugin-v1.0.1...protoc-slimrpc-plugin-v1.0.2) - 2026-02-13

### Fixed

- *(slimrpc-compiler)* correctly process errors from handlers ([#1229](https://github.com/agntcy/slim/pull/1229))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).