### PR TITLE
refactor(datapath): use Arc instead of Box for Name string storage

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -203,7 +203,6 @@ dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-tracing",
  "agntcy-slim-version",
- "bincode",
  "bit-vec",
  "criterion",
  "display-error-chain",

--- a/data-plane/core/datapath/Cargo.toml
+++ b/data-plane/core/datapath/Cargo.toml
@@ -12,7 +12,6 @@ name = "slim_datapath"
 agntcy-slim-config = { workspace = true }
 agntcy-slim-tracing = { workspace = true }
 agntcy-slim-version = { workspace = true }
-bincode = { workspace = true }
 bit-vec = { workspace = true }
 display-error-chain = { workspace = true }
 drain = { workspace = true }

--- a/data-plane/core/datapath/src/messages/encoder.rs
+++ b/data-plane/core/datapath/src/messages/encoder.rs
@@ -1,19 +1,19 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
-use bincode::{Decode, Encode};
 use std::hash::{Hash, Hasher};
+use std::sync::Arc;
 use twox_hash::XxHash64;
 
 use crate::api::ProtoName;
 
-#[derive(Clone, Encode, Decode)]
+#[derive(Clone)]
 pub struct Name {
     /// The hashed components of the name
     components: [u64; 4],
 
     // Store the original string representation of the components
-    strings: Box<[String; 3]>,
+    strings: Arc<[String; 3]>,
 }
 
 impl Hash for Name {
@@ -73,7 +73,7 @@ impl From<&ProtoName> for Name {
                 encoded.component_2,
                 encoded.component_3,
             ],
-            strings: Box::new([
+            strings: Arc::new([
                 strings.str_component_0.clone(),
                 strings.str_component_1.clone(),
                 strings.str_component_2.clone(),
@@ -101,7 +101,7 @@ impl Name {
                 calculate_hash(&strings[2]),
                 Self::NULL_COMPONENT,
             ],
-            strings: Box::new(strings),
+            strings: Arc::new(strings),
         }
     }
 


### PR DESCRIPTION
# Description

Replace Box<[String; 3]> with Arc<[String; 3]> in the Name struct so
that clones share the same string representation via reference counting
instead of performing a deep copy of the three strings.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Perf

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
