### PR TITLE
chore: release

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agntcy-protoc-slimrpc-plugin"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-auth"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-testing",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-testing",
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-tracing",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-signal"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "agntcy-slim-version",
  "tokio",
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -39,17 +39,17 @@ resolver = "2"
 [workspace.dependencies]
 # Local dependencies
 agntcy-slim = { path = "core/slim", version = "1.3.0-rc.0" }
-agntcy-slim-auth = { path = "core/auth", version = "0.5.1" }
+agntcy-slim-auth = { path = "core/auth", version = "0.5.2" }
 agntcy-slim-bindings = { path = "bindings/rust", version = "1.3.0-rc.0" }
-agntcy-slim-config = { path = "core/config", version = "0.6.3" }
-agntcy-slim-controller = { path = "core/controller", version = "0.4.8" }
-agntcy-slim-datapath = { path = "core/datapath", version = "0.11.4" }
-agntcy-slim-mls = { path = "core/mls", version = "0.1.10" }
-agntcy-slim-service = { path = "core/service", version = "0.8.7", default-features = false }
-agntcy-slim-session = { path = "core/session", version = "0.1.7" }
-agntcy-slim-signal = { path = "core/signal", version = "0.1.4" }
+agntcy-slim-config = { path = "core/config", version = "0.7.0" }
+agntcy-slim-controller = { path = "core/controller", version = "0.4.9" }
+agntcy-slim-datapath = { path = "core/datapath", version = "0.11.5" }
+agntcy-slim-mls = { path = "core/mls", version = "0.1.11" }
+agntcy-slim-service = { path = "core/service", version = "0.8.8", default-features = false }
+agntcy-slim-session = { path = "core/session", version = "0.1.8" }
+agntcy-slim-signal = { path = "core/signal", version = "0.1.5" }
 agntcy-slim-testing = { path = "testing" }
-agntcy-slim-tracing = { path = "core/tracing", version = "0.3.4" }
+agntcy-slim-tracing = { path = "core/tracing", version = "0.3.5" }
 agntcy-slim-version = { path = "core/version", version = "1.3.0-rc.0" }
 agntcy-slimctl = { path = "slimctl", version = "1.3.0-rc.0" }
 

--- a/data-plane/bindings/rust/CHANGELOG.md
+++ b/data-plane/bindings/rust/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0-rc.0](https://github.com/agntcy/slim/compare/slim-bindings-v1.2.0...slim-bindings-v1.3.0-rc.0) - 2026-03-20
+
+### Added
+
+- expose json config in bindings ([#1366](https://github.com/agntcy/slim/pull/1366))
+- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
+- *(slimrpc)* session reuse and method demultiplexing ([#1334](https://github.com/agntcy/slim/pull/1334))
+- *(websocket)* update the config module while making sure backward compatibility ([#1333](https://github.com/agntcy/slim/pull/1333))
+- upgrade bindings to uniffi 0.29 ([#1321](https://github.com/agntcy/slim/pull/1321))
+
+### Other
+
+- release candidate 1.3.0-rc.0 ([#1367](https://github.com/agntcy/slim/pull/1367))
+- *(bindings)* Refactor Taskfiles to avoid rebuilds if source unchanged ([#1261](https://github.com/agntcy/slim/pull/1261))
+
 ## [1.2.0](https://github.com/agntcy/slim/compare/slim-bindings-v1.1.1...slim-bindings-v1.2.0) - 2026-02-27
 
 ### Added

--- a/data-plane/core/auth/CHANGELOG.md
+++ b/data-plane/core/auth/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/agntcy/slim/compare/slim-auth-v0.5.1...slim-auth-v0.5.2) - 2026-03-20
+
+### Added
+
+- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
+
 ## [0.5.1](https://github.com/agntcy/slim/compare/slim-auth-v0.5.0...slim-auth-v0.5.1) - 2026-02-27
 
 ### Added

--- a/data-plane/core/auth/Cargo.toml
+++ b/data-plane/core/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-auth"
-version = "0.5.1"
+version = "0.5.2"
 license = { workspace = true }
 edition = { workspace = true }
 description = "Authentication utilities for the Agntcy Slim framework"

--- a/data-plane/core/config/CHANGELOG.md
+++ b/data-plane/core/config/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/agntcy/slim/compare/slim-config-v0.6.3...slim-config-v0.7.0) - 2026-03-20
+
+### Added
+
+- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
+- *(websocket)* update the config module while making sure backward compatibility ([#1333](https://github.com/agntcy/slim/pull/1333))
+
 ## [0.6.3](https://github.com/agntcy/slim/compare/slim-config-v0.6.2...slim-config-v0.6.3) - 2026-02-27
 
 ### Added

--- a/data-plane/core/config/Cargo.toml
+++ b/data-plane/core/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-config"
-version = "0.6.3"
+version = "0.7.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Configuration utilities"

--- a/data-plane/core/controller/CHANGELOG.md
+++ b/data-plane/core/controller/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.9](https://github.com/agntcy/slim/compare/slim-controller-v0.4.8...slim-controller-v0.4.9) - 2026-03-20
+
+### Added
+
+- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
+
 ## [0.4.8](https://github.com/agntcy/slim/compare/slim-controller-v0.4.7...slim-controller-v0.4.8) - 2026-02-27
 
 ### Added

--- a/data-plane/core/controller/Cargo.toml
+++ b/data-plane/core/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-controller"
-version = "0.4.8"
+version = "0.4.9"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Controller service and control API to configure the SLIM data plane through the control plane."

--- a/data-plane/core/datapath/CHANGELOG.md
+++ b/data-plane/core/datapath/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.5](https://github.com/agntcy/slim/compare/slim-datapath-v0.11.4...slim-datapath-v0.11.5) - 2026-03-20
+
+### Added
+
+- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
+
 ## [0.11.4](https://github.com/agntcy/slim/compare/slim-datapath-v0.11.3...slim-datapath-v0.11.4) - 2026-02-27
 
 ### Added

--- a/data-plane/core/datapath/Cargo.toml
+++ b/data-plane/core/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-datapath"
-version = "0.11.4"
+version = "0.11.5"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Core data plane functionality for SLIM"

--- a/data-plane/core/mls/CHANGELOG.md
+++ b/data-plane/core/mls/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11](https://github.com/agntcy/slim/compare/slim-mls-v0.1.10...slim-mls-v0.1.11) - 2026-03-20
+
+### Added
+
+- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
+
 ## [0.1.10](https://github.com/agntcy/slim/compare/slim-mls-v0.1.9...slim-mls-v0.1.10) - 2026-02-27
 
 ### Other

--- a/data-plane/core/mls/Cargo.toml
+++ b/data-plane/core/mls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-mls"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.10"
+version = "0.1.11"
 description = "Messaging Layer Security for SLIM data plane."
 
 [lib]

--- a/data-plane/core/service/CHANGELOG.md
+++ b/data-plane/core/service/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.8](https://github.com/agntcy/slim/compare/slim-service-v0.8.7...slim-service-v0.8.8) - 2026-03-20
+
+### Added
+
+- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
+
+### Fixed
+
+- node_id override in slim service config ([#1348](https://github.com/agntcy/slim/pull/1348))
+
 ## [0.8.7](https://github.com/agntcy/slim/compare/slim-service-v0.8.6...slim-service-v0.8.7) - 2026-02-27
 
 ### Added

--- a/data-plane/core/service/Cargo.toml
+++ b/data-plane/core/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-service"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.8.7"
+version = "0.8.8"
 description = "Main service and public API to interact with SLIM data plane."
 
 [lib]

--- a/data-plane/core/session/CHANGELOG.md
+++ b/data-plane/core/session/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/agntcy/slim/compare/slim-session-v0.1.7...slim-session-v0.1.8) - 2026-03-20
+
+### Added
+
+- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
+
 ## [0.1.7](https://github.com/agntcy/slim/compare/slim-session-v0.1.6...slim-session-v0.1.7) - 2026-02-27
 
 ### Other

--- a/data-plane/core/session/Cargo.toml
+++ b/data-plane/core/session/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-session"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.7"
+version = "0.1.8"
 description = "SLIM session internal implementation."
 
 [lib]

--- a/data-plane/core/signal/CHANGELOG.md
+++ b/data-plane/core/signal/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/agntcy/slim/compare/slim-signal-v0.1.4...slim-signal-v0.1.5) - 2026-03-20
+
+### Added
+
+- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
+
 ## [0.1.4](https://github.com/agntcy/slim/compare/slim-signal-v0.1.3...slim-signal-v0.1.4) - 2026-01-29
 
 ### Other

--- a/data-plane/core/signal/Cargo.toml
+++ b/data-plane/core/signal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-signal"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.4"
+version = "0.1.5"
 description = "Small library to handle OS signals."
 
 [lib]

--- a/data-plane/core/slim/CHANGELOG.md
+++ b/data-plane/core/slim/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0-rc.0](https://github.com/agntcy/slim/compare/slim-v1.1.0...slim-v1.3.0-rc.0) - 2026-03-20
+
+### Added
+
+- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
+
 ## [1.1.0](https://github.com/agntcy/slim/compare/slim-v1.0.2...slim-v1.1.0) - 2026-02-27
 
 ### Added

--- a/data-plane/core/tracing/CHANGELOG.md
+++ b/data-plane/core/tracing/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5](https://github.com/agntcy/slim/compare/slim-tracing-v0.3.4...slim-tracing-v0.3.5) - 2026-03-20
+
+### Added
+
+- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
+
 ## [0.3.4](https://github.com/agntcy/slim/compare/slim-tracing-v0.3.3...slim-tracing-v0.3.4) - 2026-02-27
 
 ### Added

--- a/data-plane/core/tracing/Cargo.toml
+++ b/data-plane/core/tracing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-tracing"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.4"
+version = "0.3.5"
 description = "Observability for SLIM data plane: logs, traces and metrics infrastructure."
 
 [lib]

--- a/data-plane/core/version/CHANGELOG.md
+++ b/data-plane/core/version/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.3.0-rc.0](https://github.com/agntcy/slim/releases/tag/slim-version-v1.3.0-rc.0) - 2026-03-20
+
+### Added
+
+- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))

--- a/data-plane/slimctl/CHANGELOG.md
+++ b/data-plane/slimctl/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0-rc.0](https://github.com/agntcy/slim/compare/slimctl-v1.2.0...slimctl-v1.3.0-rc.0) - 2026-03-20
+
+### Added
+
+- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
+
+### Other
+
+- release candidate 1.3.0-rc.0 ([#1367](https://github.com/agntcy/slim/pull/1367))
+
 ## [1.2.0](https://github.com/agntcy/slim/releases/tag/slimctl-v1.2.0) - 2026-02-27
 
 ### Added

--- a/data-plane/slimrpc-compiler/CHANGELOG.md
+++ b/data-plane/slimrpc-compiler/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0](https://github.com/agntcy/slim/compare/protoc-slimrpc-plugin-v1.1.0...protoc-slimrpc-plugin-v1.2.0) - 2026-03-20
+
+### Added
+
+- java plugin for slimrpc compiler ([#1342](https://github.com/agntcy/slim/pull/1342))
+
 ## [1.1.0](https://github.com/agntcy/slim/compare/protoc-slimrpc-plugin-v1.0.2...protoc-slimrpc-plugin-v1.1.0) - 2026-02-27
 
 ### Added

--- a/data-plane/slimrpc-compiler/Cargo.toml
+++ b/data-plane/slimrpc-compiler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "agntcy-protoc-slimrpc-plugin"
 description = "A protoc plugin for generating slimrpc code"
-version = "1.1.0"
+version = "1.2.0"
 license.workspace = true
 edition.workspace = true
 


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-version`: 1.3.0-rc.0
* `agntcy-slim-auth`: 0.5.1 -> 0.5.2 (✓ API compatible changes)
* `agntcy-slim-config`: 0.6.3 -> 0.7.0 (⚠ API breaking changes)
* `agntcy-slim-tracing`: 0.3.4 -> 0.3.5 (✓ API compatible changes)
* `agntcy-slim-datapath`: 0.11.4 -> 0.11.5 (✓ API compatible changes)
* `agntcy-slim-mls`: 0.1.10 -> 0.1.11 (✓ API compatible changes)
* `agntcy-slim-session`: 0.1.7 -> 0.1.8 (✓ API compatible changes)
* `agntcy-slim-signal`: 0.1.4 -> 0.1.5 (✓ API compatible changes)
* `agntcy-slim-controller`: 0.4.8 -> 0.4.9 (✓ API compatible changes)
* `agntcy-slim-service`: 0.8.7 -> 0.8.8 (✓ API compatible changes)
* `agntcy-slim`: 1.1.0 -> 1.3.0-rc.0
* `agntcy-slim-bindings`: 1.2.0 -> 1.3.0-rc.0
* `agntcy-slimctl`: 1.2.0 -> 1.3.0-rc.0
* `agntcy-protoc-slimrpc-plugin`: 1.1.0 -> 1.2.0 (✓ API compatible changes)

### ⚠ `agntcy-slim-config` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ServerConfig.transport in /tmp/.tmpcVFAmo/slim/data-plane/core/config/src/grpc/server.rs:85
  field ClientConfig.transport in /tmp/.tmpcVFAmo/slim/data-plane/core/config/src/grpc/client.rs:275
  field ClientConfig.websocket_auth_query_param in /tmp/.tmpcVFAmo/slim/data-plane/core/config/src/grpc/client.rs:279

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant ConfigError:InvalidWebSocketEndpointScheme in /tmp/.tmpcVFAmo/slim/data-plane/core/config/src/grpc/errors.rs:27
  variant ConfigError:GrpcChannelUnsupportedTransport in /tmp/.tmpcVFAmo/slim/data-plane/core/config/src/grpc/errors.rs:33
  variant ConfigError:GrpcServerUnsupportedTransport in /tmp/.tmpcVFAmo/slim/data-plane/core/config/src/grpc/errors.rs:35
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `agntcy-slim-version`

<blockquote>

## [1.3.0-rc.0](https://github.com/agntcy/slim/releases/tag/slim-version-v1.3.0-rc.0) - 2026-03-20

### Added

- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
</blockquote>

## `agntcy-slim-auth`

<blockquote>

## [0.5.2](https://github.com/agntcy/slim/compare/slim-auth-v0.5.1...slim-auth-v0.5.2) - 2026-03-20

### Added

- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
</blockquote>

## `agntcy-slim-config`

<blockquote>

## [0.7.0](https://github.com/agntcy/slim/compare/slim-config-v0.6.3...slim-config-v0.7.0) - 2026-03-20

### Added

- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
- *(websocket)* update the config module while making sure backward compatibility ([#1333](https://github.com/agntcy/slim/pull/1333))
</blockquote>

## `agntcy-slim-tracing`

<blockquote>

## [0.3.5](https://github.com/agntcy/slim/compare/slim-tracing-v0.3.4...slim-tracing-v0.3.5) - 2026-03-20

### Added

- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
</blockquote>

## `agntcy-slim-datapath`

<blockquote>

## [0.11.5](https://github.com/agntcy/slim/compare/slim-datapath-v0.11.4...slim-datapath-v0.11.5) - 2026-03-20

### Added

- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
</blockquote>

## `agntcy-slim-mls`

<blockquote>

## [0.1.11](https://github.com/agntcy/slim/compare/slim-mls-v0.1.10...slim-mls-v0.1.11) - 2026-03-20

### Added

- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
</blockquote>

## `agntcy-slim-session`

<blockquote>

## [0.1.8](https://github.com/agntcy/slim/compare/slim-session-v0.1.7...slim-session-v0.1.8) - 2026-03-20

### Added

- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
</blockquote>

## `agntcy-slim-signal`

<blockquote>

## [0.1.5](https://github.com/agntcy/slim/compare/slim-signal-v0.1.4...slim-signal-v0.1.5) - 2026-03-20

### Added

- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
</blockquote>

## `agntcy-slim-controller`

<blockquote>

## [0.4.9](https://github.com/agntcy/slim/compare/slim-controller-v0.4.8...slim-controller-v0.4.9) - 2026-03-20

### Added

- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
</blockquote>

## `agntcy-slim-service`

<blockquote>

## [0.8.8](https://github.com/agntcy/slim/compare/slim-service-v0.8.7...slim-service-v0.8.8) - 2026-03-20

### Added

- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))

### Fixed

- node_id override in slim service config ([#1348](https://github.com/agntcy/slim/pull/1348))
</blockquote>

## `agntcy-slim`

<blockquote>

## [1.3.0-rc.0](https://github.com/agntcy/slim/compare/slim-v1.1.0...slim-v1.3.0-rc.0) - 2026-03-20

### Added

- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
</blockquote>

## `agntcy-slim-bindings`

<blockquote>

## [1.3.0-rc.0](https://github.com/agntcy/slim/compare/slim-bindings-v1.2.0...slim-bindings-v1.3.0-rc.0) - 2026-03-20

### Added

- expose json config in bindings ([#1366](https://github.com/agntcy/slim/pull/1366))
- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
- *(slimrpc)* session reuse and method demultiplexing ([#1334](https://github.com/agntcy/slim/pull/1334))
- *(websocket)* update the config module while making sure backward compatibility ([#1333](https://github.com/agntcy/slim/pull/1333))
- upgrade bindings to uniffi 0.29 ([#1321](https://github.com/agntcy/slim/pull/1321))

### Other

- release candidate 1.3.0-rc.0 ([#1367](https://github.com/agntcy/slim/pull/1367))
- *(bindings)* Refactor Taskfiles to avoid rebuilds if source unchanged ([#1261](https://github.com/agntcy/slim/pull/1261))
</blockquote>

## `agntcy-slimctl`

<blockquote>

## [1.3.0-rc.0](https://github.com/agntcy/slim/compare/slimctl-v1.2.0...slimctl-v1.3.0-rc.0) - 2026-03-20

### Added

- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))

### Other

- release candidate 1.3.0-rc.0 ([#1367](https://github.com/agntcy/slim/pull/1367))
</blockquote>

## `agntcy-protoc-slimrpc-plugin`

<blockquote>

## [1.2.0](https://github.com/agntcy/slim/compare/protoc-slimrpc-plugin-v1.1.0...protoc-slimrpc-plugin-v1.2.0) - 2026-03-20

### Added

- java plugin for slimrpc compiler ([#1342](https://github.com/agntcy/slim/pull/1342))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).