### PR TITLE
feat: add tower auth middleware using spire

### DIFF
--- a/data-plane/bindings/rust/src/common_config.rs
+++ b/data-plane/bindings/rust/src/common_config.rs
@@ -305,9 +305,20 @@ impl From<BasicAuthConfig> for BasicAuth {
 /// Authentication configuration enum for client
 #[derive(uniffi::Enum, Clone, Debug, PartialEq)]
 pub enum ClientAuthenticationConfig {
-    Basic { config: BasicAuth },
-    StaticJwt { config: StaticJwtAuth },
-    Jwt { config: ClientJwtAuth },
+    Basic {
+        config: BasicAuth,
+    },
+    StaticJwt {
+        config: StaticJwtAuth,
+    },
+    Jwt {
+        config: ClientJwtAuth,
+    },
+    /// SPIRE/SPIFFE authentication (non-Windows only)
+    #[cfg(not(target_family = "windows"))]
+    Spire {
+        config: SpireConfig,
+    },
     None,
 }
 
@@ -322,6 +333,10 @@ impl From<ClientAuthenticationConfig> for slim_config::grpc::client::Authenticat
             }
             ClientAuthenticationConfig::Jwt { config } => {
                 slim_config::grpc::client::AuthenticationConfig::Jwt(config.into())
+            }
+            #[cfg(not(target_family = "windows"))]
+            ClientAuthenticationConfig::Spire { config } => {
+                slim_config::grpc::client::AuthenticationConfig::Spire(config.into())
             }
             ClientAuthenticationConfig::None => {
                 slim_config::grpc::client::AuthenticationConfig::None
@@ -347,6 +362,12 @@ impl From<slim_config::grpc::client::AuthenticationConfig> for ClientAuthenticat
             slim_config::grpc::client::AuthenticationConfig::Jwt(jwt) => {
                 ClientAuthenticationConfig::Jwt { config: jwt.into() }
             }
+            #[cfg(not(target_family = "windows"))]
+            slim_config::grpc::client::AuthenticationConfig::Spire(spire) => {
+                ClientAuthenticationConfig::Spire {
+                    config: spire.into(),
+                }
+            }
         }
     }
 }
@@ -354,8 +375,17 @@ impl From<slim_config::grpc::client::AuthenticationConfig> for ClientAuthenticat
 /// Authentication configuration enum for server
 #[derive(uniffi::Enum, Clone, Debug, PartialEq)]
 pub enum ServerAuthenticationConfig {
-    Basic { config: BasicAuth },
-    Jwt { config: JwtAuth },
+    Basic {
+        config: BasicAuth,
+    },
+    Jwt {
+        config: JwtAuth,
+    },
+    /// SPIRE/SPIFFE authentication (non-Windows only)
+    #[cfg(not(target_family = "windows"))]
+    Spire {
+        config: SpireConfig,
+    },
     None,
 }
 
@@ -367,6 +397,10 @@ impl From<ServerAuthenticationConfig> for slim_config::grpc::server::Authenticat
             }
             ServerAuthenticationConfig::Jwt { config } => {
                 slim_config::grpc::server::AuthenticationConfig::Jwt(config.into())
+            }
+            #[cfg(not(target_family = "windows"))]
+            ServerAuthenticationConfig::Spire { config } => {
+                slim_config::grpc::server::AuthenticationConfig::Spire(config.into())
             }
             ServerAuthenticationConfig::None => {
                 slim_config::grpc::server::AuthenticationConfig::None
@@ -388,6 +422,12 @@ impl From<slim_config::grpc::server::AuthenticationConfig> for ServerAuthenticat
             }
             slim_config::grpc::server::AuthenticationConfig::Jwt(jwt) => {
                 ServerAuthenticationConfig::Jwt { config: jwt.into() }
+            }
+            #[cfg(not(target_family = "windows"))]
+            slim_config::grpc::server::AuthenticationConfig::Spire(spire) => {
+                ServerAuthenticationConfig::Spire {
+                    config: spire.into(),
+                }
             }
         }
     }

--- a/data-plane/core/auth/tests/spiffe_integration_test.rs
+++ b/data-plane/core/auth/tests/spiffe_integration_test.rs
@@ -338,6 +338,150 @@ async fn test_spiffe_verifier_config() {
 
 #[tokio::test]
 #[tracing_test::traced_test]
+async fn test_spiffe_grpc_jwt_auth() {
+    require_docker!();
+
+    tracing::info!("Testing SPIFFE JWT authentication with a real gRPC client and server");
+
+    let mut env = SpireTestEnvironment::new()
+        .await
+        .expect("Failed to create test environment");
+
+    env.start().await.expect("Failed to start SPIRE containers");
+
+    // Wait for SPIRE to be ready and SVIDs to be registered
+    tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+
+    let spire_cfg = env.get_spiffe_config();
+
+    // Reserve an available TCP port for the test gRPC server
+    let tcp_listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind failed");
+    let port = tcp_listener.local_addr().expect("local addr").port();
+    drop(tcp_listener);
+
+    let mut server_task: Option<tokio::task::JoinHandle<()>> = None;
+    let mut should_panic = false;
+
+    'test_block: {
+        // Build a ServerConfig with SPIRE JWT auth
+        let mut server_cfg =
+            slim_config::grpc::server::ServerConfig::with_endpoint(&format!("127.0.0.1:{port}"));
+        server_cfg.tls_setting.insecure = true;
+        server_cfg.auth = slim_config::grpc::server::AuthenticationConfig::Spire(spire_cfg.clone());
+
+        let greeter_svc =
+            slim_config::testutils::helloworld::greeter_server::GreeterServer::from_arc(
+                std::sync::Arc::new(slim_config::testutils::Empty::new()),
+            );
+
+        let server_future = match server_cfg.to_server_future(&[greeter_svc]).await {
+            Ok(f) => f,
+            Err(e) => {
+                tracing::error!(error = %e, "Failed to create server future");
+                should_panic = true;
+                break 'test_block;
+            }
+        };
+
+        server_task = Some(tokio::spawn(async move {
+            if let Err(e) = server_future.await {
+                tracing::error!(error = %e, "Server error");
+            }
+        }));
+
+        // Give the server a moment to start accepting connections
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        // Build a ClientConfig with SPIRE JWT auth
+        let mut client_cfg = slim_config::grpc::client::ClientConfig::with_endpoint(&format!(
+            "http://127.0.0.1:{port}"
+        ));
+        client_cfg.tls_setting.insecure = true;
+        client_cfg.auth = slim_config::grpc::client::AuthenticationConfig::Spire(spire_cfg.clone());
+
+        let channel = match client_cfg.to_channel().await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::error!(error = %e, "Failed to create authenticated channel");
+                should_panic = true;
+                break 'test_block;
+            }
+        };
+
+        let mut greeter_client =
+            slim_config::testutils::helloworld::greeter_client::GreeterClient::new(channel);
+
+        match greeter_client
+            .say_hello(slim_config::testutils::helloworld::HelloRequest {
+                name: "SPIFFE".to_string(),
+            })
+            .await
+        {
+            Ok(reply) => {
+                tracing::info!(
+                    message = %reply.into_inner().message,
+                    "Authenticated gRPC call succeeded"
+                );
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "Authenticated gRPC call failed");
+                should_panic = true;
+                break 'test_block;
+            }
+        }
+
+        // Verify that a request without auth is rejected by the server
+        let mut unauthenticated_cfg = slim_config::grpc::client::ClientConfig::with_endpoint(
+            &format!("http://127.0.0.1:{port}"),
+        );
+        unauthenticated_cfg.tls_setting.insecure = true;
+
+        let unauth_channel = match unauthenticated_cfg.to_channel().await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::error!(error = %e, "Failed to create unauthenticated channel");
+                should_panic = true;
+                break 'test_block;
+            }
+        };
+
+        let mut unauth_client =
+            slim_config::testutils::helloworld::greeter_client::GreeterClient::new(unauth_channel);
+
+        let unauth_result = unauth_client
+            .say_hello(slim_config::testutils::helloworld::HelloRequest {
+                name: "NoAuth".to_string(),
+            })
+            .await;
+
+        if let Err(e) = unauth_result {
+            tracing::info!(
+                error = %e,
+                "Unauthenticated request correctly rejected"
+            );
+        } else {
+            tracing::error!("Unauthenticated request should have been rejected");
+            should_panic = true;
+        }
+
+        break 'test_block;
+    }
+
+    if let Some(task) = server_task {
+        task.abort();
+    }
+
+    env.cleanup()
+        .await
+        .expect("Failed to cleanup test environment");
+
+    if should_panic {
+        panic!("SPIFFE gRPC JWT auth test failed");
+    }
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
 async fn test_spiffe_try_methods() {
     tracing::info!("Testing SPIFFE try_* methods for non-async contexts");
 

--- a/data-plane/core/config/src/auth/spire.rs
+++ b/data-plane/core/config/src/auth/spire.rs
@@ -139,7 +139,7 @@ impl ClientAuthenticator for SpireConfig {
 
 impl<Response> ServerAuthenticator<Response> for SpireConfig
 where
-    Response: Default + Send + Sync + 'static,
+    Response: Default + Send + 'static,
 {
     type ServerLayer = ValidateJwtLayer<MetadataMap, SpireIdentityManager>;
 

--- a/data-plane/core/config/src/grpc/client.rs
+++ b/data-plane/core/config/src/grpc/client.rs
@@ -36,6 +36,8 @@ use super::headers_middleware::SetRequestHeaderLayer;
 use crate::auth::ClientAuthenticator;
 use crate::auth::basic::Config as BasicAuthenticationConfig;
 use crate::auth::jwt::Config as JwtAuthenticationConfig;
+#[cfg(not(target_family = "windows"))]
+use crate::auth::spire::SpireConfig as SpireAuthConfig;
 use crate::auth::static_jwt::Config as BearerAuthenticationConfig;
 use crate::backoff::Strategy;
 use crate::backoff::exponential::Config as ExponentialBackoff;
@@ -206,6 +208,9 @@ pub enum AuthenticationConfig {
     StaticJwt(BearerAuthenticationConfig),
     /// JWT authentication configuration.
     Jwt(JwtAuthenticationConfig),
+    /// SPIRE/SPIFFE authentication configuration.
+    #[cfg(not(target_family = "windows"))]
+    Spire(SpireAuthConfig),
     /// None
     #[default]
     None,
@@ -1055,6 +1060,10 @@ impl ClientConfig {
             }
             AuthenticationConfig::Jwt(jwt) => {
                 create_auth_service_with_init!(self, jwt, header_map, channel)
+            }
+            #[cfg(not(target_family = "windows"))]
+            AuthenticationConfig::Spire(spire) => {
+                create_auth_service_with_init!(self, spire, header_map, channel)
             }
             AuthenticationConfig::None => Ok(tower::ServiceBuilder::new()
                 .layer(SetRequestHeaderLayer::new(header_map))

--- a/data-plane/core/config/src/grpc/server.rs
+++ b/data-plane/core/config/src/grpc/server.rs
@@ -28,6 +28,8 @@ use super::errors::ConfigError;
 use crate::auth::ServerAuthenticator;
 use crate::auth::basic::Config as BasicAuthenticationConfig;
 use crate::auth::jwt::Config as JwtAuthenticationConfig;
+#[cfg(not(target_family = "windows"))]
+use crate::auth::spire::SpireConfig as SpireAuthConfig;
 use crate::component::configuration::Configuration;
 use crate::transport::TransportProtocol;
 use slim_auth::metadata::MetadataMap;
@@ -70,6 +72,9 @@ pub enum AuthenticationConfig {
     Basic(BasicAuthenticationConfig),
     /// JWT authentication configuration.
     Jwt(JwtAuthenticationConfig),
+    /// SPIRE/SPIFFE authentication configuration.
+    #[cfg(not(target_family = "windows"))]
+    Spire(SpireAuthConfig),
     /// None
     #[default]
     None,
@@ -395,6 +400,23 @@ impl ServerConfig {
                 let mut auth_layer = <JwtAuthenticationConfig as ServerAuthenticator<
                     http::Response<tonic::body::Body>,
                 >>::get_server_layer(jwt)?;
+
+                auth_layer.initialize().await?;
+
+                let mut builder = builder.layer(auth_layer);
+
+                let mut router = builder.add_service(svc[0].clone());
+                for s in svc.iter().skip(1) {
+                    router = builder.add_service(s.clone());
+                }
+
+                Ok(router.serve_with_incoming(incoming).boxed())
+            }
+            #[cfg(not(target_family = "windows"))]
+            AuthenticationConfig::Spire(spire) => {
+                let mut auth_layer = <SpireAuthConfig as ServerAuthenticator<
+                    http::Response<tonic::body::Body>,
+                >>::get_server_layer(spire)?;
 
                 auth_layer.initialize().await?;
 

--- a/data-plane/slimctl/src/commands/slim_cmd.rs
+++ b/data-plane/slimctl/src/commands/slim_cmd.rs
@@ -139,7 +139,7 @@ mod tests {
     }
 
     #[test]
-    fn create_temp_config_file_is_writeable() {
+    fn create_temp_config_file_is_writable() {
         let tmp = create_temp_config(Some("0.0.0.0:1234")).unwrap();
         assert!(tmp.path().exists());
         let content = std::fs::read_to_string(tmp.path()).unwrap();


### PR DESCRIPTION
# Description

Allow the use of spire as HTTP auth for grpc connections.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
