### PR TITLE
fix(bindings/go): use ChannelInterface and ServerInterface in generated stubs

### DIFF
--- a/data-plane/bindings/go/Taskfile.yaml
+++ b/data-plane/bindings/go/Taskfile.yaml
@@ -271,11 +271,11 @@ tasks:
   generate-proto:
     desc: "Generate proto files for the Python bindings"
     deps:
-      - task: rust:toolchain:run-command
+      - task: rust:run-command
         vars:
           COMMAND: |
             cargo build --package agntcy-protoc-slimrpc-plugin --bin protoc-gen-slimrpc-go --release
-      - task: tools:buf
+      - task: buf
     cmds:
       - |
         # Find all the buf.gen.yaml files in the current directory and its subdirectories

--- a/data-plane/bindings/go/examples/slimrpc/simple/types/example_slimrpc.pb.go
+++ b/data-plane/bindings/go/examples/slimrpc/simple/types/example_slimrpc.pb.go
@@ -24,11 +24,11 @@ type TestClient interface {
 }
 
 type TestClientImpl struct {
-	channel *slim_bindings.Channel
+	channel slim_bindings.ChannelInterface
 }
 
 // NewTestClient creates a new Test client.
-func NewTestClient(channel *slim_bindings.Channel) TestClient {
+func NewTestClient(channel slim_bindings.ChannelInterface) TestClient {
 	return &TestClientImpl{
 		channel: channel,
 	}
@@ -203,7 +203,7 @@ func (UnimplementedTestServer) ExampleStreamStream(ctx context.Context, stream s
 
 
 // RegisterTestServer registers the server with slim_bindings.
-func RegisterTestServer(server *slim_bindings.Server, impl TestServer) {
+func RegisterTestServer(server slim_bindings.ServerInterface, impl TestServer) {
 	server.RegisterUnaryUnary("example_service.Test", "ExampleUnaryUnary", &Test_ExampleUnaryUnary_Handler{impl: impl})
 	server.RegisterUnaryStream("example_service.Test", "ExampleUnaryStream", &Test_ExampleUnaryStream_Handler{impl: impl})
 	server.RegisterUnaryStream("example_service.Test", "ExampleUnaryStreamTwo", &Test_ExampleUnaryStreamTwo_Handler{impl: impl})
@@ -424,7 +424,7 @@ func (h *Test_ExampleStreamStream_Handler) Handle(stream *slim_bindings.RequestS
 
 
 // TestGroupClient is the multicast (group) client API for Test service.
-// Requires a *slim_bindings.Channel created with ChannelNewGroup* targeting multiple server instances.
+// Requires a slim_bindings.ChannelInterface backed by a channel created with ChannelNewGroup* targeting multiple server instances.
 type TestGroupClient interface {
 	ExampleUnaryUnary(ctx context.Context, req *ExampleRequest) (slimrpc.MulticastResponseStream[*ExampleResponse], error)
 	ExampleUnaryStream(ctx context.Context, req *ExampleRequest) (slimrpc.MulticastResponseStream[*ExampleResponse], error)
@@ -434,11 +434,11 @@ type TestGroupClient interface {
 }
 
 type TestGroupClientImpl struct {
-	channel *slim_bindings.Channel
+	channel slim_bindings.ChannelInterface
 }
 
 // NewTestGroupClient creates a new multicast Test client.
-func NewTestGroupClient(channel *slim_bindings.Channel) TestGroupClient {
+func NewTestGroupClient(channel slim_bindings.ChannelInterface) TestGroupClient {
 	return &TestGroupClientImpl{channel: channel}
 }
 

--- a/data-plane/slimrpc-compiler/examples/a2a/types/a2a_slimrpc.pb.go
+++ b/data-plane/slimrpc-compiler/examples/a2a/types/a2a_slimrpc.pb.go
@@ -32,11 +32,11 @@ type A2AServiceClient interface {
 }
 
 type A2AServiceClientImpl struct {
-	channel *slim_bindings.Channel
+	channel slim_bindings.ChannelInterface
 }
 
 // NewA2AServiceClient creates a new A2AService client.
-func NewA2AServiceClient(channel *slim_bindings.Channel) A2AServiceClient {
+func NewA2AServiceClient(channel slim_bindings.ChannelInterface) A2AServiceClient {
 	return &A2AServiceClientImpl{
 		channel: channel,
 	}
@@ -485,7 +485,7 @@ func (UnimplementedA2AServiceServer) DeleteTaskPushNotificationConfig(ctx contex
 
 
 // RegisterA2AServiceServer registers the server with slim_bindings.
-func RegisterA2AServiceServer(server *slim_bindings.Server, impl A2AServiceServer) {
+func RegisterA2AServiceServer(server slim_bindings.ServerInterface, impl A2AServiceServer) {
 	server.RegisterUnaryUnary("a2a.v1.A2AService", "SendMessage", &A2AService_SendMessage_Handler{impl: impl})
 	server.RegisterUnaryStream("a2a.v1.A2AService", "SendStreamingMessage", &A2AService_SendStreamingMessage_Handler{impl: impl})
 	server.RegisterUnaryUnary("a2a.v1.A2AService", "GetTask", &A2AService_GetTask_Handler{impl: impl})

--- a/data-plane/slimrpc-compiler/examples/simple/types/example_with_imports_slimrpc.pb.go
+++ b/data-plane/slimrpc-compiler/examples/simple/types/example_with_imports_slimrpc.pb.go
@@ -26,11 +26,11 @@ type TestClient interface {
 }
 
 type TestClientImpl struct {
-	channel *slim_bindings.Channel
+	channel slim_bindings.ChannelInterface
 }
 
 // NewTestClient creates a new Test client.
-func NewTestClient(channel *slim_bindings.Channel) TestClient {
+func NewTestClient(channel slim_bindings.ChannelInterface) TestClient {
 	return &TestClientImpl{
 		channel: channel,
 	}
@@ -211,7 +211,7 @@ func (UnimplementedTestServer) Delete(ctx context.Context, req *a2a_a2apb.Delete
 
 
 // RegisterTestServer registers the server with slim_bindings.
-func RegisterTestServer(server *slim_bindings.Server, impl TestServer) {
+func RegisterTestServer(server slim_bindings.ServerInterface, impl TestServer) {
 	server.RegisterUnaryUnary("example_service.Test", "ExampleUnaryUnary", &Test_ExampleUnaryUnary_Handler{impl: impl})
 	server.RegisterUnaryStream("example_service.Test", "ExampleUnaryStream", &Test_ExampleUnaryStream_Handler{impl: impl})
 	server.RegisterStreamUnary("example_service.Test", "ExampleStreamUnary", &Test_ExampleStreamUnary_Handler{impl: impl})

--- a/data-plane/slimrpc-compiler/src/golang.rs
+++ b/data-plane/slimrpc-compiler/src/golang.rs
@@ -40,11 +40,11 @@ type {{SERVICE_NAME}}Client interface {
 }
 
 type {{SERVICE_NAME}}ClientImpl struct {
-	channel *slim_bindings.Channel
+	channel slim_bindings.ChannelInterface
 }
 
 // New{{SERVICE_NAME}}Client creates a new {{SERVICE_NAME}} client.
-func New{{SERVICE_NAME}}Client(channel *slim_bindings.Channel) {{SERVICE_NAME}}Client {
+func New{{SERVICE_NAME}}Client(channel slim_bindings.ChannelInterface) {{SERVICE_NAME}}Client {
 	return &{{SERVICE_NAME}}ClientImpl{
 		channel: channel,
 	}
@@ -188,7 +188,7 @@ type Unimplemented{{SERVICE_NAME}}Server struct {
 {{UNIMPLEMENTED_METHODS}}
 
 // Register{{SERVICE_NAME}}Server registers the server with slim_bindings.
-func Register{{SERVICE_NAME}}Server(server *slim_bindings.Server, impl {{SERVICE_NAME}}Server) {
+func Register{{SERVICE_NAME}}Server(server slim_bindings.ServerInterface, impl {{SERVICE_NAME}}Server) {
 {{REGISTER_METHODS}}
 }
 
@@ -415,17 +415,17 @@ const REGISTER_STREAM_STREAM_METHOD: &str = r#"	server.RegisterStreamStream("{{P
 
 const GROUP_CLIENT_INTERFACE_TEMPLATE: &str = r#"
 // {{SERVICE_NAME}}GroupClient is the multicast (group) client API for {{SERVICE_NAME}} service.
-// Requires a *slim_bindings.Channel created with ChannelNewGroup* targeting multiple server instances.
+// Requires a slim_bindings.ChannelInterface backed by a channel created with ChannelNewGroup* targeting multiple server instances.
 type {{SERVICE_NAME}}GroupClient interface {
 {{GROUP_CLIENT_METHODS}}
 }
 
 type {{SERVICE_NAME}}GroupClientImpl struct {
-	channel *slim_bindings.Channel
+	channel slim_bindings.ChannelInterface
 }
 
 // New{{SERVICE_NAME}}GroupClient creates a new multicast {{SERVICE_NAME}} client.
-func New{{SERVICE_NAME}}GroupClient(channel *slim_bindings.Channel) {{SERVICE_NAME}}GroupClient {
+func New{{SERVICE_NAME}}GroupClient(channel slim_bindings.ChannelInterface) {{SERVICE_NAME}}GroupClient {
 	return &{{SERVICE_NAME}}GroupClientImpl{channel: channel}
 }
 


### PR DESCRIPTION
# Description

`protoc-gen-slimrpc-go` previously generated client stubs that accepted the concrete `*slim_bindings.Channel` type in constructors, and server registration functions that accepted `*slim_bindings.Server`. This made it impossible to inject test doubles without standing up a real SLIM server.

The UniFFI-generated `slim_bindings.go` already defines `ChannelInterface` and `ServerInterface` — this change updates the code generator to use those interfaces everywhere the concrete pointer types were used in generated client/server registration code.

**Changes:**
- `New{{Service}}Client(channel *Channel)` → `New{{Service}}Client(channel ChannelInterface)` — allows mock channel injection in client tests
- `Register{{Service}}Server(server *Server, ...)` → `Register{{Service}}Server(server ServerInterface, ...)` — allows mock server injection for registration tests

Because `*Channel` and `*Server` already implement the respective interfaces, all existing callers continue to compile and work without any modifications.

Fixes #1419

## Type of Change

- [x] Bugfix

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] All code style checks pass
- [x] All new and existing tests pass