### PR TITLE
ci(go-release): fix FILES_TO_RELEASE word splitting using bash array

### DIFF
--- a/.github/workflows/reusable-go-bindings-release.yaml
+++ b/.github/workflows/reusable-go-bindings-release.yaml
@@ -116,7 +116,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          git add "$FILES_TO_RELEASE"
+          read -ra files <<< "$FILES_TO_RELEASE"
+          git add "${files[@]}"
 
           # Check if there are changes to commit
           if git diff --cached --quiet; then


### PR DESCRIPTION
# Description

Fix FILES_TO_RELEASE word splitting using bash array.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
