### PR TITLE
fix: race condition between subscription forwarding and link negotiation

### DIFF
--- a/data-plane/core/datapath/Cargo.toml
+++ b/data-plane/core/datapath/Cargo.toml
@@ -41,6 +41,7 @@ tonic-prost-build = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }
 tracing-test = { workspace = true, features = ["no-env-filter"] }
 
 [[bench]]

--- a/data-plane/core/datapath/src/message_processing.rs
+++ b/data-plane/core/datapath/src/message_processing.rs
@@ -524,52 +524,6 @@ impl MessageProcessor {
         }
     }
 
-    /// Re-send every subscription already forwarded on `out_conn` using the remote
-    /// ack path.  Called after link negotiation completes so that subscriptions
-    /// that were initially forwarded via the default path (before the remote peer's
-    /// version was known) are now confirmed with a full ACK round-trip.
-    fn upgrade_forwarded_subscriptions(&self, out_conn: u64) {
-        let subs = self
-            .forwarder()
-            .get_subscriptions_forwarded_on_connection(out_conn);
-
-        if subs.is_empty() {
-            debug!(%out_conn, "empty subscription set on connection");
-            return;
-        }
-
-        debug!(
-            %out_conn,
-            count = subs.len(),
-            "link negotiation complete: upgrading forwarded subscriptions to remote ack path",
-        );
-
-        for info in subs {
-            let subscription_id = match info.subscription_id() {
-                0 => rand::random::<u64>(),
-                id => id,
-            };
-            let msg = Message::builder()
-                .source(info.source().clone())
-                .destination(info.name().clone())
-                .identity(info.source_identity().clone())
-                .subscription_id(subscription_id)
-                .build_subscribe()
-                .unwrap();
-
-            let rx = self.internal.sub_ack_manager.register(subscription_id);
-            tokio::spawn(crate::subscription_ack::retry_loop(
-                self.clone(),
-                subscription_id,
-                msg,
-                out_conn,
-                out_conn, // in_connection – unused (no upstream to notify)
-                None,
-                rx,
-            ));
-        }
-    }
-
     /// Handle an inbound link negotiation message.
     ///
     /// On request (`is_reply == false`): validate the client-provided `link_id` as UUID v4,
@@ -627,12 +581,6 @@ impl MessageProcessor {
             // version atomically (replay-protected).
             if !conn.complete_negotiation_as_client(link_id, version) {
                 debug!(%in_connection, %link_id, "ignoring link negotiation reply");
-            } else {
-                // Link negotiation just completed on this outgoing connection.
-                // Re-send any subscriptions already forwarded on it using the remote
-                // ack path so the upstream ACK is obtained even though the initial
-                // subscribe fired before negotiation was done.
-                self.upgrade_forwarded_subscriptions(in_connection);
             }
         } else {
             // Server path: validates link_id as UUID v4, stores it together with the remote
@@ -817,6 +765,13 @@ impl MessageProcessor {
             .map(|c| crate::subscription_ack::supports(&c))
             .unwrap_or(false);
 
+        if !use_remote_ack {
+            debug!(
+                forward_to = forward,
+                "subscription: remote ack not available, link negotiation may not have completed yet"
+            );
+        }
+
         // As connection is deleted only after processing, at this point it must exist.
         let Some(connection) = self.forwarder().get_connection(in_conn) else {
             if let Some(id) = subscription_id {
@@ -844,33 +799,23 @@ impl MessageProcessor {
         }
 
         debug!(use_remote_ack, dst = %msg.get_dst(), forward_to = forward, "subscription: ack path decision");
-        if use_remote_ack {
-            debug!(%in_connection, "subscription: remote ack path");
+
+        let sub_id = subscription_id.unwrap_or(0);
+
+        // Always register subscription as at this point we might not have received the link negotiaiion
+        // yet, so the other side might reply just after
+        let rx = self.internal.sub_ack_manager.register(sub_id);
+
+        // Update local state and forward the subscription.
+        let result = self
+            .process_subscription_update_and_forward(msg.clone(), in_conn, forward, add, sub_id)
+            .await;
+
+        // Remote-ack path: on success, spawn a retry loop that waits for the
+        // downstream ACK (the initial send was already done above) and retries
+        // on timeout.
+        if use_remote_ack && result.is_ok() {
             let out_conn = forward.unwrap();
-
-            // Local update only (no forwarding yet).
-            let sub_id = subscription_id.unwrap_or(0);
-            if let Err(e) = self
-                .process_subscription_update_and_forward(msg.clone(), in_conn, None, add, sub_id)
-                .await
-            {
-                if let Some(id) = subscription_id {
-                    debug!(%in_connection, error = %e, "local subscription update failed, sending error ack");
-                    self.send_subscription_ack(in_connection, id, &Err(e)).await;
-                }
-                return Ok(());
-            }
-
-            // The subscription_id stays the same when forwarding — it is a
-            // globally unique identifier that travels with the subscription.
-            // Register it in the ack manager so we can correlate the response.
-            let source = msg.get_source();
-            let dst = msg.get_dst();
-            let identity = msg.get_identity();
-            self.forwarder()
-                .on_forwarded_subscription(source, dst, identity, out_conn, add, sub_id);
-
-            let rx = self.internal.sub_ack_manager.register(sub_id);
 
             tokio::spawn(crate::subscription_ack::retry_loop(
                 self.clone(),
@@ -885,13 +830,7 @@ impl MessageProcessor {
             return Ok(());
         }
 
-        // Default path: update local state and forward, then immediately ACK the requester.
-        debug!(%in_connection, forward = forward.is_some(), "subscription: default ack path");
-        let sub_id = subscription_id.unwrap_or(0);
-        let result = self
-            .process_subscription_update_and_forward(msg, in_conn, forward, add, sub_id)
-            .await;
-
+        // Default path (or remote-ack error fallback): ACK the requester immediately.
         if let Some(id) = subscription_id {
             debug!(%in_connection, ok = result.is_ok(), "sending immediate subscription ack");
             self.send_subscription_ack(in_connection, id, &result).await;
@@ -1892,5 +1831,280 @@ mod tests {
         assert_eq!(ack_inner.subscription_id, upstream_ack_id);
         assert!(!ack_inner.success);
         assert!(!ack_inner.error.is_empty());
+    }
+
+    // ── retry_loop tests ──────────────────────────────────────────────────────
+
+    fn make_test_subscribe(sub_id: u64) -> Message {
+        let source = Name::from_strings(["org", "ns", "src"]).with_id(1);
+        let destination = Name::from_strings(["org", "ns", "dst"]).with_id(2);
+        Message::builder()
+            .source(source)
+            .destination(destination)
+            .subscription_id(sub_id)
+            .build_subscribe()
+            .unwrap()
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_retry_loop_ack_received_before_timeout() {
+        // ACK arrives within the first wait window → no retry send.
+        let processor = MessageProcessor::new();
+        let (local_conn, _tx_local, mut rx_local) = processor
+            .register_local_connection(false)
+            .expect("failed to create local connection");
+        let (remote_conn, mut rx_remote) = make_server_conn(&processor);
+
+        let sub_id: u64 = 1000;
+        let msg = make_test_subscribe(sub_id);
+        let rx = processor.internal.sub_ack_manager.register(sub_id);
+
+        let proc_clone = processor.clone();
+        let handle = tokio::spawn(crate::subscription_ack::retry_loop(
+            proc_clone,
+            sub_id,
+            msg,
+            remote_conn,
+            local_conn,
+            Some(sub_id),
+            rx,
+        ));
+
+        // Resolve immediately — the loop should receive it before the timeout.
+        processor.internal.sub_ack_manager.resolve(sub_id, Ok(()));
+
+        handle.await.unwrap();
+
+        // No retry sends should have been made.
+        assert!(
+            rx_remote.try_recv().is_err(),
+            "no retry send expected when ack arrives before timeout"
+        );
+
+        // Upstream ack must have been sent.
+        let ack = rx_local
+            .try_recv()
+            .expect("upstream ack should have been sent")
+            .unwrap();
+        assert!(ack.get_subscription_ack().success);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_retry_loop_timeout_then_retry_send_then_ack() {
+        // First wait times out → retry send → ACK arrives on second wait.
+        let processor = MessageProcessor::new();
+        let (local_conn, _tx_local, mut rx_local) = processor
+            .register_local_connection(false)
+            .expect("failed to create local connection");
+        let (remote_conn, mut rx_remote) = make_server_conn(&processor);
+
+        let sub_id: u64 = 1001;
+        let msg = make_test_subscribe(sub_id);
+        let rx = processor.internal.sub_ack_manager.register(sub_id);
+
+        let proc_clone = processor.clone();
+        let handle = tokio::spawn(crate::subscription_ack::retry_loop(
+            proc_clone,
+            sub_id,
+            msg,
+            remote_conn,
+            local_conn,
+            Some(sub_id),
+            rx,
+        ));
+
+        // Let the first timeout elapse → triggers a retry send.
+        tokio::time::sleep(crate::subscription_ack::TIMEOUT + Duration::from_millis(100)).await;
+
+        // A retry message should have been sent.
+        let retried = rx_remote
+            .try_recv()
+            .expect("retry send expected after first timeout")
+            .unwrap();
+        assert!(retried.get_subscription_id().is_some());
+
+        // Now resolve so the second wait succeeds.
+        processor.internal.sub_ack_manager.resolve(sub_id, Ok(()));
+
+        handle.await.unwrap();
+
+        // Upstream success ack.
+        let ack = rx_local
+            .try_recv()
+            .expect("upstream ack should have been sent")
+            .unwrap();
+        assert!(ack.get_subscription_ack().success);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_retry_loop_retry_send_fails() {
+        // Timeout → retry send fails because the connection is gone → loop
+        // exits with the send error, upstream receives a failure ack.
+        let processor = MessageProcessor::new();
+        let (local_conn, _tx_local, mut rx_local) = processor
+            .register_local_connection(false)
+            .expect("failed to create local connection");
+        let (remote_conn, _rx_remote) = make_server_conn(&processor);
+
+        let sub_id: u64 = 1002;
+        let msg = make_test_subscribe(sub_id);
+        let rx = processor.internal.sub_ack_manager.register(sub_id);
+
+        // Drop the remote connection so send_msg fails on retry.
+        processor.connection_table().remove(remote_conn as usize);
+
+        let proc_clone = processor.clone();
+        let handle = tokio::spawn(crate::subscription_ack::retry_loop(
+            proc_clone,
+            sub_id,
+            msg,
+            remote_conn,
+            local_conn,
+            Some(sub_id),
+            rx,
+        ));
+
+        // Let the first timeout elapse → triggers a retry send which fails.
+        tokio::time::sleep(crate::subscription_ack::TIMEOUT + Duration::from_millis(100)).await;
+
+        handle.await.unwrap();
+
+        // Upstream failure ack.
+        let ack = rx_local
+            .try_recv()
+            .expect("upstream ack should have been sent")
+            .unwrap();
+        assert!(!ack.get_subscription_ack().success);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_retry_loop_all_retries_exhausted() {
+        // No ACK ever arrives → all waits time out → final_result is timeout error.
+        let processor = MessageProcessor::new();
+        let (local_conn, _tx_local, mut rx_local) = processor
+            .register_local_connection(false)
+            .expect("failed to create local connection");
+        let (remote_conn, mut rx_remote) = make_server_conn(&processor);
+
+        let sub_id: u64 = 1003;
+        let msg = make_test_subscribe(sub_id);
+        let rx = processor.internal.sub_ack_manager.register(sub_id);
+
+        let proc_clone = processor.clone();
+        let handle = tokio::spawn(crate::subscription_ack::retry_loop(
+            proc_clone,
+            sub_id,
+            msg,
+            remote_conn,
+            local_conn,
+            Some(sub_id),
+            rx,
+        ));
+
+        // Advance time past all retry windows: (MAX_RETRIES + 1) timeouts.
+        for _ in 0..=crate::subscription_ack::MAX_RETRIES {
+            tokio::time::sleep(crate::subscription_ack::TIMEOUT + Duration::from_millis(100)).await;
+        }
+
+        handle.await.unwrap();
+
+        // Should have exactly MAX_RETRIES retry sends (attempts 0..MAX_RETRIES-1
+        // trigger resends; the last attempt only waits).
+        let mut retry_count = 0;
+        while rx_remote.try_recv().is_ok() {
+            retry_count += 1;
+        }
+        assert_eq!(
+            retry_count,
+            crate::subscription_ack::MAX_RETRIES as usize,
+            "expected {} retry sends",
+            crate::subscription_ack::MAX_RETRIES,
+        );
+
+        // Upstream ack must indicate failure (timeout).
+        let ack = rx_local
+            .try_recv()
+            .expect("upstream ack should have been sent")
+            .unwrap();
+        let ack_inner = ack.get_subscription_ack();
+        assert!(
+            !ack_inner.success,
+            "ack must indicate failure after exhausting retries"
+        );
+        assert!(!ack_inner.error.is_empty());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_retry_loop_no_upstream_subscription_id() {
+        // When upstream_subscription_id is None, no upstream ack is sent.
+        let processor = MessageProcessor::new();
+        let (_local_conn, _tx_local, mut rx_local) = processor
+            .register_local_connection(false)
+            .expect("failed to create local connection");
+        let (remote_conn, _rx_remote) = make_server_conn(&processor);
+
+        let sub_id: u64 = 1004;
+        let msg = make_test_subscribe(sub_id);
+        let rx = processor.internal.sub_ack_manager.register(sub_id);
+
+        let proc_clone = processor.clone();
+        let handle = tokio::spawn(crate::subscription_ack::retry_loop(
+            proc_clone,
+            sub_id,
+            msg,
+            remote_conn,
+            0, // in_connection — irrelevant since upstream_subscription_id is None
+            None,
+            rx,
+        ));
+
+        // Resolve immediately.
+        processor.internal.sub_ack_manager.resolve(sub_id, Ok(()));
+
+        handle.await.unwrap();
+
+        // No upstream ack should be sent.
+        assert!(
+            rx_local.try_recv().is_err(),
+            "no upstream ack when upstream_subscription_id is None"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_retry_loop_sender_dropped() {
+        // If the oneshot sender is dropped (e.g. processor shutdown), the loop
+        // must exit promptly without panicking.
+        let processor = MessageProcessor::new();
+        let (local_conn, _tx_local, mut rx_local) = processor
+            .register_local_connection(false)
+            .expect("failed to create local connection");
+        let (remote_conn, _rx_remote) = make_server_conn(&processor);
+
+        let sub_id: u64 = 1005;
+        let msg = make_test_subscribe(sub_id);
+        let rx = processor.internal.sub_ack_manager.register(sub_id);
+
+        // Drop the sender by removing the pending entry.
+        processor.internal.sub_ack_manager.remove(sub_id);
+
+        let proc_clone = processor.clone();
+        let handle = tokio::spawn(crate::subscription_ack::retry_loop(
+            proc_clone,
+            sub_id,
+            msg,
+            remote_conn,
+            local_conn,
+            Some(sub_id),
+            rx,
+        ));
+
+        handle.await.unwrap();
+
+        // Upstream failure ack (timeout error since we never got a result).
+        let ack = rx_local
+            .try_recv()
+            .expect("upstream ack should have been sent")
+            .unwrap();
+        assert!(!ack.get_subscription_ack().success);
     }
 }

--- a/data-plane/core/datapath/src/subscription_ack.rs
+++ b/data-plane/core/datapath/src/subscription_ack.rs
@@ -51,6 +51,7 @@ impl RemoteSubAckManager {
     /// Removes the entry atomically — `oneshot::Sender::send` takes ownership.
     pub fn resolve(&self, ack_id: u64, result: Result<(), DataPathError>) {
         if let Some(tx) = self.pending.write().remove(&ack_id) {
+            debug!(%ack_id, "subscription: remote ack received");
             let _ = tx.send(result);
         }
     }
@@ -68,10 +69,11 @@ pub(crate) fn supports(conn: &Connection) -> bool {
         .is_some_and(|v| v >= min_version())
 }
 
-/// Send/timeout/retry loop for a remote subscription ACK.
+/// Wait/retry loop for a remote subscription ACK.
 ///
-/// Runs until an ACK is received, the channel is closed, or max retries are
-/// exhausted. Cleans up the manager entry and notifies the upstream requester.
+/// The caller is responsible for the initial send; this loop waits for the
+/// ACK and re-sends on timeout up to [`MAX_RETRIES`] times. Cleans up the
+/// manager entry and notifies the upstream requester.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn retry_loop(
     processor: MessageProcessor,
@@ -85,15 +87,12 @@ pub(crate) async fn retry_loop(
     let mut final_result = Err(DataPathError::RemoteSubscriptionAckTimeout(MAX_RETRIES));
 
     'retry: for attempt in 0..=MAX_RETRIES {
-        if let Err(e) = processor.send_msg(forwarded_msg.clone(), out_conn).await {
-            final_result = Err(e);
-            break;
-        }
+        // Wait for the remote ACK. The initial send was done by the caller;
+        // re-sends (retries) happen below on timeout.
         tokio::select! {
             result = &mut rx => {
                 match result {
                     Ok(r) => {
-                        debug!(%subscription_id, "subscription: remote ack received");
                         final_result = r;
                         break 'retry;
                     }
@@ -101,7 +100,13 @@ pub(crate) async fn retry_loop(
                 }
             }
             _ = tokio::time::sleep(TIMEOUT) => {
-                debug!(attempt = attempt + 1, "remote sub ack timeout, retrying");
+                if attempt < MAX_RETRIES {
+                    debug!(attempt = attempt + 1, "remote sub ack timeout, retrying");
+                    if let Err(e) = processor.send_msg(forwarded_msg.clone(), out_conn).await {
+                        final_result = Err(e);
+                        break;
+                    }
+                }
             }
         }
     }

--- a/tests/integration/subscription_ack_test.go
+++ b/tests/integration/subscription_ack_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Subscription ACK Compatibility", func() {
 			relayPort := reservePort()
 
 			replacements := map[string]string{
-				"0.0.0.0:46490":         fmt.Sprintf("0.0.0.0:%d", relayPort),
+				"0.0.0.0:46490":          fmt.Sprintf("0.0.0.0:%d", relayPort),
 				"http://localhost:46490": fmt.Sprintf("http://localhost:%d", relayPort),
 			}
 
@@ -116,7 +116,7 @@ var _ = Describe("Subscription ACK Compatibility", func() {
 			relayPort := reservePort()
 
 			replacements := map[string]string{
-				"0.0.0.0:46490":         fmt.Sprintf("0.0.0.0:%d", relayPort),
+				"0.0.0.0:46490":          fmt.Sprintf("0.0.0.0:%d", relayPort),
 				"http://localhost:46490": fmt.Sprintf("http://localhost:%d", relayPort),
 			}
 
@@ -148,7 +148,7 @@ var _ = Describe("Subscription ACK Compatibility", func() {
 			// the old relay never responds to link negotiation (supports()=false).
 			// The ACK is immediate so the subscription is ready as soon as this
 			// log line appears.
-			Eventually(appASession.Out, 10*time.Second).Should(gbytes.Say("subscription: default ack path"))
+			Eventually(appASession.Out, 10*time.Second).Should(gbytes.Say("subscription: remote ack not available, link negotiation may not have completed yet"))
 
 			// App B: sender.
 			appBConfig := writeTempConfig(tempDir, "./testdata/sub-ack-app-config.yaml", "app-b.yaml", replacements)
@@ -180,7 +180,7 @@ var _ = Describe("Subscription ACK Compatibility", func() {
 			newRelayPort := reservePort()
 
 			replacements := map[string]string{
-				"0.0.0.0:46490":         fmt.Sprintf("0.0.0.0:%d", newRelayPort),
+				"0.0.0.0:46490":          fmt.Sprintf("0.0.0.0:%d", newRelayPort),
 				"http://localhost:46490": fmt.Sprintf("http://localhost:%d", newRelayPort),
 			}
 
@@ -254,7 +254,7 @@ var _ = Describe("Subscription ACK Compatibility", func() {
 			relayPort := reservePort()
 
 			replacements := map[string]string{
-				"0.0.0.0:46490":         fmt.Sprintf("0.0.0.0:%d", relayPort),
+				"0.0.0.0:46490":          fmt.Sprintf("0.0.0.0:%d", relayPort),
 				"http://localhost:46490": fmt.Sprintf("http://localhost:%d", relayPort),
 			}
 
@@ -313,7 +313,7 @@ var _ = Describe("Subscription ACK Compatibility", func() {
 			relayPort := reservePort()
 
 			replacements := map[string]string{
-				"0.0.0.0:46490":         fmt.Sprintf("0.0.0.0:%d", relayPort),
+				"0.0.0.0:46490":          fmt.Sprintf("0.0.0.0:%d", relayPort),
 				"http://localhost:46490": fmt.Sprintf("http://localhost:%d", relayPort),
 			}
 
@@ -344,7 +344,7 @@ var _ = Describe("Subscription ACK Compatibility", func() {
 			// App A's embedded relay falls back to the default path.  The ACK is
 			// immediate; a brief pause lets the subscribe propagate through the
 			// old relay's internal state before B starts sending.
-			Eventually(appASession.Out, 10*time.Second).Should(gbytes.Say("subscription: default ack path"))
+			Eventually(appASession.Out, 10*time.Second).Should(gbytes.Say("subscription: remote ack not available, link negotiation may not have completed yet"))
 			time.Sleep(500 * time.Millisecond)
 
 			// App B: sender.
@@ -382,7 +382,7 @@ var _ = Describe("Subscription ACK Compatibility", func() {
 			relayPort := reservePort()
 
 			replacements := map[string]string{
-				"0.0.0.0:46490":         fmt.Sprintf("0.0.0.0:%d", relayPort),
+				"0.0.0.0:46490":          fmt.Sprintf("0.0.0.0:%d", relayPort),
 				"http://localhost:46490": fmt.Sprintf("http://localhost:%d", relayPort),
 			}
 
@@ -411,7 +411,7 @@ var _ = Describe("Subscription ACK Compatibility", func() {
 
 			// New relay processes the old app's subscribe with default path
 			// (no ack_id from old app, use_remote_ack=false).
-			Eventually(relaySession.Out, 10*time.Second).Should(gbytes.Say("subscription: default ack path"))
+			Eventually(relaySession.Out, 10*time.Second).Should(gbytes.Say("subscription: remote ack not available, link negotiation may not have completed yet"))
 
 			// App B: new sdk-mock, sender.
 			appBConfig := writeTempConfig(tempDir, "./testdata/sub-ack-app-config.yaml", "app-b.yaml", replacements)
@@ -441,7 +441,7 @@ var _ = Describe("Subscription ACK Compatibility", func() {
 			relayPort := reservePort()
 
 			replacements := map[string]string{
-				"0.0.0.0:46490":         fmt.Sprintf("0.0.0.0:%d", relayPort),
+				"0.0.0.0:46490":          fmt.Sprintf("0.0.0.0:%d", relayPort),
 				"http://localhost:46490": fmt.Sprintf("http://localhost:%d", relayPort),
 			}
 
@@ -503,7 +503,7 @@ var _ = Describe("Subscription ACK Compatibility", func() {
 			relayPort := reservePort()
 
 			replacements := map[string]string{
-				"0.0.0.0:46490":         fmt.Sprintf("0.0.0.0:%d", relayPort),
+				"0.0.0.0:46490":          fmt.Sprintf("0.0.0.0:%d", relayPort),
 				"http://localhost:46490": fmt.Sprintf("http://localhost:%d", relayPort),
 			}
 
@@ -531,7 +531,7 @@ var _ = Describe("Subscription ACK Compatibility", func() {
 			defer terminateSession(appASession, 5*time.Second)
 
 			// New relay takes the default path for the old app's subscribe (no ack_id).
-			Eventually(relaySession.Out, 10*time.Second).Should(gbytes.Say("subscription: default ack path"))
+			Eventually(relaySession.Out, 10*time.Second).Should(gbytes.Say("subscription: remote ack not available, link negotiation may not have completed yet"))
 
 			// App B: new sdk-mock, sender.
 			appBConfig := writeTempConfig(tempDir, "./testdata/sub-ack-app-config.yaml", "app-b.yaml", replacements)
@@ -561,7 +561,7 @@ var _ = Describe("Subscription ACK Compatibility", func() {
 			relayPort := reservePort()
 
 			replacements := map[string]string{
-				"0.0.0.0:46490":         fmt.Sprintf("0.0.0.0:%d", relayPort),
+				"0.0.0.0:46490":          fmt.Sprintf("0.0.0.0:%d", relayPort),
 				"http://localhost:46490": fmt.Sprintf("http://localhost:%d", relayPort),
 			}
 


### PR DESCRIPTION
# Description

When a subscription is forwarded to a remote peer whose
link negotiation hasn't completed yet, `use_remote_ack`
evaluates to `false` and the default (immediate ACK) path
is taken.

However, link negotiation can complete between the moment
we check and the moment `process_subscription_update_and_forward`
writes to the remote subscription table. In that case, we are not
able to forward the subscription when the link negotiation completes.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
