### PR TITLE
fix: copy cargo-config before running taiki-e/upload-rust-binary-action

### DIFF
--- a/.github/workflows/release-slimctl.yaml
+++ b/.github/workflows/release-slimctl.yaml
@@ -61,6 +61,11 @@ jobs:
         with:
           workspace: ./data-plane
 
+      - name: Copy Cargo config from data-plane
+        run: |
+          mkdir -p .cargo
+          cp data-plane/.cargo/config.toml .cargo/config.toml
+
       - uses: taiki-e/upload-rust-binary-action@f391289bcff6a7f36b6301c0a74199657bbb4561 # v1.28.0
         with:
           bin: slimctl


### PR DESCRIPTION
# Description

As the action can only run from the root of the repo, we need to copy the
.cargo/config.toml there to include compilation options.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
