### PR TITLE
feat(go-bindings): add versioning to Go bindings cache

### DIFF
--- a/.github/workflows/reusable-bindings-build-and-test.yaml
+++ b/.github/workflows/reusable-bindings-build-and-test.yaml
@@ -226,7 +226,12 @@ jobs:
 
       - name: Generate Go bindings
         run: |
-          task generate PROFILE=release
+          # Extract version from tag name if present (e.g., slim-bindings-v1.3.0 -> v1.3.0)
+          VERSION="${{ inputs.tag-name }}"
+          VERSION="${VERSION#slim-bindings-}"
+          VERSION="${VERSION:-devel}"
+
+          task generate PROFILE=release VERSION="$VERSION"
 
           echo "📁 slim-bindings-go files:"
           find ./slim_bindings -type f

--- a/data-plane/bindings/go/Taskfile.yaml
+++ b/data-plane/bindings/go/Taskfile.yaml
@@ -41,6 +41,8 @@ tasks:
   patch-cgo-directives:
     desc: Patch generated Go bindings with proper cgo directives
     internal: true
+    vars:
+      VERSION: '{{.VERSION | default "devel"}}'
     cmds:
       - echo "🔧 Patching cgo directives..."
       - |
@@ -52,11 +54,11 @@ tasks:
 
         /*
         #cgo CFLAGS: -I${SRCDIR}
-        #cgo linux,amd64 LDFLAGS: -L${SRCDIR} -L${SRCDIR}/../../../../../.cgo-cache/slim-bindings -lslim_bindings_x86_64_linux_gnu -lm
-        #cgo linux,arm64 LDFLAGS: -L${SRCDIR} -L${SRCDIR}/../../../../../.cgo-cache/slim-bindings -lslim_bindings_aarch64_linux_gnu -lm
-        #cgo darwin,amd64 LDFLAGS: -L${SRCDIR} -L${SRCDIR}/../../../../../.cgo-cache/slim-bindings -lslim_bindings_x86_64_darwin -Wl,-undefined,dynamic_lookup
-        #cgo darwin,arm64 LDFLAGS: -L${SRCDIR} -L${SRCDIR}/../../../../../.cgo-cache/slim-bindings -lslim_bindings_aarch64_darwin -Wl,-undefined,dynamic_lookup
-        #cgo windows,amd64 LDFLAGS: -L${SRCDIR} -L${SRCDIR}/../../../../../.cgo-cache/slim-bindings -lslim_bindings_x86_64_windows_gnu -lws2_32 -lbcrypt -ladvapi32 -luserenv -lntdll -lgcc_eh -lgcc -lkernel32 -lole32
+        #cgo linux,amd64 LDFLAGS: -L${SRCDIR} -L${SRCDIR}/../../../../../.cgo-cache/slim-bindings/{{.VERSION}} -lslim_bindings_x86_64_linux_gnu -lm
+        #cgo linux,arm64 LDFLAGS: -L${SRCDIR} -L${SRCDIR}/../../../../../.cgo-cache/slim-bindings/{{.VERSION}} -lslim_bindings_aarch64_linux_gnu -lm
+        #cgo darwin,amd64 LDFLAGS: -L${SRCDIR} -L${SRCDIR}/../../../../../.cgo-cache/slim-bindings/{{.VERSION}} -lslim_bindings_x86_64_darwin -Wl,-undefined,dynamic_lookup
+        #cgo darwin,arm64 LDFLAGS: -L${SRCDIR} -L${SRCDIR}/../../../../../.cgo-cache/slim-bindings/{{.VERSION}} -lslim_bindings_aarch64_darwin -Wl,-undefined,dynamic_lookup
+        #cgo windows,amd64 LDFLAGS: -L${SRCDIR} -L${SRCDIR}/../../../../../.cgo-cache/slim-bindings/{{.VERSION}} -lslim_bindings_x86_64_windows_gnu -lws2_32 -lbcrypt -ladvapi32 -luserenv -lntdll -lgcc_eh -lgcc -lkernel32 -lole32
         #include <slim_bindings.h>
         */
         import "C"
@@ -121,6 +123,8 @@ tasks:
       # exists and sources have not changed (sources/generates fingerprinting).
       - task: adapter:bindings:build:all
       - task: install-uniffi-bindgen-go
+    vars:
+      VERSION: '{{.VERSION | default "devel"}}'
     cmds:
       - echo "🔧 Generating Go bindings from compiled library..."
       - |
@@ -130,6 +134,8 @@ tasks:
       - task: copy-library
       - task: patch-header
       - task: patch-cgo-directives
+        vars:
+          VERSION: '{{.VERSION}}'
       - echo "✅ Bindings generated in slim_bindings/"
     silent: true
 
@@ -137,6 +143,8 @@ tasks:
     desc: Generate Go bindings using a cached native library
     deps:
       - task: install-uniffi-bindgen-go
+    vars:
+      VERSION: '{{.VERSION | default "devel"}}'
     cmds:
       - echo "🔧 Generating Go bindings from cached library..."
       - |
@@ -190,7 +198,7 @@ tasks:
         esac
 
         GOPATH_DIR=$(go env GOPATH)
-        CACHE_DIR="$GOPATH_DIR/.cgo-cache/slim-bindings"
+        CACHE_DIR="$GOPATH_DIR/.cgo-cache/slim-bindings/{{.VERSION}}"
         LIB_PATH="$CACHE_DIR/$LIB_NAME"
 
         if [ ! -f "$LIB_PATH" ]; then
@@ -204,6 +212,8 @@ tasks:
 
       - task: patch-header
       - task: patch-cgo-directives
+        vars:
+          VERSION: '{{.VERSION}}'
       - echo "✅ Bindings generated in slim_bindings/"
     silent: true
 

--- a/data-plane/bindings/go/slim_bindings/cmd/slim-bindings-setup/main.go
+++ b/data-plane/bindings/go/slim_bindings/cmd/slim-bindings-setup/main.go
@@ -116,14 +116,17 @@ func GetTarget(goos, arch, abi string) string {
 	return fmt.Sprintf("%s-unknown-%s", arch, goos)
 }
 
-// GetCacheDir returns the cache directory for SLIM bindings libraries.
+// GetCacheDir returns the versioned cache directory for SLIM bindings libraries.
+// Libraries are stored under $GOPATH/.cgo-cache/slim-bindings/<version> to support
+// side-by-side installations and reliable cache invalidation when upgrading.
 func GetCacheDir() (string, error) {
 	gopath := build.Default.GOPATH
 	if gopath == "" {
 		return "", fmt.Errorf("failed to determine GOPATH")
 	}
 
-	return filepath.Join(gopath, ".cgo-cache", cacheDirName), nil
+	version := Version()
+	return filepath.Join(gopath, ".cgo-cache", cacheDirName, version), nil
 }
 
 // TargetToLibraryName converts a Rust target triple to the library name format.

--- a/data-plane/bindings/go/slim_bindings/cmd/slim-bindings-setup/main_test.go
+++ b/data-plane/bindings/go/slim_bindings/cmd/slim-bindings-setup/main_test.go
@@ -4,9 +4,31 @@
 package main
 
 import (
+	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
+
+func TestGetCacheDir(t *testing.T) {
+	dir, err := GetCacheDir()
+	if err != nil {
+		t.Skipf("GetCacheDir() returned error (GOPATH not set?): %v", err)
+	}
+
+	version := Version()
+
+	// Cache dir must include the version as a subdirectory
+	expectedSuffix := filepath.Join("slim-bindings", version)
+	if !strings.HasSuffix(dir, expectedSuffix) {
+		t.Errorf("GetCacheDir() = %q, want path ending with %q", dir, expectedSuffix)
+	}
+
+	// Cache dir must be under .cgo-cache
+	if !strings.Contains(dir, ".cgo-cache") {
+		t.Errorf("GetCacheDir() = %q, want path containing .cgo-cache", dir)
+	}
+}
 
 func TestGetTarget(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
# Description

Fixes #1344.

The Go bindings cache stored native libraries in a flat directory (`$GOPATH/.cgo-cache/slim-bindings/`) with no version identifier. This caused two problems:

1. **Stale binaries**: upgrading `slim-bindings-go` to a new version would not re-fetch the native library if one already existed in the cache.
2. **Environment conflicts**: working on multiple projects requiring different binding versions was impossible since they all wrote to the same cache path.

Libraries are now stored under `$GOPATH/.cgo-cache/slim-bindings/<version>/` (e.g. `v1.3.0`), giving each module version an isolated slot in the cache.

### Implementation

- `GetCacheDir()` in `slim-bindings-setup` appends the module version (read from build info) to the cache path.
- `patch-cgo-directives` in `Taskfile.yaml` accepts a `VERSION` variable (default: `devel`) and embeds it into the CGO `LDFLAGS` at generation time.
- The `generate` and `generate-from-cache` tasks forward `VERSION` to `patch-cgo-directives`.
- `reusable-bindings-build-and-test.yaml` extracts the version from the release tag name and passes it to `task generate`, so release artifacts are built with the correct versioned path already baked in — no post-processing needed in the release workflow.

## Type of Change

- [x] Bugfix

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass