### PR TITLE
feat: add agntcy-slim-version crate as single source of truth for version and build info

### DIFF
--- a/data-plane/.release-plz.toml
+++ b/data-plane/.release-plz.toml
@@ -8,6 +8,12 @@ git_tag_name = "{{ package | replace(from='agntcy-', to='') }}-v{{ version }}"
 git_release_name = "{{ package | replace(from='agntcy-', to='') }} v{{ version }}"
 
 [[package]]
+name = "agntcy-slim-version"
+publish = true
+release = true
+changelog_update = true
+
+[[package]]
 name = "agntcy-slim-config"
 publish = true
 release = true

--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -20,6 +20,7 @@ dependencies = [
  "agntcy-slim-service",
  "agntcy-slim-signal",
  "agntcy-slim-tracing",
+ "agntcy-slim-version",
  "anyhow",
  "clap",
  "duration-string",
@@ -42,6 +43,7 @@ version = "0.5.1"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-testing",
+ "agntcy-slim-version",
  "async-trait",
  "aws-lc-rs",
  "base64",
@@ -88,6 +90,7 @@ dependencies = [
  "agntcy-slim-signal",
  "agntcy-slim-testing",
  "agntcy-slim-tracing",
+ "agntcy-slim-version",
  "async-stream",
  "async-trait",
  "bincode",
@@ -116,6 +119,7 @@ version = "0.6.3"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-testing",
+ "agntcy-slim-version",
  "async-trait",
  "base64",
  "display-error-chain",
@@ -166,6 +170,7 @@ dependencies = [
  "agntcy-slim-signal",
  "agntcy-slim-testing",
  "agntcy-slim-tracing",
+ "agntcy-slim-version",
  "display-error-chain",
  "drain",
  "h2",
@@ -194,6 +199,7 @@ version = "0.11.4"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-tracing",
+ "agntcy-slim-version",
  "bincode",
  "bit-vec",
  "criterion",
@@ -226,6 +232,7 @@ version = "0.1.10"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
+ "agntcy-slim-version",
  "async-trait",
  "base64",
  "hex",
@@ -250,6 +257,7 @@ dependencies = [
  "agntcy-slim-mls",
  "agntcy-slim-session",
  "agntcy-slim-testing",
+ "agntcy-slim-version",
  "async-trait",
  "display-error-chain",
  "futures",
@@ -271,6 +279,7 @@ dependencies = [
  "agntcy-slim-datapath",
  "agntcy-slim-mls",
  "agntcy-slim-testing",
+ "agntcy-slim-version",
  "async-trait",
  "display-error-chain",
  "parking_lot",
@@ -288,6 +297,7 @@ dependencies = [
 name = "agntcy-slim-signal"
 version = "0.1.4"
 dependencies = [
+ "agntcy-slim-version",
  "tokio",
  "tracing",
 ]
@@ -326,6 +336,7 @@ name = "agntcy-slim-tracing"
 version = "0.3.4"
 dependencies = [
  "agntcy-slim-config",
+ "agntcy-slim-version",
  "once_cell",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -341,6 +352,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "agntcy-slim-version"
+version = "1.1.0"
+
+[[package]]
 name = "agntcy-slimctl"
 version = "1.2.0"
 dependencies = [
@@ -350,6 +365,7 @@ dependencies = [
  "agntcy-slim-service",
  "agntcy-slim-signal",
  "agntcy-slim-tracing",
+ "agntcy-slim-version",
  "anyhow",
  "chrono",
  "clap",

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "core/signal",
     "core/slim",
     "core/tracing",
+    "core/version",
     "examples",
     "slimctl",
     "slimrpc-compiler",
@@ -26,6 +27,7 @@ default-members = [
     "core/signal",
     "core/slim",
     "core/tracing",
+    "core/version",
     "examples",
     "slimctl",
     "slimrpc-compiler",
@@ -48,6 +50,7 @@ agntcy-slim-session = { path = "core/session", version = "0.1.7" }
 agntcy-slim-signal = { path = "core/signal", version = "0.1.4" }
 agntcy-slim-testing = { path = "testing" }
 agntcy-slim-tracing = { path = "core/tracing", version = "0.3.4" }
+agntcy-slim-version = { path = "core/version", version = "1.1.0" }
 agntcy-slimctl = { path = "slimctl", version = "1.2.0" }
 
 anyhow = "1.0.98"
@@ -143,6 +146,7 @@ uuid = { version = "1.15.1", features = ["v4"] }
 wiremock = "0.6"
 
 [workspace.package]
+version = "1.1.0"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/agntcy/slim"
@@ -161,6 +165,7 @@ ignored = [
     "agntcy-slim-signal",
     "agntcy-slim-testing",
     "agntcy-slim-tracing",
+    "agntcy-slim-version",
     "agntcy-slimctl",
     "agntcy-slimrpc",
 ]

--- a/data-plane/bindings/rust/Cargo.toml
+++ b/data-plane/bindings/rust/Cargo.toml
@@ -20,6 +20,7 @@ agntcy-slim-service = { workspace = true, features = ["session"] }
 agntcy-slim-session = { workspace = true }
 agntcy-slim-signal = { workspace = true }
 agntcy-slim-tracing = { workspace = true }
+agntcy-slim-version = { workspace = true }
 
 # External dependencies
 async-stream = { workspace = true }
@@ -40,6 +41,7 @@ uniffi = { workspace = true, features = ["cli"] }
 uuid = { workspace = true }
 
 [build-dependencies]
+agntcy-slim-version = { workspace = true }
 uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]

--- a/data-plane/bindings/rust/build.rs
+++ b/data-plane/bindings/rust/build.rs
@@ -1,36 +1,8 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
-use std::process::Command;
-
-fn set_env(name: &str, cmd: &mut Command) {
-    let value = match cmd.output() {
-        Ok(output) => String::from_utf8(output.stdout)
-            .unwrap_or_default()
-            .trim()
-            .to_string(),
-        Err(err) => {
-            println!("cargo:warning={}", err);
-            "unknown".to_string()
-        }
-    };
-    println!("cargo:rustc-env={}={}", name, value);
-}
-
 fn main() {
-    // Git commit hash (short)
-    set_env(
-        "GIT_SHA",
-        Command::new("git").args(["rev-parse", "--short", "HEAD"]),
-    );
-
-    // Build date in ISO 8601 UTC format
-    set_env(
-        "BUILD_DATE",
-        Command::new("date").args(["-u", "+%Y-%m-%dT%H:%M:%SZ"]),
-    );
-
-    // Build profile (debug/release)
-    let profile = std::env::var("PROFILE").unwrap_or_else(|_| "unknown".to_string());
-    println!("cargo:rustc-env=PROFILE={profile}");
+    slim_version::build::set_git_sha();
+    slim_version::build::set_build_date();
+    slim_version::build::set_profile();
 }

--- a/data-plane/core/auth/Cargo.toml
+++ b/data-plane/core/auth/Cargo.toml
@@ -9,6 +9,7 @@ description = "Authentication utilities for the Agntcy Slim framework"
 name = "slim_auth"
 
 [dependencies]
+agntcy-slim-version = { workspace = true }
 async-trait = { workspace = true }
 aws-lc-rs = { workspace = true }
 base64 = { workspace = true }

--- a/data-plane/core/config/Cargo.toml
+++ b/data-plane/core/config/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/grpc/schema/generate_schema.rs"
 
 [dependencies]
 agntcy-slim-auth = { workspace = true }
+agntcy-slim-version = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 display-error-chain = { workspace = true }

--- a/data-plane/core/controller/Cargo.toml
+++ b/data-plane/core/controller/Cargo.toml
@@ -17,6 +17,7 @@ agntcy-slim-datapath = { workspace = true }
 agntcy-slim-session = { workspace = true }
 agntcy-slim-signal = { workspace = true }
 agntcy-slim-tracing = { workspace = true }
+agntcy-slim-version = { workspace = true }
 display-error-chain = { workspace = true }
 drain = { workspace = true }
 h2 = { workspace = true }

--- a/data-plane/core/datapath/Cargo.toml
+++ b/data-plane/core/datapath/Cargo.toml
@@ -11,6 +11,7 @@ name = "slim_datapath"
 [dependencies]
 agntcy-slim-config = { workspace = true }
 agntcy-slim-tracing = { workspace = true }
+agntcy-slim-version = { workspace = true }
 bincode = { workspace = true }
 bit-vec = { workspace = true }
 display-error-chain = { workspace = true }

--- a/data-plane/core/mls/Cargo.toml
+++ b/data-plane/core/mls/Cargo.toml
@@ -11,6 +11,7 @@ name = "slim_mls"
 [dependencies]
 agntcy-slim-auth = { workspace = true }
 agntcy-slim-datapath = { workspace = true }
+agntcy-slim-version = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 hex = "0.4"

--- a/data-plane/core/service/Cargo.toml
+++ b/data-plane/core/service/Cargo.toml
@@ -20,6 +20,7 @@ agntcy-slim-controller = { workspace = true }
 agntcy-slim-datapath = { workspace = true }
 agntcy-slim-mls = { workspace = true }
 agntcy-slim-session = { workspace = true, optional = true }
+agntcy-slim-version = { workspace = true }
 async-trait = { workspace = true }
 display-error-chain = { workspace = true }
 futures = { workspace = true }

--- a/data-plane/core/session/Cargo.toml
+++ b/data-plane/core/session/Cargo.toml
@@ -12,6 +12,7 @@ name = "slim_session"
 agntcy-slim-auth = { workspace = true }
 agntcy-slim-datapath = { workspace = true }
 agntcy-slim-mls = { workspace = true }
+agntcy-slim-version = { workspace = true }
 async-trait = { workspace = true }
 display-error-chain = { workspace = true }
 parking_lot = { workspace = true }

--- a/data-plane/core/signal/Cargo.toml
+++ b/data-plane/core/signal/Cargo.toml
@@ -9,5 +9,6 @@ description = "Small library to handle OS signals."
 name = "slim_signal"
 
 [dependencies]
+agntcy-slim-version = { workspace = true }
 tokio = { version = "1", features = ["macros", "signal"] }
 tracing = { workspace = true }

--- a/data-plane/core/slim/Cargo.toml
+++ b/data-plane/core/slim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim"
-version = "1.1.0"
+version.workspace = true
 edition = { workspace = true }
 license = { workspace = true }
 description = "The main SLIM executable."
@@ -21,6 +21,7 @@ agntcy-slim-config = { workspace = true }
 agntcy-slim-service = { workspace = true }
 agntcy-slim-signal = { workspace = true }
 agntcy-slim-tracing = { workspace = true }
+agntcy-slim-version = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true }
 duration-string = { workspace = true }
@@ -35,6 +36,9 @@ tracing = { workspace = true }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 jemallocator = { workspace = true }
+
+[build-dependencies]
+agntcy-slim-version = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/data-plane/core/slim/build.rs
+++ b/data-plane/core/slim/build.rs
@@ -1,36 +1,6 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
-use std::process::Command;
-
-fn set_env(name: &str, cmd: &mut Command) {
-    let value = match cmd.output() {
-        Ok(output) => String::from_utf8(output.stdout).unwrap(),
-        Err(err) => {
-            println!("cargo:warning={}", err);
-            "".to_string()
-        }
-    };
-    println!("cargo:rustc-env={}={}", name, value);
-}
-
-pub fn main() {
-    set_env(
-        "GIT_SHA",
-        Command::new("git").args(["rev-parse", "--short", "HEAD"]),
-    );
-
-    // Capture the ISO 8601 formatted UTC time.
-    set_env(
-        "BUILD_DATE",
-        Command::new("date").args(["-u", "+%Y-%m-%dT%H:%M:%SZ"]),
-    );
-
-    set_env(
-        "VERSION",
-        Command::new("git").args(["describe", "--tags", "--always", "--match", "slim-v*"]),
-    );
-
-    let profile = std::env::var("PROFILE").expect("PROFILE must be set");
-    println!("cargo:rustc-env=PROFILE={profile}");
+fn main() {
+    slim_version::build::setup("slim-v*");
 }

--- a/data-plane/core/tracing/Cargo.toml
+++ b/data-plane/core/tracing/Cargo.toml
@@ -10,6 +10,7 @@ name = "slim_tracing"
 
 [dependencies]
 agntcy-slim-config = { workspace = true }
+agntcy-slim-version = { workspace = true }
 once_cell = { workspace = true }
 opentelemetry = { workspace = true }
 opentelemetry-otlp = { workspace = true }

--- a/data-plane/core/version/Cargo.toml
+++ b/data-plane/core/version/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "agntcy-slim-version"
+version.workspace = true
+edition = { workspace = true }
+license = { workspace = true }
+description = "SLIM version information."
+
+[lib]
+name = "slim_version"

--- a/data-plane/core/version/build.rs
+++ b/data-plane/core/version/build.rs
@@ -1,0 +1,36 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+use std::process::Command;
+
+fn set_env(name: &str, cmd: &mut Command) {
+    let value = match cmd.output() {
+        Ok(output) => String::from_utf8(output.stdout)
+            .unwrap_or_default()
+            .trim()
+            .to_string(),
+        Err(err) => {
+            println!("cargo:warning={err}");
+            String::new()
+        }
+    };
+    println!("cargo:rustc-env={name}={value}");
+}
+
+pub fn main() {
+    set_env(
+        "GIT_SHA",
+        Command::new("git").args(["rev-parse", "--short", "HEAD"]),
+    );
+    set_env(
+        "BUILD_DATE",
+        Command::new("date").args(["-u", "+%Y-%m-%dT%H:%M:%SZ"]),
+    );
+    set_env(
+        "VERSION",
+        Command::new("git").args(["describe", "--tags", "--always", "--match", "slim-v*"]),
+    );
+
+    let profile = std::env::var("PROFILE").unwrap_or_else(|_| "unknown".to_string());
+    println!("cargo:rustc-env=PROFILE={profile}");
+}

--- a/data-plane/core/version/src/lib.rs
+++ b/data-plane/core/version/src/lib.rs
@@ -1,0 +1,136 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+/// Return the current SLIM version.
+///
+/// This is in sync with the crate version defined in Cargo.toml.
+pub fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+/// Return the git SHA of the build.
+pub fn git_sha() -> &'static str {
+    env!("GIT_SHA")
+}
+
+/// Return the build date in ISO 8601 UTC format.
+pub fn build_date() -> &'static str {
+    env!("BUILD_DATE")
+}
+
+/// Return the build profile (e.g. `debug` or `release`).
+pub fn profile() -> &'static str {
+    env!("PROFILE")
+}
+
+/// Structured build information.
+#[derive(Copy, Clone, Debug, Default, Hash, PartialEq, Eq)]
+pub struct BuildInfo {
+    pub version: &'static str,
+    pub git_sha: &'static str,
+    pub date: &'static str,
+    pub profile: &'static str,
+}
+
+impl std::fmt::Display for BuildInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Version:\t{}\nBuild Date:\t{}\nGit SHA:\t{}\nProfile:\t{}",
+            self.version, self.date, self.git_sha, self.profile
+        )
+    }
+}
+
+/// Return a [`BuildInfo`] populated with compile-time values.
+pub fn build_info() -> BuildInfo {
+    BuildInfo {
+        version: version(),
+        git_sha: git_sha(),
+        date: build_date(),
+        profile: profile(),
+    }
+}
+
+/// Helpers for use inside `build.rs` scripts.
+///
+/// Add `agntcy-slim-version` to `[build-dependencies]` to use these.
+pub mod build {
+    use std::process::Command;
+
+    /// Run `cmd`, trim its stdout, and emit `cargo:rustc-env=NAME=<value>`.
+    ///
+    /// On error, emits a `cargo:warning` and uses an empty string.
+    pub fn set_env(name: &str, cmd: &mut Command) {
+        let value = match cmd.output() {
+            Ok(output) => String::from_utf8(output.stdout)
+                .unwrap_or_default()
+                .trim()
+                .to_string(),
+            Err(err) => {
+                println!("cargo:warning={err}");
+                String::new()
+            }
+        };
+        println!("cargo:rustc-env={name}={value}");
+    }
+
+    /// Emit `cargo:rustc-env=GIT_SHA=<short hash>`.
+    pub fn set_git_sha() {
+        set_env(
+            "GIT_SHA",
+            Command::new("git").args(["rev-parse", "--short", "HEAD"]),
+        );
+    }
+
+    /// Emit `cargo:rustc-env=BUILD_DATE=<ISO 8601 UTC timestamp>`.
+    pub fn set_build_date() {
+        set_env(
+            "BUILD_DATE",
+            Command::new("date").args(["-u", "+%Y-%m-%dT%H:%M:%SZ"]),
+        );
+    }
+
+    /// Emit `cargo:rustc-env=VERSION=<git describe>` matching `tag_pattern`.
+    pub fn set_version(tag_pattern: &str) {
+        set_env(
+            "VERSION",
+            Command::new("git").args(["describe", "--tags", "--always", "--match", tag_pattern]),
+        );
+    }
+
+    /// Emit `cargo:rustc-env=PROFILE=<debug|release>`.
+    pub fn set_profile() {
+        let profile = std::env::var("PROFILE").unwrap_or_else(|_| "unknown".to_string());
+        println!("cargo:rustc-env=PROFILE={profile}");
+    }
+
+    /// Emit all standard SLIM build environment variables.
+    ///
+    /// Sets `GIT_SHA`, `BUILD_DATE`, `VERSION` (matched against `tag_pattern`), and `PROFILE`.
+    pub fn setup(tag_pattern: &str) {
+        set_git_sha();
+        set_build_date();
+        set_version(tag_pattern);
+        set_profile();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_version() {
+        assert_eq!(version().to_string(), env!("CARGO_PKG_VERSION").to_string());
+    }
+
+    #[test]
+    fn test_build_info() {
+        let info = build_info();
+        assert_eq!(info.version, env!("CARGO_PKG_VERSION"));
+        assert!(!info.git_sha.is_empty());
+        assert!(!info.date.is_empty());
+        assert!(!info.profile.is_empty());
+    }
+}

--- a/data-plane/slimctl/Cargo.toml
+++ b/data-plane/slimctl/Cargo.toml
@@ -28,6 +28,7 @@ agntcy-slim-datapath = { workspace = true }
 agntcy-slim-service = { workspace = true }
 agntcy-slim-signal = { workspace = true }
 agntcy-slim-tracing = { workspace = true }
+agntcy-slim-version = { workspace = true }
 
 # Error handling
 anyhow = { workspace = true }
@@ -58,6 +59,7 @@ url = { workspace = true }
 uuid = { workspace = true }
 
 [build-dependencies]
+agntcy-slim-version = { workspace = true }
 protoc-bin-vendored = { workspace = true }
 tonic-prost-build = { workspace = true }
 

--- a/data-plane/slimctl/build.rs
+++ b/data-plane/slimctl/build.rs
@@ -1,36 +1,8 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
-use std::process::Command;
-
-fn set_env(name: &str, cmd: &mut Command) {
-    let value = match cmd.output() {
-        Ok(output) => String::from_utf8(output.stdout).unwrap_or_default(),
-        Err(err) => {
-            println!("cargo:warning={}", err);
-            "".to_string()
-        }
-    };
-    println!("cargo:rustc-env={}={}", name, value.trim());
-}
-
 fn main() {
-    // Set build info environment variables
-    set_env(
-        "GIT_SHA",
-        Command::new("git").args(["rev-parse", "--short", "HEAD"]),
-    );
-    set_env(
-        "BUILD_DATE",
-        Command::new("date").args(["-u", "+%Y-%m-%dT%H:%M:%SZ"]),
-    );
-    set_env(
-        "VERSION",
-        Command::new("git").args(["describe", "--tags", "--always", "--match", "slimctl-v*"]),
-    );
-
-    let profile = std::env::var("PROFILE").unwrap_or_else(|_| "unknown".to_string());
-    println!("cargo:rustc-env=PROFILE={profile}");
+    slim_version::build::setup("slimctl-v*");
 
     // Compile proto files
     let protoc_path = protoc_bin_vendored::protoc_bin_path().unwrap();
@@ -39,18 +11,6 @@ fn main() {
         std::env::set_var("PROTOC", protoc_path);
     }
 
-    // Locate the proto directory.
-    //
-    // During normal workspace development the canonical files live at
-    // <repo-root>/proto/ (three levels above data-plane/core/slimctl/).
-    // The crate-local proto/ directory holds symlinks that point there, so
-    // both strategies ultimately read the same files.
-    //
-    // When running `cargo publish` the crate is packaged without the rest of
-    // the repository.  Cargo resolves symlinks when creating the tarball, so
-    // the published package contains the real proto files under proto/.
-    // build.rs therefore always uses the crate-local proto/ as its input; no
-    // separate copy step is required.
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     let proto_dir = std::path::Path::new(&manifest_dir).join("proto");
 


### PR DESCRIPTION
# Description

Add agntcy-slim-version crate as single source of truth for version and build info

Fixes: #1359 

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
