### PR TITLE
feat(mulitcluster-demo): add MCP clien for k8s troubleshooting agent

### DIFF
--- a/multicluster-demo/k8s_troubleshooting_agent/.env.template
+++ b/multicluster-demo/k8s_troubleshooting_agent/.env.template
@@ -23,4 +23,3 @@ SLIM_SECRET=secretsecretsecretsecretsecretsecret
 MCP_PROXY_NAMESPACE=org
 MCP_PROXY_GROUP=mcp
 MCP_PROXY_NAME=k8s-proxy
-MCP_CLIENT_NAME=k8s-mcp-client

--- a/multicluster-demo/k8s_troubleshooting_agent/.env.template
+++ b/multicluster-demo/k8s_troubleshooting_agent/.env.template
@@ -18,3 +18,9 @@ SLIM_NAMESPACE=agntcy
 SLIM_GROUP=demo
 SLIM_NAME=k8s_troubleshooting_agent
 SLIM_SECRET=secretsecretsecretsecretsecretsecret
+
+# MCP Proxy Configuration (for connecting to k8s MCP server)
+MCP_PROXY_NAMESPACE=org
+MCP_PROXY_GROUP=mcp
+MCP_PROXY_NAME=k8s-proxy
+MCP_CLIENT_NAME=k8s-mcp-client

--- a/multicluster-demo/k8s_troubleshooting_agent/k8s_troubleshooting_agent/agent.py
+++ b/multicluster-demo/k8s_troubleshooting_agent/k8s_troubleshooting_agent/agent.py
@@ -3,6 +3,11 @@ import os
 from google.adk.agents import Agent
 from google.adk.models.lite_llm import LiteLlm
 
+from k8s_troubleshooting_agent.tools import (
+    call_mcp_tool,
+    list_available_mcp_tools,
+)
+
 MODEL = os.getenv("MODEL", "gemini/gemini-2.0-flash")
 
 root_agent = Agent(
@@ -10,8 +15,20 @@ root_agent = Agent(
     model=LiteLlm(model=MODEL),
     description="An agent that helps troubleshoot Kubernetes clusters.",
     instruction=(
-        "You are a Kubernetes expert. Help the user diagnose and resolve issues "
-        "in their Kubernetes clusters. Ask clarifying questions about symptoms, "
-        "inspect provided manifests or error messages, and suggest actionable fixes."
+        "You are a Kubernetes expert with direct access to query a Kubernetes cluster. "
+        "Help the user diagnose and resolve issues in their Kubernetes clusters. "
+        "\n\n"
+        "When troubleshooting:\n"
+        "1. First, use list_available_mcp_tools to discover what tools are available\n"
+        "2. Use call_mcp_tool to query the cluster\n"
+        "3. Ask clarifying questions about symptoms if needed\n"
+        "4. Analyze the data returned from the cluster\n"
+        "5. Suggest actionable fixes based on what you observe\n"
+        "\n"
+        "Always check the actual cluster state before making recommendations."
     ),
+    tools=[
+        list_available_mcp_tools,
+        call_mcp_tool,
+    ],
 )

--- a/multicluster-demo/k8s_troubleshooting_agent/k8s_troubleshooting_agent/agent.py
+++ b/multicluster-demo/k8s_troubleshooting_agent/k8s_troubleshooting_agent/agent.py
@@ -3,11 +3,6 @@ import os
 from google.adk.agents import Agent
 from google.adk.models.lite_llm import LiteLlm
 
-from k8s_troubleshooting_agent.tools import (
-    call_mcp_tool,
-    list_available_mcp_tools,
-)
-
 MODEL = os.getenv("MODEL", "gemini/gemini-2.0-flash")
 
 root_agent = Agent(
@@ -19,16 +14,12 @@ root_agent = Agent(
         "Help the user diagnose and resolve issues in their Kubernetes clusters. "
         "\n\n"
         "When troubleshooting:\n"
-        "1. First, use list_available_mcp_tools to discover what tools are available\n"
-        "2. Use call_mcp_tool to query the cluster\n"
-        "3. Ask clarifying questions about symptoms if needed\n"
-        "4. Analyze the data returned from the cluster\n"
-        "5. Suggest actionable fixes based on what you observe\n"
+        "1. Query the cluster using the available MCP tools\n"
+        "2. Ask clarifying questions about symptoms if needed\n"
+        "3. Analyze the data returned from the cluster\n"
+        "4. Suggest actionable fixes based on what you observe\n"
         "\n"
         "Always check the actual cluster state before making recommendations."
     ),
-    tools=[
-        list_available_mcp_tools,
-        call_mcp_tool,
-    ],
+    tools=[],  # Tools will be set after MCP client initialization
 )

--- a/multicluster-demo/k8s_troubleshooting_agent/k8s_troubleshooting_agent/mcp_client.py
+++ b/multicluster-demo/k8s_troubleshooting_agent/k8s_troubleshooting_agent/mcp_client.py
@@ -1,0 +1,81 @@
+"""MCP Client for accessing Kubernetes cluster information via MCP server."""
+
+import logging
+from typing import Any
+
+import slim_bindings
+from mcp import ClientSession
+from slim_mcp import create_client_streams
+
+logger = logging.getLogger(__name__)
+
+class K8sMCPClient:
+    """Client for interacting with Kubernetes MCP server through SLIM."""
+
+    def __init__(
+        self,
+        local_app: Any,
+        proxy_name: str,
+        connection_id: str,
+    ):
+        """Initialize the MCP client.
+
+        Args:
+            local_app: Existing SLIM app instance
+            proxy_name: MCP proxy name in the form org/ns/name
+            connection_id: SLIM connection ID
+        """
+        self._client_app = local_app
+        self.proxy_name = proxy_name
+        self._connection_id = connection_id
+        self._session: ClientSession | None = None
+        self._destination = slim_bindings.Name.from_string(proxy_name)
+
+    async def set_proxy_route(self) -> None:
+        """Set route to MCP proxy in SLIM (must be called after __init__)."""
+        if self._connection_id is not None:
+            await self._client_app.set_route_async(self._destination, self._connection_id)
+        logger.info(f"Route set to MCP server at {self.proxy_name}")
+
+    async def list_available_tools(self) -> list[dict[str, Any]]:
+        """List all available tools from the MCP server.
+
+        Returns:
+            List of tool definitions
+        """
+        async with create_client_streams(self._client_app, self._destination) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                tools = await session.list_tools()
+                return [
+                    {
+                        "name": tool.name,
+                        "description": tool.description,
+                        "input_schema": tool.inputSchema,
+                    }
+                    for tool in tools.tools
+                ]
+
+    async def call_tool(self, tool_name: str, arguments: dict[str, Any]) -> str:
+        """Call a tool on the MCP server.
+
+        Args:
+            tool_name: Name of the tool to call
+            arguments: Tool arguments
+
+        Returns:
+            Tool result as a string
+        """
+        async with create_client_streams(self._client_app, self._destination) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                result = await session.call_tool(tool_name, arguments)
+
+                if result and len(result.content) > 0:
+                    output = []
+                    for content in result.content:
+                        if hasattr(content, "text"):
+                            output.append(content.text)
+                    return "\n".join(output)
+                return "No result returned"
+

--- a/multicluster-demo/k8s_troubleshooting_agent/k8s_troubleshooting_agent/mcp_client.py
+++ b/multicluster-demo/k8s_troubleshooting_agent/k8s_troubleshooting_agent/mcp_client.py
@@ -52,6 +52,7 @@ class K8sMCPClient:
                         "name": tool.name,
                         "description": tool.description,
                         "input_schema": tool.inputSchema,
+                        "output_schema": tool.outputSchema,
                     }
                     for tool in tools.tools
                 ]

--- a/multicluster-demo/k8s_troubleshooting_agent/k8s_troubleshooting_agent/tools.py
+++ b/multicluster-demo/k8s_troubleshooting_agent/k8s_troubleshooting_agent/tools.py
@@ -1,73 +1,156 @@
-"""Tools for the Kubernetes troubleshooting agent."""
-
-import json
 import logging
-from typing import Annotated
+from typing import Any, Optional
 
-from pydantic import Field
+from google.adk.tools.base_tool import BaseTool
+from google.adk.tools.base_toolset import BaseToolset
+from google.adk.tools.tool_context import ToolContext
+from google.adk.agents.readonly_context import ReadonlyContext
+from google.genai.types import FunctionDeclaration
+from mcp.types import Tool as McpBaseTool
+from typing_extensions import override
 
 from k8s_troubleshooting_agent.mcp_client import K8sMCPClient
 
 logger = logging.getLogger(__name__)
 
-# Global MCP client instance (will be initialized in main.py)
-mcp_client: K8sMCPClient | None = None
+class SLIMMcpTool(BaseTool):
+    """Wraps an MCP tool to work with ADK framework using SLIM MCP client."""
 
+    def __init__(
+        self,
+        mcp_tool: McpBaseTool,
+        mcp_client: K8sMCPClient,
+    ):
+        """Initialize a SLIM MCP tool.
 
-def set_mcp_client(client: K8sMCPClient) -> None:
-    """Set the global MCP client instance."""
-    global mcp_client
-    mcp_client = client
+        Args:
+            mcp_tool: The MCP tool definition from the server
+            mcp_client: The K8sMCPClient instance for communication
+        """
+        super().__init__(
+            name=mcp_tool.name,
+            description=mcp_tool.description if mcp_tool.description else "",
+        )
+        self._mcp_tool = mcp_tool
+        self._mcp_client = mcp_client
 
+    @override
+    def _get_declaration(self) -> FunctionDeclaration:
+        """Gets the function declaration for the tool.
 
-async def list_available_mcp_tools() -> str:
-    """List all available MCP tools from the Kubernetes MCP server.
-
-    Use this to discover what tools are available for querying the cluster.
-    Always call this first to know what operations you can perform.
-    
-    Returns a JSON array of tools, each with:
-    - name: The tool name to use with call_mcp_tool
-    - description: What the tool does
-    - input_schema: JSON schema describing required/optional parameters
-    """
-    if not mcp_client:
-        return "Error: MCP client not initialized"
-
-    try:
-        tools = await mcp_client.list_available_tools()
-        return json.dumps(tools, indent=2)
-    except Exception as e:
-        logger.error(f"Error listing MCP tools: {e}")
-        return f"Error listing MCP tools: {e}"
-
-
-async def call_mcp_tool(
-    tool_name: Annotated[str, Field(description="Name of the MCP tool to call")],
-    arguments: Annotated[dict, Field(description="Tool arguments as a dictionary")] = None,
-) -> str:
-    """Call any available MCP tool to query the Kubernetes cluster.
-
-    Use this to perform any operation discovered via list_available_mcp_tools.
-    Always call list_available_mcp_tools first to see what tools exist and what parameters they accept.
-    
-    Args:
-        tool_name: Name of the tool to call
-        arguments: Dictionary of arguments (optional, defaults to empty dict)
-    """
-    if not mcp_client:
-        return "Error: MCP client not initialized"
-
-    if arguments is None:
-        arguments = {}
+        Returns:
+            FunctionDeclaration: The Gemini function declaration for the tool.
+        """
+        input_schema = self._mcp_tool.inputSchema
+        output_schema = self._mcp_tool.outputSchema
         
-    logger.debug(f"Calling MCP tool: {tool_name} with args: {arguments}")
+        function_decl = FunctionDeclaration(
+            name=self.name,
+            description=self.description,
+            parameters_json_schema=input_schema,
+            response_json_schema=output_schema,
+        )
+        return function_decl
 
-    try:
-        result = await mcp_client.call_tool(tool_name, arguments)
-        logger.debug(f"MCP tool {tool_name} returned successfully")
-        return result
-    except Exception as e:
-        logger.error(f"Error calling MCP tool {tool_name}: {e}", exc_info=True)
-        return f"Error calling MCP tool {tool_name}: {e}"
+    @override
+    async def run_async(
+        self, *, args: dict[str, Any], tool_context: ToolContext
+    ) -> Any:
+        """Runs the tool with the given arguments.
+
+        Args:
+            args: The LLM-filled arguments.
+            tool_context: The context of the tool.
+
+        Returns:
+            The result of running the tool.
+        """
+        try:
+            logger.debug(f"Calling MCP tool: {self.name} with args: {args}")
+            result = await self._mcp_client.call_tool(self.name, args)
+            logger.debug(f"MCP tool {self.name} returned successfully")
+            return result
+        except Exception as e:
+            logger.error(f"Error calling MCP tool {self.name}: {e}", exc_info=True)
+            return {"error": f"Error calling MCP tool {self.name}: {e}"}
+
+
+class SLIMMcpToolSet(BaseToolset):
+    """Toolset that provides MCP tools via SLIM MCP client.
+    
+    This toolset automatically fetches available tools from the MCP server
+    and wraps them as ADK tools.
+    """
+
+    def __init__(
+        self,
+        mcp_client: K8sMCPClient,
+        tool_filter: Optional[list[str]] = None,
+        tool_name_prefix: Optional[str] = None,
+    ):
+        """Initialize the SLIM MCP toolset.
+
+        Args:
+            mcp_client: The K8sMCPClient instance for communication
+            tool_filter: Optional list of tool names to include (filters others out)
+            tool_name_prefix: Optional prefix to add to all tool names
+        """
+        super().__init__(
+            tool_filter=tool_filter,
+            tool_name_prefix=tool_name_prefix,
+        )
+        self._mcp_client = mcp_client
+
+    @override
+    async def get_tools(
+        self,
+        readonly_context: Optional[ReadonlyContext] = None,
+    ) -> list[BaseTool]:
+        """Return all tools from the MCP server.
+
+        Args:
+            readonly_context: Context used to filter tools available to the agent.
+                If None, all tools in the toolset are returned.
+
+        Returns:
+            List of BaseTool instances for each available MCP tool
+        """
+        try:
+            # Fetch available tools from the MCP server
+            tools_data = await self._mcp_client.list_available_tools()
+            
+            tools = []
+            for tool_data in tools_data:
+                # Reconstruct McpBaseTool from the dict
+                mcp_tool = McpBaseTool(
+                    # required fields
+                    name=tool_data["name"],
+                    inputSchema=tool_data["input_schema"],
+                    # Optional fields with defaults
+                    description=tool_data.get("description", ""),
+                    outputSchema=tool_data.get("output_schema", {}),  
+                )
+                
+                # Wrap as SLIMMcpTool
+                slim_tool = SLIMMcpTool(
+                    mcp_tool=mcp_tool,
+                    mcp_client=self._mcp_client,
+                )
+                
+                # Apply tool filter if specified
+                if self._is_tool_selected(slim_tool, readonly_context):
+                    tools.append(slim_tool)
+            
+            logger.info(f"Loaded {len(tools)} MCP tools from server")
+            return tools
+            
+        except Exception as e:
+            logger.error(f"Error fetching tools from MCP server: {e}", exc_info=True)
+            return []
+
+    async def close(self) -> None:
+        """Cleanup resources (no-op for SLIM client which is managed externally)."""
+        # The K8sMCPClient is managed by the main application lifecycle
+        # so we don't close it here
+        pass
 

--- a/multicluster-demo/k8s_troubleshooting_agent/k8s_troubleshooting_agent/tools.py
+++ b/multicluster-demo/k8s_troubleshooting_agent/k8s_troubleshooting_agent/tools.py
@@ -1,0 +1,73 @@
+"""Tools for the Kubernetes troubleshooting agent."""
+
+import json
+import logging
+from typing import Annotated
+
+from pydantic import Field
+
+from k8s_troubleshooting_agent.mcp_client import K8sMCPClient
+
+logger = logging.getLogger(__name__)
+
+# Global MCP client instance (will be initialized in main.py)
+mcp_client: K8sMCPClient | None = None
+
+
+def set_mcp_client(client: K8sMCPClient) -> None:
+    """Set the global MCP client instance."""
+    global mcp_client
+    mcp_client = client
+
+
+async def list_available_mcp_tools() -> str:
+    """List all available MCP tools from the Kubernetes MCP server.
+
+    Use this to discover what tools are available for querying the cluster.
+    Always call this first to know what operations you can perform.
+    
+    Returns a JSON array of tools, each with:
+    - name: The tool name to use with call_mcp_tool
+    - description: What the tool does
+    - input_schema: JSON schema describing required/optional parameters
+    """
+    if not mcp_client:
+        return "Error: MCP client not initialized"
+
+    try:
+        tools = await mcp_client.list_available_tools()
+        return json.dumps(tools, indent=2)
+    except Exception as e:
+        logger.error(f"Error listing MCP tools: {e}")
+        return f"Error listing MCP tools: {e}"
+
+
+async def call_mcp_tool(
+    tool_name: Annotated[str, Field(description="Name of the MCP tool to call")],
+    arguments: Annotated[dict, Field(description="Tool arguments as a dictionary")] = None,
+) -> str:
+    """Call any available MCP tool to query the Kubernetes cluster.
+
+    Use this to perform any operation discovered via list_available_mcp_tools.
+    Always call list_available_mcp_tools first to see what tools exist and what parameters they accept.
+    
+    Args:
+        tool_name: Name of the tool to call
+        arguments: Dictionary of arguments (optional, defaults to empty dict)
+    """
+    if not mcp_client:
+        return "Error: MCP client not initialized"
+
+    if arguments is None:
+        arguments = {}
+        
+    logger.debug(f"Calling MCP tool: {tool_name} with args: {arguments}")
+
+    try:
+        result = await mcp_client.call_tool(tool_name, arguments)
+        logger.debug(f"MCP tool {tool_name} returned successfully")
+        return result
+    except Exception as e:
+        logger.error(f"Error calling MCP tool {tool_name}: {e}", exc_info=True)
+        return f"Error calling MCP tool {tool_name}: {e}"
+

--- a/multicluster-demo/k8s_troubleshooting_agent/main.py
+++ b/multicluster-demo/k8s_troubleshooting_agent/main.py
@@ -58,7 +58,6 @@ SPIRE_JWT_AUDIENCE = [
 MCP_PROXY_NAMESPACE = os.getenv("MCP_PROXY_NAMESPACE", "org")
 MCP_PROXY_GROUP = os.getenv("MCP_PROXY_GROUP", "mcp")
 MCP_PROXY_NAME = os.getenv("MCP_PROXY_NAME", "k8s-proxy")
-MCP_CLIENT_NAME = os.getenv("MCP_CLIENT_NAME", "k8s-mcp-client")
 
 async def create_slim_app() -> tuple[slim_bindings.App, slim_bindings.Name, int]:
     """Initialise SLIM and create an App using SPIRE or shared-secret auth.

--- a/multicluster-demo/k8s_troubleshooting_agent/main.py
+++ b/multicluster-demo/k8s_troubleshooting_agent/main.py
@@ -1,9 +1,16 @@
 import asyncio
+import logging
 import os
 
 from dotenv import load_dotenv
 
 load_dotenv()
+
+# Set up logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
 
 import slim_bindings
 from a2a.server.request_handlers import DefaultRequestHandler
@@ -22,12 +29,20 @@ from slima2a.handler import SRPCHandler
 from slima2a.types.a2a_pb2_slimrpc import add_A2AServiceServicer_to_server
 
 from k8s_troubleshooting_agent.agent import root_agent
+from k8s_troubleshooting_agent.mcp_client import K8sMCPClient
+from k8s_troubleshooting_agent.tools import set_mcp_client
 
 SLIM_URL = os.getenv("SLIM_URL", "http://localhost:46357")
 SLIM_NAMESPACE = os.getenv("SLIM_NAMESPACE", "agntcy")
 SLIM_GROUP = os.getenv("SLIM_GROUP", "demo")
 SLIM_NAME = os.getenv("SLIM_NAME", "k8s_troubleshooting_agent")
 SLIM_SECRET = os.getenv("SLIM_SECRET", "secretsecretsecretsecretsecretsecret")
+
+# MCP proxy configuration
+MCP_PROXY_NAMESPACE = os.getenv("MCP_PROXY_NAMESPACE", "org")
+MCP_PROXY_GROUP = os.getenv("MCP_PROXY_GROUP", "mcp")
+MCP_PROXY_NAME = os.getenv("MCP_PROXY_NAME", "k8s-proxy")
+MCP_CLIENT_NAME = os.getenv("MCP_CLIENT_NAME", "k8s-mcp-client")
 
 
 async def main() -> None:
@@ -74,6 +89,15 @@ async def main() -> None:
         slim_url=SLIM_URL,
         secret=SLIM_SECRET,
     )
+
+    # Initialize MCP client after SLIM connection is established
+    mcp_client = K8sMCPClient(
+        local_app=local_app,
+        proxy_name=f"{MCP_PROXY_NAMESPACE}/{MCP_PROXY_GROUP}/{MCP_PROXY_NAME}",
+        connection_id=conn_id,
+    )
+    await mcp_client.set_proxy_route()
+    set_mcp_client(mcp_client)
 
     server = slim_bindings.Server.new_with_connection(local_app, local_name, conn_id)
     add_A2AServiceServicer_to_server(servicer, server)

--- a/multicluster-demo/k8s_troubleshooting_agent/main.py
+++ b/multicluster-demo/k8s_troubleshooting_agent/main.py
@@ -34,7 +34,7 @@ from slima2a.types.a2a_pb2_slimrpc import add_A2AServiceServicer_to_server
 
 from k8s_troubleshooting_agent.agent import root_agent
 from k8s_troubleshooting_agent.mcp_client import K8sMCPClient
-from k8s_troubleshooting_agent.tools import set_mcp_client
+from k8s_troubleshooting_agent.tools import SLIMMcpToolSet
 
 # SLIM connection
 SLIM_URL = os.getenv("SLIM_URL", "http://localhost:46357")
@@ -150,7 +150,13 @@ async def main() -> None:
         connection_id=conn_id,
     )
     await mcp_client.set_proxy_route()
-    set_mcp_client(mcp_client)
+    
+    # Create the MCP toolset
+    mcp_toolset = SLIMMcpToolSet(mcp_client=mcp_client)
+    
+    # Set the toolset on the agent
+    # The toolset will automatically handle tool loading on first use
+    root_agent.tools = [mcp_toolset]
 
     server = slim_bindings.Server.new_with_connection(local_app, local_name, conn_id)
     add_A2AServiceServicer_to_server(servicer, server)

--- a/multicluster-demo/k8s_troubleshooting_agent/pyproject.toml
+++ b/multicluster-demo/k8s_troubleshooting_agent/pyproject.toml
@@ -10,4 +10,6 @@ dependencies = [
     "python-dotenv>=1.2.2",
     "slima2a>=0.3.0",
     "slim-bindings<1.3.0",
+    "mcp>=1.0.0",
+    "slim-mcp>=0.2.2",
 ]

--- a/multicluster-demo/k8s_troubleshooting_agent/uv.lock
+++ b/multicluster-demo/k8s_troubleshooting_agent/uv.lock
@@ -1667,8 +1667,10 @@ source = { virtual = "." }
 dependencies = [
     { name = "google-adk", extra = ["a2a"] },
     { name = "litellm" },
+    { name = "mcp" },
     { name = "python-dotenv" },
     { name = "slim-bindings" },
+    { name = "slim-mcp" },
     { name = "slima2a" },
 ]
 
@@ -1676,8 +1678,10 @@ dependencies = [
 requires-dist = [
     { name = "google-adk", extras = ["a2a"], specifier = ">=1.28.0" },
     { name = "litellm", specifier = ">=1.83.0" },
+    { name = "mcp", specifier = ">=1.0.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "slim-bindings", specifier = "<1.3.0" },
+    { name = "slim-mcp", specifier = ">=0.2.2" },
     { name = "slima2a", specifier = ">=0.3.0" },
 ]
 
@@ -2987,6 +2991,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8c/6a/c58247afbaaf7057c9143c6170eb08111a05996337b4c51edb507cc5101a/slim_bindings-1.2.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:74470934fca9278dfffbc979dee833d29335a6d74e89310c0eafcebe08038381", size = 13272688, upload-time = "2026-02-27T18:53:38.321Z" },
     { url = "https://files.pythonhosted.org/packages/06/92/baf8ee49db646f336914f1ecd9415f965402f4aa357bd228319a06581405/slim_bindings-1.2.0-py3-none-win_amd64.whl", hash = "sha256:1255250e8db8b3838d0ce940350f9202c4545f9175208366993cfae2f5a0221c", size = 12036097, upload-time = "2026-02-27T18:53:40.444Z" },
     { url = "https://files.pythonhosted.org/packages/3a/6b/03eaf28c9bb1578d02fceb65ddccf7884049cb010d865f58c8ae2c43f821/slim_bindings-1.2.0-py3-none-win_arm64.whl", hash = "sha256:8abb184c1d054a1c5fbd587e44d70c2dee13c69c71b9992d58915ca6e704a581", size = 11284386, upload-time = "2026-02-27T18:53:42.738Z" },
+]
+
+[[package]]
+name = "slim-mcp"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "mcp" },
+    { name = "slim-bindings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/77/ff76ae083271dca883c8ef6f2ec1cd392904e34695004c32160d2b0607aa/slim_mcp-0.2.2.tar.gz", hash = "sha256:942a4c0f0525ab9309ef8a5d7c78ab132e294a2f3e242b2c8ddf96d7837a2077", size = 164338, upload-time = "2026-04-03T11:27:35.637Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/7e/0203ff663c2f85da22f29fed7a12442a540393d352df018861d4e8be825c/slim_mcp-0.2.2-py3-none-any.whl", hash = "sha256:914d2881b4cb32b48d931b27818a601726ea5dcf514bc80c44acd1e1fb1ab2bc", size = 25228, upload-time = "2026-04-03T11:27:34.119Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description
Integrates the MCP client to enable the Kubernetes troubleshooting agent to query cluster resources via an MCP server proxy over SLIM.

### Changes

**New MCP Client (`mcp_client.py`)**
- `K8sMCPClient` class that connects to an MCP proxy via SLIM
- `list_available_tools()`: discovers available MCP tools from the server
- `call_tool()`: executes MCP tool calls and returns results

**Configuration**
- `.env.template`: Added `MCP_PROXY_NAMESPACE`, `MCP_PROXY_GROUP`, `MCP_PROXY_NAME` settings



## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
