### PR TITLE
chore: release

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agntcy-protoc-slimrpc-plugin"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-service",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-auth"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-testing",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-bindings"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-testing",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-tracing",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "agntcy-slim-config",
  "once_cell",

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -36,19 +36,19 @@ resolver = "2"
 
 [workspace.dependencies]
 # Local dependencies
-agntcy-slim = { path = "core/slim", version = "1.0.2" }
-agntcy-slim-auth = { path = "core/auth", version = "0.5.0" }
-agntcy-slim-bindings = { path = "bindings/rust", version = "1.1.1" }
-agntcy-slim-config = { path = "core/config", version = "0.6.2" }
-agntcy-slim-controller = { path = "core/controller", version = "0.4.7" }
-agntcy-slim-datapath = { path = "core/datapath", version = "0.11.3" }
-agntcy-slim-mls = { path = "core/mls", version = "0.1.9" }
-agntcy-slim-service = { path = "core/service", version = "0.8.6", default-features = false }
-agntcy-slim-session = { path = "core/session", version = "0.1.6" }
+agntcy-slim = { path = "core/slim", version = "1.1.0" }
+agntcy-slim-auth = { path = "core/auth", version = "0.5.1" }
+agntcy-slim-bindings = { path = "bindings/rust", version = "1.2.0" }
+agntcy-slim-config = { path = "core/config", version = "0.6.3" }
+agntcy-slim-controller = { path = "core/controller", version = "0.4.8" }
+agntcy-slim-datapath = { path = "core/datapath", version = "0.11.4" }
+agntcy-slim-mls = { path = "core/mls", version = "0.1.10" }
+agntcy-slim-service = { path = "core/service", version = "0.8.7", default-features = false }
+agntcy-slim-session = { path = "core/session", version = "0.1.7" }
 agntcy-slim-signal = { path = "core/signal", version = "0.1.4" }
 agntcy-slim-testing = { path = "testing" }
-agntcy-slim-tracing = { path = "core/tracing", version = "0.3.3" }
-agntcy-slimctl = { path = "slimctl", version = "0.1.0" }
+agntcy-slim-tracing = { path = "core/tracing", version = "0.3.4" }
+agntcy-slimctl = { path = "slimctl", version = "1.2.0" }
 
 anyhow = "1.0.98"
 

--- a/data-plane/bindings/rust/CHANGELOG.md
+++ b/data-plane/bindings/rust/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0](https://github.com/agntcy/slim/compare/slim-bindings-v1.1.1...slim-bindings-v1.2.0) - 2026-02-27
+
+### Added
+
+- slim bindings kotlin ([#1198](https://github.com/agntcy/slim/pull/1198))
+- remove go implementation of slimctl and refactor workflows ([#1276](https://github.com/agntcy/slim/pull/1276))
+- Create helper to convert string name to slim_bindings.Name ([#1251](https://github.com/agntcy/slim/pull/1251))
+- improve default values for exposed Client and Server config ([#1244](https://github.com/agntcy/slim/pull/1244))
+
+### Fixed
+
+- *(slimctl)* improve startup error reporting ([#1248](https://github.com/agntcy/slim/pull/1248))
+- remove finalize keyword from bindings ([#1237](https://github.com/agntcy/slim/pull/1237))
+
 ## [1.1.1](https://github.com/agntcy/slim/compare/slim-bindings-v1.1.0...slim-bindings-v1.1.1) - 2026-02-13
 
 ### Fixed

--- a/data-plane/bindings/rust/Cargo.toml
+++ b/data-plane/bindings/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-bindings"
-version = "1.1.1"
+version = "1.2.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "UniFFI bindings and FFI adapter for SLIM data plane - enables language integrations (Go, Swift, Kotlin, etc.)"

--- a/data-plane/core/auth/CHANGELOG.md
+++ b/data-plane/core/auth/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/agntcy/slim/compare/slim-auth-v0.5.0...slim-auth-v0.5.1) - 2026-02-27
+
+### Added
+
+- *(data-plane)* port slimctl to Rust ([#1255](https://github.com/agntcy/slim/pull/1255))
+
 ## [0.5.0](https://github.com/agntcy/slim/compare/slim-auth-v0.4.1...slim-auth-v0.5.0) - 2026-01-29
 
 ### Added

--- a/data-plane/core/auth/Cargo.toml
+++ b/data-plane/core/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-auth"
-version = "0.5.0"
+version = "0.5.1"
 license = { workspace = true }
 edition = { workspace = true }
 description = "Authentication utilities for the Agntcy Slim framework"

--- a/data-plane/core/config/CHANGELOG.md
+++ b/data-plane/core/config/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3](https://github.com/agntcy/slim/compare/slim-config-v0.6.2...slim-config-v0.6.3) - 2026-02-27
+
+### Added
+
+- remove go implementation of slimctl and refactor workflows ([#1276](https://github.com/agntcy/slim/pull/1276))
+
 ## [0.6.2](https://github.com/agntcy/slim/compare/slim-config-v0.6.1...slim-config-v0.6.2) - 2026-02-12
 
 ### Added

--- a/data-plane/core/config/Cargo.toml
+++ b/data-plane/core/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-config"
-version = "0.6.2"
+version = "0.6.3"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Configuration utilities"

--- a/data-plane/core/controller/CHANGELOG.md
+++ b/data-plane/core/controller/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.8](https://github.com/agntcy/slim/compare/slim-controller-v0.4.7...slim-controller-v0.4.8) - 2026-02-27
+
+### Added
+
+- remove go implementation of slimctl and refactor workflows ([#1276](https://github.com/agntcy/slim/pull/1276))
+- add subscribe/unsubscribe ack handling ([#1111](https://github.com/agntcy/slim/pull/1111))
+
 ## [0.4.7](https://github.com/agntcy/slim/compare/slim-controller-v0.4.6...slim-controller-v0.4.7) - 2026-02-12
 
 ### Other

--- a/data-plane/core/controller/Cargo.toml
+++ b/data-plane/core/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-controller"
-version = "0.4.7"
+version = "0.4.8"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Controller service and control API to configure the SLIM data plane through the control plane."

--- a/data-plane/core/datapath/CHANGELOG.md
+++ b/data-plane/core/datapath/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.4](https://github.com/agntcy/slim/compare/slim-datapath-v0.11.3...slim-datapath-v0.11.4) - 2026-02-27
+
+### Added
+
+- add subscribe/unsubscribe ack handling ([#1111](https://github.com/agntcy/slim/pull/1111))
+
 ## [0.11.3](https://github.com/agntcy/slim/compare/slim-datapath-v0.11.2...slim-datapath-v0.11.3) - 2026-02-12
 
 ### Other

--- a/data-plane/core/datapath/Cargo.toml
+++ b/data-plane/core/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-datapath"
-version = "0.11.3"
+version = "0.11.4"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Core data plane functionality for SLIM"

--- a/data-plane/core/mls/CHANGELOG.md
+++ b/data-plane/core/mls/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10](https://github.com/agntcy/slim/compare/slim-mls-v0.1.9...slim-mls-v0.1.10) - 2026-02-27
+
+### Other
+
+- updated the following local packages: agntcy-slim-auth, agntcy-slim-datapath
+
 ## [0.1.9](https://github.com/agntcy/slim/compare/slim-mls-v0.1.8...slim-mls-v0.1.9) - 2026-02-12
 
 ### Added

--- a/data-plane/core/mls/Cargo.toml
+++ b/data-plane/core/mls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-mls"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.9"
+version = "0.1.10"
 description = "Messaging Layer Security for SLIM data plane."
 
 [lib]

--- a/data-plane/core/service/CHANGELOG.md
+++ b/data-plane/core/service/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.7](https://github.com/agntcy/slim/compare/slim-service-v0.8.6...slim-service-v0.8.7) - 2026-02-27
+
+### Added
+
+- remove go implementation of slimctl and refactor workflows ([#1276](https://github.com/agntcy/slim/pull/1276))
+- add subscribe/unsubscribe ack handling ([#1111](https://github.com/agntcy/slim/pull/1111))
+
 ## [0.8.6](https://github.com/agntcy/slim/compare/slim-service-v0.8.5...slim-service-v0.8.6) - 2026-02-12
 
 ### Added

--- a/data-plane/core/service/Cargo.toml
+++ b/data-plane/core/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-service"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.8.6"
+version = "0.8.7"
 description = "Main service and public API to interact with SLIM data plane."
 
 [lib]

--- a/data-plane/core/session/CHANGELOG.md
+++ b/data-plane/core/session/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/agntcy/slim/compare/slim-session-v0.1.6...slim-session-v0.1.7) - 2026-02-27
+
+### Other
+
+- updated the following local packages: agntcy-slim-auth, agntcy-slim-datapath, agntcy-slim-mls
+
 ## [0.1.6](https://github.com/agntcy/slim/compare/slim-session-v0.1.5...slim-session-v0.1.6) - 2026-02-12
 
 ### Added

--- a/data-plane/core/session/Cargo.toml
+++ b/data-plane/core/session/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-session"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.6"
+version = "0.1.7"
 description = "SLIM session internal implementation."
 
 [lib]

--- a/data-plane/core/slim/CHANGELOG.md
+++ b/data-plane/core/slim/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/agntcy/slim/compare/slim-v1.0.2...slim-v1.1.0) - 2026-02-27
+
+### Added
+
+- remove go implementation of slimctl and refactor workflows ([#1276](https://github.com/agntcy/slim/pull/1276))
+
 ## [1.0.2](https://github.com/agntcy/slim/compare/slim-v1.0.1...slim-v1.0.2) - 2026-02-12
 
 ### Other

--- a/data-plane/core/slim/Cargo.toml
+++ b/data-plane/core/slim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim"
-version = "1.0.2"
+version = "1.1.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "The main SLIM executable."

--- a/data-plane/core/tracing/CHANGELOG.md
+++ b/data-plane/core/tracing/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.4](https://github.com/agntcy/slim/compare/slim-tracing-v0.3.3...slim-tracing-v0.3.4) - 2026-02-27
+
+### Added
+
+- remove go implementation of slimctl and refactor workflows ([#1276](https://github.com/agntcy/slim/pull/1276))
+
 ## [0.3.3](https://github.com/agntcy/slim/compare/slim-tracing-v0.3.2...slim-tracing-v0.3.3) - 2026-02-12
 
 ### Other

--- a/data-plane/core/tracing/Cargo.toml
+++ b/data-plane/core/tracing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-tracing"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.3"
+version = "0.3.4"
 description = "Observability for SLIM data plane: logs, traces and metrics infrastructure."
 
 [lib]

--- a/data-plane/slimctl/CHANGELOG.md
+++ b/data-plane/slimctl/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.2.0](https://github.com/agntcy/slim/releases/tag/slimctl-v1.2.0) - 2026-02-27
+
+### Added
+
+- remove go implementation of slimctl and refactor workflows ([#1276](https://github.com/agntcy/slim/pull/1276))
+- *(data-plane)* port slimctl to Rust ([#1255](https://github.com/agntcy/slim/pull/1255))
+
+### Fixed
+
+- bump slimctl version ([#1286](https://github.com/agntcy/slim/pull/1286))

--- a/data-plane/slimrpc-compiler/CHANGELOG.md
+++ b/data-plane/slimrpc-compiler/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/agntcy/slim/compare/protoc-slimrpc-plugin-v1.0.2...protoc-slimrpc-plugin-v1.1.0) - 2026-02-27
+
+### Added
+
+- *(slimrpc-compiler)* add types_import/types_alias params to Go plugin ([#1274](https://github.com/agntcy/slim/pull/1274))
+
+### Fixed
+
+- remove finalize keyword from bindings ([#1237](https://github.com/agntcy/slim/pull/1237))
+
 ## [1.0.2](https://github.com/agntcy/slim/compare/protoc-slimrpc-plugin-v1.0.1...protoc-slimrpc-plugin-v1.0.2) - 2026-02-13
 
 ### Fixed

--- a/data-plane/slimrpc-compiler/Cargo.toml
+++ b/data-plane/slimrpc-compiler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "agntcy-protoc-slimrpc-plugin"
 description = "A protoc plugin for generating slimrpc code"
-version = "1.0.2"
+version = "1.1.0"
 license.workspace = true
 edition.workspace = true
 


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-auth`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `agntcy-slim-config`: 0.6.2 -> 0.6.3 (✓ API compatible changes)
* `agntcy-slim-tracing`: 0.3.3 -> 0.3.4 (✓ API compatible changes)
* `agntcy-slim-datapath`: 0.11.3 -> 0.11.4 (✓ API compatible changes)
* `agntcy-slim-controller`: 0.4.7 -> 0.4.8 (✓ API compatible changes)
* `agntcy-slim-service`: 0.8.6 -> 0.8.7 (✓ API compatible changes)
* `agntcy-slim`: 1.0.2 -> 1.1.0 (✓ API compatible changes)
* `agntcy-slim-bindings`: 1.1.1 -> 1.2.0 (✓ API compatible changes)
* `agntcy-slimctl`: 1.2.0
* `agntcy-protoc-slimrpc-plugin`: 1.0.2 -> 1.1.0 (✓ API compatible changes)
* `agntcy-slim-mls`: 0.1.9 -> 0.1.10
* `agntcy-slim-session`: 0.1.6 -> 0.1.7

<details><summary><i><b>Changelog</b></i></summary><p>

## `agntcy-slim-auth`

<blockquote>

## [0.5.1](https://github.com/agntcy/slim/compare/slim-auth-v0.5.0...slim-auth-v0.5.1) - 2026-02-27

### Added

- *(data-plane)* port slimctl to Rust ([#1255](https://github.com/agntcy/slim/pull/1255))
</blockquote>

## `agntcy-slim-config`

<blockquote>

## [0.6.3](https://github.com/agntcy/slim/compare/slim-config-v0.6.2...slim-config-v0.6.3) - 2026-02-27

### Added

- remove go implementation of slimctl and refactor workflows ([#1276](https://github.com/agntcy/slim/pull/1276))
</blockquote>

## `agntcy-slim-tracing`

<blockquote>

## [0.3.4](https://github.com/agntcy/slim/compare/slim-tracing-v0.3.3...slim-tracing-v0.3.4) - 2026-02-27

### Added

- remove go implementation of slimctl and refactor workflows ([#1276](https://github.com/agntcy/slim/pull/1276))
</blockquote>

## `agntcy-slim-datapath`

<blockquote>

## [0.11.4](https://github.com/agntcy/slim/compare/slim-datapath-v0.11.3...slim-datapath-v0.11.4) - 2026-02-27

### Added

- add subscribe/unsubscribe ack handling ([#1111](https://github.com/agntcy/slim/pull/1111))
</blockquote>

## `agntcy-slim-controller`

<blockquote>

## [0.4.8](https://github.com/agntcy/slim/compare/slim-controller-v0.4.7...slim-controller-v0.4.8) - 2026-02-27

### Added

- remove go implementation of slimctl and refactor workflows ([#1276](https://github.com/agntcy/slim/pull/1276))
- add subscribe/unsubscribe ack handling ([#1111](https://github.com/agntcy/slim/pull/1111))
</blockquote>

## `agntcy-slim-service`

<blockquote>

## [0.8.7](https://github.com/agntcy/slim/compare/slim-service-v0.8.6...slim-service-v0.8.7) - 2026-02-27

### Added

- remove go implementation of slimctl and refactor workflows ([#1276](https://github.com/agntcy/slim/pull/1276))
- add subscribe/unsubscribe ack handling ([#1111](https://github.com/agntcy/slim/pull/1111))
</blockquote>

## `agntcy-slim`

<blockquote>

## [1.1.0](https://github.com/agntcy/slim/compare/slim-v1.0.2...slim-v1.1.0) - 2026-02-27

### Added

- remove go implementation of slimctl and refactor workflows ([#1276](https://github.com/agntcy/slim/pull/1276))
</blockquote>

## `agntcy-slim-bindings`

<blockquote>

## [1.2.0](https://github.com/agntcy/slim/compare/slim-bindings-v1.1.1...slim-bindings-v1.2.0) - 2026-02-27

### Added

- slim bindings kotlin ([#1198](https://github.com/agntcy/slim/pull/1198))
- remove go implementation of slimctl and refactor workflows ([#1276](https://github.com/agntcy/slim/pull/1276))
- Create helper to convert string name to slim_bindings.Name ([#1251](https://github.com/agntcy/slim/pull/1251))
- improve default values for exposed Client and Server config ([#1244](https://github.com/agntcy/slim/pull/1244))

### Fixed

- *(slimctl)* improve startup error reporting ([#1248](https://github.com/agntcy/slim/pull/1248))
- remove finalize keyword from bindings ([#1237](https://github.com/agntcy/slim/pull/1237))
</blockquote>

## `agntcy-slimctl`

<blockquote>

## [1.2.0](https://github.com/agntcy/slim/releases/tag/slimctl-v1.2.0) - 2026-02-27

### Added

- remove go implementation of slimctl and refactor workflows ([#1276](https://github.com/agntcy/slim/pull/1276))
- *(data-plane)* port slimctl to Rust ([#1255](https://github.com/agntcy/slim/pull/1255))

### Fixed

- bump slimctl version ([#1286](https://github.com/agntcy/slim/pull/1286))
</blockquote>

## `agntcy-protoc-slimrpc-plugin`

<blockquote>

## [1.1.0](https://github.com/agntcy/slim/compare/protoc-slimrpc-plugin-v1.0.2...protoc-slimrpc-plugin-v1.1.0) - 2026-02-27

### Added

- *(slimrpc-compiler)* add types_import/types_alias params to Go plugin ([#1274](https://github.com/agntcy/slim/pull/1274))

### Fixed

- remove finalize keyword from bindings ([#1237](https://github.com/agntcy/slim/pull/1237))
</blockquote>

## `agntcy-slim-mls`

<blockquote>

## [0.1.10](https://github.com/agntcy/slim/compare/slim-mls-v0.1.9...slim-mls-v0.1.10) - 2026-02-27

### Other

- updated the following local packages: agntcy-slim-auth, agntcy-slim-datapath
</blockquote>

## `agntcy-slim-session`

<blockquote>

## [0.1.7](https://github.com/agntcy/slim/compare/slim-session-v0.1.6...slim-session-v0.1.7) - 2026-02-27

### Other

- updated the following local packages: agntcy-slim-auth, agntcy-slim-datapath, agntcy-slim-mls
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).