### PR TITLE
fix(session-participant): skip adding participant itself an endpoint

### DIFF
--- a/data-plane/core/session/src/session_participant.rs
+++ b/data-plane/core/session/src/session_participant.rs
@@ -451,12 +451,15 @@ where
                 let name = Name::from(new_participant);
                 self.group_list.insert(name.clone());
 
-                debug!(name  = %msg.get_source(), "add endpoint to session");
-                // add a route to the new endpoint, this is needed in case of message retransmission
-                self.common
-                    .add_route(&name, msg.get_incoming_conn())
-                    .await?;
-                self.add_endpoint(&name).await?;
+                // Skip adding ourselves as an endpoint
+                if name != self.common.settings.source {
+                    debug!(name  = %msg.get_source(), "add endpoint to session");
+                    // add a route to the new endpoint, this is needed in case of message retransmission
+                    self.common
+                        .add_route(&name, msg.get_incoming_conn())
+                        .await?;
+                    self.add_endpoint(&name).await?;
+                }
             }
         } else {
             let p = msg


### PR DESCRIPTION
# Description

When a new participant joins a GROUP session,
the moderator broadcasts a GroupAdd message to all
existing members.

The new member itself also received this broadcast
(before the GroupWelcome) and was unconditionally
adding itself to its own endpoints_list via add_endpoint.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
