### PR TITLE
fix: Adding back example code to gitignore

### DIFF
--- a/data-plane/bindings/dotnet/.gitignore
+++ b/data-plane/bindings/dotnet/.gitignore
@@ -9,8 +9,11 @@ runtimes/
 # Generated bindings (regenerated at build time)
 Slim/generated/
 
-# SlimRpc example generated C# (example.proto) is committed; regenerate via
-# `task slimrpc:generate-proto` in this directory when protos or the plugin change.
+# SlimRpc example: ignore generated output by default; committed files are exceptions.
+# Regenerate with `task slimrpc:generate-proto` when protos or the plugin change.
+Slim.Examples.SlimRpc/Generated/*
+!Slim.Examples.SlimRpc/Generated/Example.cs
+!Slim.Examples.SlimRpc/Generated/example_slimrpc.cs
 
 # IDE
 .vs/


### PR DESCRIPTION
# Description

Updating gitignore to not exclude example code

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
