### PR TITLE
feat: expose json config in bindings

### DIFF
--- a/data-plane/bindings/python/examples/common.py
+++ b/data-plane/bindings/python/examples/common.py
@@ -17,6 +17,7 @@ import argparse
 import base64  # Used to decode base64-encoded JWKS content (when provided).
 import datetime  # Used for timedelta in JWT configs
 import json  # Used for parsing JWKS JSON and dynamic option values.
+from pathlib import Path
 from typing import Any
 
 import slim_bindings  # The Python bindings package we are demonstrating.
@@ -220,7 +221,17 @@ async def create_local_app(config: BaseConfig) -> tuple[slim_bindings.App, int]:
     # Convert local identifier to a strongly typed Name.
     local_name = slim_bindings.Name.from_string(config.local)
 
-    client_config = slim_bindings.new_insecure_client_config(config.slim)
+    if config.slim_client_config:
+        json_text = Path(config.slim_client_config).read_text(encoding="utf-8")
+        try:
+            client_config = slim_bindings.new_config_from_json(json_text)
+        except slim_bindings.SlimError as e:
+            raise RuntimeError(
+                f"Invalid slim client config JSON ({config.slim_client_config}): {e}"
+            ) from e
+    else:
+        client_config = slim_bindings.new_insecure_client_config(config.slim)
+
     conn_id = await service.connect_async(client_config)
 
     # Determine authentication mode
@@ -295,7 +306,19 @@ def create_base_parser(description: str) -> argparse.ArgumentParser:
         "--slim",
         type=str,
         default="http://127.0.0.1:46357",
-        help="SLIM remote endpoint URL (default: http://127.0.0.1:46357)",
+        help="SLIM remote endpoint URL (default: http://127.0.0.1:46357); ignored if --slim-config is set",
+    )
+
+    parser.add_argument(
+        "--slim-config",
+        type=str,
+        dest="slim_client_config",
+        default=None,
+        help=(
+            "Path to JSON file for full gRPC ClientConfig "
+            "(same schema as data-plane/core/config/src/grpc/schema/client-config.schema.json); "
+            "when set, overrides --slim for the dataplane connection"
+        ),
     )
 
     # Feature flags

--- a/data-plane/bindings/python/examples/config.py
+++ b/data-plane/bindings/python/examples/config.py
@@ -59,7 +59,15 @@ class BaseConfig(BaseSettings):
     # Service connection
     slim: str = Field(
         default="http://127.0.0.1:46357",
-        description="SLIM remote endpoint URL",
+        description="SLIM remote endpoint URL (used when slim_client_config is not set)",
+    )
+
+    slim_client_config: str | None = Field(
+        default=None,
+        description=(
+            "Path to JSON file for full gRPC ClientConfig "
+            "(schema: data-plane/core/config/src/grpc/schema/client-config.schema.json)"
+        ),
     )
 
     # Feature flags
@@ -121,7 +129,7 @@ class BaseConfig(BaseSettings):
             return [a.strip() for a in v.split(",") if a.strip()]
         return v
 
-    @field_validator("jwt", "spire_trust_bundle", mode="after")
+    @field_validator("jwt", "spire_trust_bundle", "slim_client_config", mode="after")
     @classmethod
     def validate_file_paths(cls, v: str | None) -> str | None:
         """Validate that file paths exist if provided."""

--- a/data-plane/bindings/rust/src/client_config.rs
+++ b/data-plane/bindings/rust/src/client_config.rs
@@ -16,7 +16,10 @@ use slim_config::grpc::client::{
 };
 
 use crate::common_config::{ClientAuthenticationConfig, TlsClientConfig};
+use crate::errors::SlimError;
 use crate::transport_protocol::TransportProtocol;
+
+use slim_config::component::configuration::Configuration;
 
 /// Compression type for gRPC messages
 #[derive(uniffi::Enum, Clone, Debug, PartialEq)]
@@ -436,10 +439,27 @@ pub fn new_secure_client_config(endpoint: String) -> ClientConfig {
     }
 }
 
+/// Parse and validate a SLIM gRPC client configuration from JSON.
+///
+/// The JSON must match [`CoreClientConfig`] (same as
+/// `data-plane/core/config/src/grpc/schema/client-config.schema.json`).
+#[uniffi::export]
+pub fn new_config_from_json(json: String) -> Result<ClientConfig, SlimError> {
+    let core: CoreClientConfig =
+        serde_json::from_str(&json).map_err(|e| SlimError::ConfigError {
+            message: format!("invalid JSON for client config: {e}"),
+        })?;
+    core.validate().map_err(|e| SlimError::ConfigError {
+        message: e.to_string(),
+    })?;
+    Ok(core.into())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::common_config::{CaSource, TlsSource};
+    use crate::errors::SlimError;
     use slim_config::transport::TransportProtocol as CoreTransportProtocol;
     use std::collections::HashMap;
 
@@ -537,6 +557,31 @@ mod tests {
         assert_eq!(config.request_timeout, None);
         assert_eq!(config.auth, None);
         assert_eq!(config.backoff, None);
+    }
+
+    #[test]
+    fn new_config_from_json_minimal_insecure() {
+        let json = r#"{"endpoint":"http://127.0.0.1:46357","tls":{"insecure":true}}"#;
+        let cfg = new_config_from_json(json.to_string()).expect("parse");
+        assert_eq!(cfg.endpoint, "http://127.0.0.1:46357");
+        assert!(cfg.tls.insecure);
+    }
+
+    #[test]
+    fn new_config_from_json_invalid_json() {
+        let err = new_config_from_json("{not json".to_string()).unwrap_err();
+        assert!(matches!(err, SlimError::ConfigError { .. }));
+        let SlimError::ConfigError { message } = err else {
+            unreachable!();
+        };
+        assert!(message.contains("invalid JSON"), "message was: {message}");
+    }
+
+    #[test]
+    fn new_config_from_json_missing_endpoint() {
+        let json = r#"{"endpoint":"","tls":{"insecure":true}}"#;
+        let err = new_config_from_json(json.to_string()).unwrap_err();
+        assert!(matches!(err, SlimError::ConfigError { .. }));
     }
 
     #[test]

--- a/data-plane/bindings/rust/src/lib.rs
+++ b/data-plane/bindings/rust/src/lib.rs
@@ -68,7 +68,7 @@ pub use app::{App, Direction, SessionWithCompletion};
 pub use build_info::{BuildInfo, get_build_info, get_version};
 pub use client_config::{
     BackoffConfig, ClientConfig, ExponentialBackoff, KeepaliveConfig, ProxyConfig,
-    new_insecure_client_config,
+    new_config_from_json, new_insecure_client_config,
 };
 pub use common_config::{
     BasicAuth, CaSource, ClientAuthenticationConfig, ServerAuthenticationConfig, SpireConfig,


### PR DESCRIPTION
# Description

Expose a new client config func on bindings: new_config_from_json to create ClientConfig from a json.
Add `--slim-config` param to python bindings examples to be able to pass more complex connection configs including tls settings.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
