### PR TITLE
ci: release rust crates only when release PR gets merged

### DIFF
--- a/data-plane/.release-plz.toml
+++ b/data-plane/.release-plz.toml
@@ -1,5 +1,5 @@
 [workspace]
-release_always = true
+release_always = false
 # do not release packages by default
 release = false
 


### PR DESCRIPTION
# Description

Release rust crates only when release PR gets merged

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
