### PR TITLE
fix: use latest as tag for slim images in scan job

### DIFF
--- a/.github/workflows/container-security-scan.yml
+++ b/.github/workflows/container-security-scan.yml
@@ -28,10 +28,10 @@ jobs:
         include:
           - image: slim-node
             repo: ghcr.io/${{ github.repository_owner }}/slim
-            version: 1.0.0
+            version: latest
           - image: slim-controller
             repo: ghcr.io/${{ github.repository_owner }}/slim/control-plane
-            version: 1.0.0
+            version: latest
           - image: spire-server
             repo: ghcr.io/spiffe/spire-server
             version: 1.14.1


### PR DESCRIPTION
# Description

Use latest as tag for slim images in the security scan job

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
