### PR TITLE
chore: release

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim"
-version = "1.3.0-rc.1"
+version = "1.3.0-rc.2"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-service",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-auth"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-testing",
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-testing",
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.11.5"
+version = "0.12.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-tracing",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.8.8"
+version = "0.8.9"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-signal"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "agntcy-slim-version",
  "tokio",
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -358,7 +358,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-version"
-version = "1.3.0-rc.1"
+version = "1.3.0-rc.2"
 
 [[package]]
 name = "agntcy-slimctl"

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -38,19 +38,19 @@ resolver = "2"
 
 [workspace.dependencies]
 # Local dependencies
-agntcy-slim = { path = "core/slim", version = "1.3.0-rc.1" }
-agntcy-slim-auth = { path = "core/auth", version = "0.5.2" }
+agntcy-slim = { path = "core/slim", version = "1.3.0-rc.2" }
+agntcy-slim-auth = { path = "core/auth", version = "0.6.0" }
 agntcy-slim-bindings = { path = "bindings/rust", version = "1.3.0-rc.1" }
-agntcy-slim-config = { path = "core/config", version = "0.7.0" }
-agntcy-slim-controller = { path = "core/controller", version = "0.4.9" }
-agntcy-slim-datapath = { path = "core/datapath", version = "0.11.5" }
-agntcy-slim-mls = { path = "core/mls", version = "0.1.11" }
-agntcy-slim-service = { path = "core/service", version = "0.8.8", default-features = false }
-agntcy-slim-session = { path = "core/session", version = "0.1.8" }
-agntcy-slim-signal = { path = "core/signal", version = "0.1.5" }
+agntcy-slim-config = { path = "core/config", version = "0.8.0" }
+agntcy-slim-controller = { path = "core/controller", version = "0.4.10" }
+agntcy-slim-datapath = { path = "core/datapath", version = "0.12.0" }
+agntcy-slim-mls = { path = "core/mls", version = "0.1.12" }
+agntcy-slim-service = { path = "core/service", version = "0.8.9", default-features = false }
+agntcy-slim-session = { path = "core/session", version = "0.1.9" }
+agntcy-slim-signal = { path = "core/signal", version = "0.1.6" }
 agntcy-slim-testing = { path = "testing" }
-agntcy-slim-tracing = { path = "core/tracing", version = "0.3.5" }
-agntcy-slim-version = { path = "core/version", version = "1.3.0-rc.1" }
+agntcy-slim-tracing = { path = "core/tracing", version = "0.3.6" }
+agntcy-slim-version = { path = "core/version", version = "1.3.0-rc.2" }
 agntcy-slimctl = { path = "slimctl", version = "1.3.0-rc.1" }
 
 anyhow = "1.0.98"
@@ -147,7 +147,7 @@ uuid = { version = "1.15.1", features = ["v4"] }
 wiremock = "0.6"
 
 [workspace.package]
-version = "1.3.0-rc.1"
+version = "1.3.0-rc.2"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/agntcy/slim"

--- a/data-plane/bindings/rust/CHANGELOG.md
+++ b/data-plane/bindings/rust/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0-rc.1](https://github.com/agntcy/slim/compare/slim-bindings-v1.3.0-rc.0...slim-bindings-v1.3.0-rc.1) - 2026-03-26
+
+### Added
+
+- Fix dotnet bindings ([#1403](https://github.com/agntcy/slim/pull/1403))
+- MLS identity key integration and security dependency upgrades ([#1394](https://github.com/agntcy/slim/pull/1394))
+- add link negotiation protocol between SLIM nodes ([#1353](https://github.com/agntcy/slim/pull/1353))
+
+### Other
+
+- upgrade versions for 1.3.0-rc.1 ([#1406](https://github.com/agntcy/slim/pull/1406))
+
 ## [1.3.0-rc.0](https://github.com/agntcy/slim/compare/slim-bindings-v1.2.0...slim-bindings-v1.3.0-rc.0) - 2026-03-20
 
 ### Added

--- a/data-plane/core/auth/CHANGELOG.md
+++ b/data-plane/core/auth/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/agntcy/slim/compare/slim-auth-v0.5.2...slim-auth-v0.6.0) - 2026-03-26
+
+### Added
+
+- MLS identity key integration and security dependency upgrades ([#1394](https://github.com/agntcy/slim/pull/1394))
+
 ## [0.5.2](https://github.com/agntcy/slim/compare/slim-auth-v0.5.1...slim-auth-v0.5.2) - 2026-03-20
 
 ### Added

--- a/data-plane/core/auth/Cargo.toml
+++ b/data-plane/core/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-auth"
-version = "0.5.2"
+version = "0.6.0"
 license = { workspace = true }
 edition = { workspace = true }
 description = "Authentication utilities for the Agntcy Slim framework"

--- a/data-plane/core/config/CHANGELOG.md
+++ b/data-plane/core/config/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/agntcy/slim/compare/slim-config-v0.7.0...slim-config-v0.8.0) - 2026-03-26
+
+### Added
+
+- MLS identity key integration and security dependency upgrades ([#1394](https://github.com/agntcy/slim/pull/1394))
+- add link negotiation protocol between SLIM nodes ([#1353](https://github.com/agntcy/slim/pull/1353))
+
 ## [0.7.0](https://github.com/agntcy/slim/compare/slim-config-v0.6.3...slim-config-v0.7.0) - 2026-03-20
 
 ### Added

--- a/data-plane/core/config/Cargo.toml
+++ b/data-plane/core/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-config"
-version = "0.7.0"
+version = "0.8.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Configuration utilities"

--- a/data-plane/core/controller/CHANGELOG.md
+++ b/data-plane/core/controller/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.10](https://github.com/agntcy/slim/compare/slim-controller-v0.4.9...slim-controller-v0.4.10) - 2026-03-26
+
+### Added
+
+- ack for remote subscriptions ([#1364](https://github.com/agntcy/slim/pull/1364))
+- MLS identity key integration and security dependency upgrades ([#1394](https://github.com/agntcy/slim/pull/1394))
+- add link negotiation protocol between SLIM nodes ([#1353](https://github.com/agntcy/slim/pull/1353))
+
 ## [0.4.9](https://github.com/agntcy/slim/compare/slim-controller-v0.4.8...slim-controller-v0.4.9) - 2026-03-20
 
 ### Added

--- a/data-plane/core/controller/Cargo.toml
+++ b/data-plane/core/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-controller"
-version = "0.4.9"
+version = "0.4.10"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Controller service and control API to configure the SLIM data plane through the control plane."

--- a/data-plane/core/datapath/CHANGELOG.md
+++ b/data-plane/core/datapath/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/agntcy/slim/compare/slim-datapath-v0.11.5...slim-datapath-v0.12.0) - 2026-03-26
+
+### Added
+
+- ack for remote subscriptions ([#1364](https://github.com/agntcy/slim/pull/1364))
+- add link negotiation protocol between SLIM nodes ([#1353](https://github.com/agntcy/slim/pull/1353))
+
+### Fixed
+
+- race condition between subscription forwarding and link negotiation ([#1404](https://github.com/agntcy/slim/pull/1404))
+
 ## [0.11.5](https://github.com/agntcy/slim/compare/slim-datapath-v0.11.4...slim-datapath-v0.11.5) - 2026-03-20
 
 ### Added

--- a/data-plane/core/datapath/Cargo.toml
+++ b/data-plane/core/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-datapath"
-version = "0.11.5"
+version = "0.12.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Core data plane functionality for SLIM"

--- a/data-plane/core/mls/CHANGELOG.md
+++ b/data-plane/core/mls/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12](https://github.com/agntcy/slim/compare/slim-mls-v0.1.11...slim-mls-v0.1.12) - 2026-03-26
+
+### Added
+
+- MLS identity key integration and security dependency upgrades ([#1394](https://github.com/agntcy/slim/pull/1394))
+
 ## [0.1.11](https://github.com/agntcy/slim/compare/slim-mls-v0.1.10...slim-mls-v0.1.11) - 2026-03-20
 
 ### Added

--- a/data-plane/core/mls/Cargo.toml
+++ b/data-plane/core/mls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-mls"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.11"
+version = "0.1.12"
 description = "Messaging Layer Security for SLIM data plane."
 
 [lib]

--- a/data-plane/core/service/CHANGELOG.md
+++ b/data-plane/core/service/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.9](https://github.com/agntcy/slim/compare/slim-service-v0.8.8...slim-service-v0.8.9) - 2026-03-26
+
+### Added
+
+- ack for remote subscriptions ([#1364](https://github.com/agntcy/slim/pull/1364))
+- add link negotiation protocol between SLIM nodes ([#1353](https://github.com/agntcy/slim/pull/1353))
+
 ## [0.8.8](https://github.com/agntcy/slim/compare/slim-service-v0.8.7...slim-service-v0.8.8) - 2026-03-20
 
 ### Added

--- a/data-plane/core/service/Cargo.toml
+++ b/data-plane/core/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-service"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.8.8"
+version = "0.8.9"
 description = "Main service and public API to interact with SLIM data plane."
 
 [lib]

--- a/data-plane/core/session/CHANGELOG.md
+++ b/data-plane/core/session/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/agntcy/slim/compare/slim-session-v0.1.8...slim-session-v0.1.9) - 2026-03-26
+
+### Added
+
+- ack for remote subscriptions ([#1364](https://github.com/agntcy/slim/pull/1364))
+- MLS identity key integration and security dependency upgrades ([#1394](https://github.com/agntcy/slim/pull/1394))
+
+### Fixed
+
+- *(session)* delay invite ACK until MLS update sequence completes ([#1393](https://github.com/agntcy/slim/pull/1393))
+
 ## [0.1.8](https://github.com/agntcy/slim/compare/slim-session-v0.1.7...slim-session-v0.1.8) - 2026-03-20
 
 ### Added

--- a/data-plane/core/session/Cargo.toml
+++ b/data-plane/core/session/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-session"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.8"
+version = "0.1.9"
 description = "SLIM session internal implementation."
 
 [lib]

--- a/data-plane/core/signal/CHANGELOG.md
+++ b/data-plane/core/signal/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/agntcy/slim/compare/slim-signal-v0.1.5...slim-signal-v0.1.6) - 2026-03-26
+
+### Other
+
+- updated the following local packages: agntcy-slim-version
+
 ## [0.1.5](https://github.com/agntcy/slim/compare/slim-signal-v0.1.4...slim-signal-v0.1.5) - 2026-03-20
 
 ### Added

--- a/data-plane/core/signal/Cargo.toml
+++ b/data-plane/core/signal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-signal"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.5"
+version = "0.1.6"
 description = "Small library to handle OS signals."
 
 [lib]

--- a/data-plane/core/slim/CHANGELOG.md
+++ b/data-plane/core/slim/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0-rc.2](https://github.com/agntcy/slim/compare/slim-v1.3.0-rc.1...slim-v1.3.0-rc.2) - 2026-03-26
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [1.3.0-rc.0](https://github.com/agntcy/slim/compare/slim-v1.1.0...slim-v1.3.0-rc.0) - 2026-03-20
 
 ### Added

--- a/data-plane/core/tracing/CHANGELOG.md
+++ b/data-plane/core/tracing/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.6](https://github.com/agntcy/slim/compare/slim-tracing-v0.3.5...slim-tracing-v0.3.6) - 2026-03-26
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-config
+
 ## [0.3.5](https://github.com/agntcy/slim/compare/slim-tracing-v0.3.4...slim-tracing-v0.3.5) - 2026-03-20
 
 ### Added

--- a/data-plane/core/tracing/Cargo.toml
+++ b/data-plane/core/tracing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-tracing"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.5"
+version = "0.3.6"
 description = "Observability for SLIM data plane: logs, traces and metrics infrastructure."
 
 [lib]

--- a/data-plane/slimctl/CHANGELOG.md
+++ b/data-plane/slimctl/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0-rc.1](https://github.com/agntcy/slim/compare/slimctl-v1.3.0-rc.0...slimctl-v1.3.0-rc.1) - 2026-03-26
+
+### Other
+
+- upgrade versions for 1.3.0-rc.1 ([#1406](https://github.com/agntcy/slim/pull/1406))
+
 ## [1.3.0-rc.0](https://github.com/agntcy/slim/compare/slimctl-v1.2.0...slimctl-v1.3.0-rc.0) - 2026-03-20
 
 ### Added

--- a/data-plane/slimrpc-compiler/CHANGELOG.md
+++ b/data-plane/slimrpc-compiler/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0-rc.1](https://github.com/agntcy/slim/compare/protoc-slimrpc-plugin-v1.2.0...protoc-slimrpc-plugin-v1.3.0-rc.1) - 2026-03-26
+
+### Added
+
+- Fix dotnet bindings ([#1403](https://github.com/agntcy/slim/pull/1403))
+- Add slimrpc support for .NET (C#) ([#1345](https://github.com/agntcy/slim/pull/1345))
+
+### Other
+
+- upgrade versions for 1.3.0-rc.1 ([#1406](https://github.com/agntcy/slim/pull/1406))
+
 ## [1.2.0](https://github.com/agntcy/slim/compare/protoc-slimrpc-plugin-v1.1.0...protoc-slimrpc-plugin-v1.2.0) - 2026-03-20
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-version`: 1.3.0-rc.1 -> 1.3.0-rc.2
* `agntcy-slim-auth`: 0.5.2 -> 0.6.0 (⚠ API breaking changes)
* `agntcy-slim-config`: 0.7.0 -> 0.8.0 (⚠ API breaking changes)
* `agntcy-slim-datapath`: 0.11.5 -> 0.12.0 (⚠ API breaking changes)
* `agntcy-slim-mls`: 0.1.11 -> 0.1.12 (✓ API compatible changes)
* `agntcy-slim-session`: 0.1.8 -> 0.1.9 (✓ API compatible changes)
* `agntcy-slim-controller`: 0.4.9 -> 0.4.10 (✓ API compatible changes)
* `agntcy-slim-service`: 0.8.8 -> 0.8.9 (✓ API compatible changes)
* `agntcy-slim`: 1.3.0-rc.1 -> 1.3.0-rc.2 (✓ API compatible changes)
* `agntcy-slim-bindings`: 1.3.0-rc.0 -> 1.3.0-rc.1
* `agntcy-slimctl`: 1.3.0-rc.0 -> 1.3.0-rc.1
* `agntcy-protoc-slimrpc-plugin`: 1.2.0 -> 1.3.0-rc.1
* `agntcy-slim-tracing`: 0.3.5 -> 0.3.6
* `agntcy-slim-signal`: 0.1.5 -> 0.1.6

### ⚠ `agntcy-slim-auth` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant AuthError:MlsNotSupported in /tmp/.tmpb9Xcp3/slim/data-plane/core/auth/src/errors.rs:175
  variant AuthError:MlsKeyGenerationFailed in /tmp/.tmpb9Xcp3/slim/data-plane/core/auth/src/errors.rs:177
  variant AuthError:PublicKeyNotFound in /tmp/.tmpb9Xcp3/slim/data-plane/core/auth/src/errors.rs:179
  variant AuthError:SubjectNotFound in /tmp/.tmpb9Xcp3/slim/data-plane/core/auth/src/errors.rs:181

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant AuthError::SpiffeCustomAudiencesJwtSourceClosed, previously in file /tmp/.tmpAEHooz/agntcy-slim-auth/src/errors.rs:165
  variant AuthError::SpiffeCustomAudiencesError, previously in file /tmp/.tmpAEHooz/agntcy-slim-auth/src/errors.rs:168

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_method_missing.ron

Failed in:
  method get_token_with_claims of trait TokenProvider, previously in file /tmp/.tmpAEHooz/agntcy-slim-auth/src/traits.rs:128
```

### ⚠ `agntcy-slim-config` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ClientConfig.link_id in /tmp/.tmpb9Xcp3/slim/data-plane/core/config/src/grpc/client.rs:336

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant ConfigError:InvalidLinkId in /tmp/.tmpb9Xcp3/slim/data-plane/core/config/src/grpc/errors.rs:79
```

### ⚠ `agntcy-slim-datapath` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Subscribe.subscription_id in /tmp/.tmpb9Xcp3/slim/data-plane/core/datapath/src/api/gen/dataplane.proto.v1.rs:10
  field Unsubscribe.subscription_id in /tmp/.tmpb9Xcp3/slim/data-plane/core/datapath/src/api/gen/dataplane.proto.v1.rs:19

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant MessageError::InvalidCommandPayloadType 9 -> 10 in /tmp/.tmpb9Xcp3/slim/data-plane/core/datapath/src/messages/utils.rs:85
  variant MessageError::BuilderErrorSourceRequired 10 -> 11 in /tmp/.tmpb9Xcp3/slim/data-plane/core/datapath/src/messages/utils.rs:92
  variant MessageError::BuilderErrorDestinationRequired 11 -> 12 in /tmp/.tmpb9Xcp3/slim/data-plane/core/datapath/src/messages/utils.rs:94

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant MessageError:LinkTypeNotSet in /tmp/.tmpb9Xcp3/slim/data-plane/core/datapath/src/messages/utils.rs:83
  variant MessageType:Link in /tmp/.tmpb9Xcp3/slim/data-plane/core/datapath/src/api/gen/dataplane.proto.v1.rs:51
  variant MessageType:SubscriptionAck in /tmp/.tmpb9Xcp3/slim/data-plane/core/datapath/src/api/gen/dataplane.proto.v1.rs:53
  variant DataPathError:SubscriptionIdNotFound in /tmp/.tmpb9Xcp3/slim/data-plane/core/datapath/src/errors.rs:33
  variant DataPathError:RemoteSubscriptionAckTimeout in /tmp/.tmpb9Xcp3/slim/data-plane/core/datapath/src/errors.rs:63
  variant DataPathError:RemoteSubscriptionAckError in /tmp/.tmpb9Xcp3/slim/data-plane/core/datapath/src/errors.rs:66

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  slim_datapath::tables::remote_subscription_table::RemoteSubscriptions::add_subscription now takes 5 parameters instead of 4, in /tmp/.tmpb9Xcp3/slim/data-plane/core/datapath/src/tables/remote_subscription_table.rs:52
  slim_datapath::tables::remote_subscription_table::RemoteSubscriptions::remove_subscription now takes 5 parameters instead of 4, in /tmp/.tmpb9Xcp3/slim/data-plane/core/datapath/src/tables/remote_subscription_table.rs:80
  slim_datapath::message_processing::MessageProcessor::process_message now takes 3 parameters instead of 2, in /tmp/.tmpb9Xcp3/slim/data-plane/core/datapath/src/message_processing.rs:842

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  SUBSCRIPTION_ACK_ERROR in file /tmp/.tmpAEHooz/agntcy-slim-datapath/src/messages/utils.rs:60
  SUBSCRIPTION_ACK_SUCCESS in file /tmp/.tmpAEHooz/agntcy-slim-datapath/src/messages/utils.rs:57
  SUBSCRIPTION_ACK_ID in file /tmp/.tmpAEHooz/agntcy-slim-datapath/src/messages/utils.rs:53

--- failure trait_method_parameter_count_changed: pub trait method parameter count changed ---

Description:
A trait method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_method_parameter_count_changed.ron

Failed in:
  SubscriptionTable::add_subscription now takes 4 instead of 3 parameters, in file /tmp/.tmpb9Xcp3/slim/data-plane/core/datapath/src/tables.rs:24
  SubscriptionTable::remove_subscription now takes 4 instead of 3 parameters, in file /tmp/.tmpb9Xcp3/slim/data-plane/core/datapath/src/tables.rs:32
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `agntcy-slim-version`

<blockquote>

## [1.3.0-rc.0](https://github.com/agntcy/slim/releases/tag/slim-version-v1.3.0-rc.0) - 2026-03-20

### Added

- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
</blockquote>

## `agntcy-slim-auth`

<blockquote>

## [0.6.0](https://github.com/agntcy/slim/compare/slim-auth-v0.5.2...slim-auth-v0.6.0) - 2026-03-26

### Added

- MLS identity key integration and security dependency upgrades ([#1394](https://github.com/agntcy/slim/pull/1394))
</blockquote>

## `agntcy-slim-config`

<blockquote>

## [0.8.0](https://github.com/agntcy/slim/compare/slim-config-v0.7.0...slim-config-v0.8.0) - 2026-03-26

### Added

- MLS identity key integration and security dependency upgrades ([#1394](https://github.com/agntcy/slim/pull/1394))
- add link negotiation protocol between SLIM nodes ([#1353](https://github.com/agntcy/slim/pull/1353))
</blockquote>

## `agntcy-slim-datapath`

<blockquote>

## [0.12.0](https://github.com/agntcy/slim/compare/slim-datapath-v0.11.5...slim-datapath-v0.12.0) - 2026-03-26

### Added

- ack for remote subscriptions ([#1364](https://github.com/agntcy/slim/pull/1364))
- add link negotiation protocol between SLIM nodes ([#1353](https://github.com/agntcy/slim/pull/1353))

### Fixed

- race condition between subscription forwarding and link negotiation ([#1404](https://github.com/agntcy/slim/pull/1404))
</blockquote>

## `agntcy-slim-mls`

<blockquote>

## [0.1.12](https://github.com/agntcy/slim/compare/slim-mls-v0.1.11...slim-mls-v0.1.12) - 2026-03-26

### Added

- MLS identity key integration and security dependency upgrades ([#1394](https://github.com/agntcy/slim/pull/1394))
</blockquote>

## `agntcy-slim-session`

<blockquote>

## [0.1.9](https://github.com/agntcy/slim/compare/slim-session-v0.1.8...slim-session-v0.1.9) - 2026-03-26

### Added

- ack for remote subscriptions ([#1364](https://github.com/agntcy/slim/pull/1364))
- MLS identity key integration and security dependency upgrades ([#1394](https://github.com/agntcy/slim/pull/1394))

### Fixed

- *(session)* delay invite ACK until MLS update sequence completes ([#1393](https://github.com/agntcy/slim/pull/1393))
</blockquote>

## `agntcy-slim-controller`

<blockquote>

## [0.4.10](https://github.com/agntcy/slim/compare/slim-controller-v0.4.9...slim-controller-v0.4.10) - 2026-03-26

### Added

- ack for remote subscriptions ([#1364](https://github.com/agntcy/slim/pull/1364))
- MLS identity key integration and security dependency upgrades ([#1394](https://github.com/agntcy/slim/pull/1394))
- add link negotiation protocol between SLIM nodes ([#1353](https://github.com/agntcy/slim/pull/1353))
</blockquote>

## `agntcy-slim-service`

<blockquote>

## [0.8.9](https://github.com/agntcy/slim/compare/slim-service-v0.8.8...slim-service-v0.8.9) - 2026-03-26

### Added

- ack for remote subscriptions ([#1364](https://github.com/agntcy/slim/pull/1364))
- add link negotiation protocol between SLIM nodes ([#1353](https://github.com/agntcy/slim/pull/1353))
</blockquote>

## `agntcy-slim`

<blockquote>

## [1.3.0-rc.2](https://github.com/agntcy/slim/compare/slim-v1.3.0-rc.1...slim-v1.3.0-rc.2) - 2026-03-26

### Other

- update Cargo.lock dependencies
</blockquote>

## `agntcy-slim-bindings`

<blockquote>

## [1.3.0-rc.1](https://github.com/agntcy/slim/compare/slim-bindings-v1.3.0-rc.0...slim-bindings-v1.3.0-rc.1) - 2026-03-26

### Added

- Fix dotnet bindings ([#1403](https://github.com/agntcy/slim/pull/1403))
- MLS identity key integration and security dependency upgrades ([#1394](https://github.com/agntcy/slim/pull/1394))
- add link negotiation protocol between SLIM nodes ([#1353](https://github.com/agntcy/slim/pull/1353))

### Other

- upgrade versions for 1.3.0-rc.1 ([#1406](https://github.com/agntcy/slim/pull/1406))
</blockquote>

## `agntcy-slimctl`

<blockquote>

## [1.3.0-rc.1](https://github.com/agntcy/slim/compare/slimctl-v1.3.0-rc.0...slimctl-v1.3.0-rc.1) - 2026-03-26

### Other

- upgrade versions for 1.3.0-rc.1 ([#1406](https://github.com/agntcy/slim/pull/1406))
</blockquote>

## `agntcy-protoc-slimrpc-plugin`

<blockquote>

## [1.3.0-rc.1](https://github.com/agntcy/slim/compare/protoc-slimrpc-plugin-v1.2.0...protoc-slimrpc-plugin-v1.3.0-rc.1) - 2026-03-26

### Added

- Fix dotnet bindings ([#1403](https://github.com/agntcy/slim/pull/1403))
- Add slimrpc support for .NET (C#) ([#1345](https://github.com/agntcy/slim/pull/1345))

### Other

- upgrade versions for 1.3.0-rc.1 ([#1406](https://github.com/agntcy/slim/pull/1406))
</blockquote>

## `agntcy-slim-tracing`

<blockquote>

## [0.3.6](https://github.com/agntcy/slim/compare/slim-tracing-v0.3.5...slim-tracing-v0.3.6) - 2026-03-26

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-config
</blockquote>

## `agntcy-slim-signal`

<blockquote>

## [0.1.6](https://github.com/agntcy/slim/compare/slim-signal-v0.1.5...slim-signal-v0.1.6) - 2026-03-26

### Other

- updated the following local packages: agntcy-slim-version
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).