### PR TITLE
feat(multicluster-demo): add SPIRE identity auth to a2acli

### DIFF
--- a/multicluster-demo/a2acli-skill/.a2acli.yaml.example
+++ b/multicluster-demo/a2acli-skill/.a2acli.yaml.example
@@ -11,4 +11,13 @@
 slim:
   endpoint: "http://localhost:46357"
   local-name: "agntcy/cli/a2acli"
+
+  # Shared-secret auth (used when spire.socket-path is not set)
   secret: "my_shared_secret"
+
+  # SPIRE dynamic identity auth (takes precedence over secret when socket-path is set)
+  # spire:
+  #   socket-path: "/tmp/spire-agent/public/api.sock"
+  #   target-spiffe-id: "spiffe://example.org/agent"   # optional
+  #   jwt-audiences:                                    # optional
+  #     - "my-audience"

--- a/multicluster-demo/a2acli-skill/README.md
+++ b/multicluster-demo/a2acli-skill/README.md
@@ -41,7 +41,11 @@ An annotated example is provided at `.a2acli.yaml.example`:
 slim:
   endpoint: "http://localhost:46357"
   local-name: "agntcy/cli/a2acli"
-  secret: "my_shared_secret"
+  secret: "my_shared_secret"        # used when spire.socket-path is not set
+  # spire:
+  #   socket-path: "/tmp/spire-agent/public/api.sock"
+  #   target-spiffe-id: "spiffe://example.org/agent"
+  #   jwt-audiences: ["my-audience"]
 
 # agents-dir: /path/to/my/.a2aagents
 ```
@@ -144,17 +148,35 @@ a2acli get-task --agent <digest> <task-id>
 | `--agents-dir` | | Path to agents directory (overrides auto-discovery) |
 | `--slim-endpoint` | | SLIM node URL, e.g. `http://localhost:46357`. When set, SLIM RPC transport is enabled. |
 | `--slim-local-name` | `agntcy/cli/a2acli` | Local SLIM identity (`namespace/group/name`) |
-| `--slim-secret` | | Shared secret for SLIM authentication |
+| `--slim-secret` | | Shared secret for SLIM authentication (used when `--spire-socket-path` is not set) |
+| `--spire-socket-path` | | SPIRE Workload API socket path. When set, SPIRE identity auth is used instead of shared secret. |
+| `--spire-target-spiffe-id` | | Target SPIFFE ID to request from SPIRE (optional) |
+| `--spire-jwt-audience` | | JWT audience to request from SPIRE; may be repeated (optional) |
 
 ## SLIM Transport
 
-When `--slim-endpoint` is provided, the CLI connects to a SLIM node and registers both the v0.3 and v1.0 SLIM RPC transports. The transport is selected automatically based on the `protocolVersion` declared in the agent's card.
+When `--slim-endpoint` is provided the CLI connects to a SLIM node and registers both the v0.3 and v1.0 SLIM RPC transports. The correct transport is selected automatically based on the `protocolVersion` declared in the agent's card.
+
+### Shared-secret auth
 
 ```bash
 a2acli send-message \
   --agent sha256:6a403dbd \
   --slim-endpoint http://localhost:46357 \
   --slim-secret "my_secret" \
+  "What pods are failing in my cluster?"
+```
+
+### SPIRE dynamic identity auth
+
+When `--spire-socket-path` is set the CLI uses SPIRE's Workload API for dynamic identity instead of a shared secret:
+
+```bash
+a2acli send-message \
+  --agent sha256:6a403dbd \
+  --slim-endpoint http://localhost:46357 \
+  --spire-socket-path /tmp/spire-agent/public/api.sock \
+  --spire-target-spiffe-id spiffe://example.org/agent \
   "What pods are failing in my cluster?"
 ```
 

--- a/multicluster-demo/a2acli-skill/cmd/root.go
+++ b/multicluster-demo/a2acli-skill/cmd/root.go
@@ -29,6 +29,10 @@ var (
 	slimSecret    string
 	slimApp       *slim_bindings.App
 	slimConnID    uint64
+
+	spireSocketPath     string
+	spireTargetSpiffeID string
+	spireJwtAudiences   []string
 )
 
 var rootCmd = &cobra.Command{
@@ -58,6 +62,15 @@ Each agent is identified by the SHA256 digest of its AgentCard file.`,
 		if !flags.Changed("slim-secret") && cfg.Slim.Secret != "" {
 			slimSecret = cfg.Slim.Secret
 		}
+		if !flags.Changed("spire-socket-path") && cfg.Slim.Spire.SocketPath != "" {
+			spireSocketPath = cfg.Slim.Spire.SocketPath
+		}
+		if !flags.Changed("spire-target-spiffe-id") && cfg.Slim.Spire.TargetSpiffeID != "" {
+			spireTargetSpiffeID = cfg.Slim.Spire.TargetSpiffeID
+		}
+		if !flags.Changed("spire-jwt-audience") && len(cfg.Slim.Spire.JwtAudiences) > 0 {
+			spireJwtAudiences = cfg.Slim.Spire.JwtAudiences
+		}
 
 		s, err := store.NewStore(agentsDir)
 		if err != nil {
@@ -74,17 +87,41 @@ Each agent is identified by the SHA256 digest of its AgentCard file.`,
 				return fmt.Errorf("invalid --slim-local-name %q: %w", slimLocalName, err)
 			}
 
-			app, err := svc.CreateAppWithSecret(localName, slimSecret)
-			if err != nil {
-				return fmt.Errorf("SLIM CreateApp failed: %w", err)
-			}
-			slimApp = app
-
 			connID, err := svc.Connect(slim_bindings.NewInsecureClientConfig(slimEndpoint))
 			if err != nil {
 				return fmt.Errorf("SLIM Connect failed: %w", err)
 			}
 			slimConnID = connID
+
+			var app *slim_bindings.App
+			if spireSocketPath != "" {
+				var socketPath *string
+				if spireSocketPath != "" {
+					socketPath = &spireSocketPath
+				}
+				var targetSpiffeID *string
+				if spireTargetSpiffeID != "" {
+					targetSpiffeID = &spireTargetSpiffeID
+				}
+				spireConfig := slim_bindings.SpireConfig{
+					SocketPath:     socketPath,
+					TargetSpiffeId: targetSpiffeID,
+					JwtAudiences:   spireJwtAudiences,
+					TrustDomains:   []string{},
+				}
+				providerConfig := slim_bindings.IdentityProviderConfigSpire{Config: spireConfig}
+				verifierConfig := slim_bindings.IdentityVerifierConfigSpire{Config: spireConfig}
+				app, err = svc.CreateApp(localName, providerConfig, verifierConfig)
+				if err != nil {
+					return fmt.Errorf("SLIM CreateApp (SPIRE) failed: %w", err)
+				}
+			} else {
+				app, err = svc.CreateAppWithSecret(localName, slimSecret)
+				if err != nil {
+					return fmt.Errorf("SLIM CreateApp (shared secret) failed: %w", err)
+				}
+			}
+			slimApp = app
 
 			if err := app.Subscribe(localName, &slimConnID); err != nil {
 				return fmt.Errorf("SLIM Subscribe failed: %w", err)
@@ -119,6 +156,9 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&slimEndpoint, "slim-endpoint", "", "SLIM node URL (e.g. http://localhost:46357)")
 	rootCmd.PersistentFlags().StringVar(&slimLocalName, "slim-local-name", "agntcy/cli/a2acli", "local SLIM name (namespace/group/name)")
 	rootCmd.PersistentFlags().StringVar(&slimSecret, "slim-secret", "", "shared secret for SLIM authentication")
+	rootCmd.PersistentFlags().StringVar(&spireSocketPath, "spire-socket-path", "", "SPIRE Workload API socket path; when set, SPIRE identity auth is used instead of shared secret")
+	rootCmd.PersistentFlags().StringVar(&spireTargetSpiffeID, "spire-target-spiffe-id", "", "target SPIFFE ID to request from SPIRE (optional)")
+	rootCmd.PersistentFlags().StringArrayVar(&spireJwtAudiences, "spire-jwt-audience", nil, "JWT audience(s) to request from SPIRE (may be repeated)")
 	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(getCardCmd)
 	rootCmd.AddCommand(sendMessageCmd)

--- a/multicluster-demo/a2acli-skill/internal/config/config.go
+++ b/multicluster-demo/a2acli-skill/internal/config/config.go
@@ -14,11 +14,19 @@ import (
 
 const configFileName = ".a2acli.yaml"
 
+// SpireConfig holds SPIRE Workload API settings for dynamic identity auth.
+type SpireConfig struct {
+	SocketPath      string   `yaml:"socket-path"`
+	TargetSpiffeID  string   `yaml:"target-spiffe-id"`
+	JwtAudiences    []string `yaml:"jwt-audiences"`
+}
+
 // SlimConfig holds connection settings for the SLIM messaging node.
 type SlimConfig struct {
-	Endpoint  string `yaml:"endpoint"`
-	LocalName string `yaml:"local-name"`
-	Secret    string `yaml:"secret"`
+	Endpoint  string      `yaml:"endpoint"`
+	LocalName string      `yaml:"local-name"`
+	Secret    string      `yaml:"secret"`
+	Spire     SpireConfig `yaml:"spire"`
 }
 
 // Config is the top-level configuration for a2acli.


### PR DESCRIPTION
# Description

Extends `a2acli` to support SPIRE dynamic identity authentication alongside the existing shared-secret mode.

Auth selection follows the same precedence as the k8s troubleshooting agent:
- **`--spire-socket-path` set** → SPIRE Workload API (`SpireConfig` provider + verifier via `CreateApp`)
- **otherwise** → shared secret (`CreateAppWithSecret`)

## New flags

| Flag | Description |
|------|-------------|
| `--spire-socket-path` | SPIRE Workload API socket path (enables SPIRE auth) |
| `--spire-target-spiffe-id` | Target SPIFFE ID to request (optional) |
| `--spire-jwt-audience` | JWT audience(s) to request; may be repeated (optional) |

All three are also supported in `.a2acli.yaml` under `slim.spire.*`.

## Type of Change

- [x] New Feature

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented