### PR TITLE
feat: add release for k8s-agent image and helm

### DIFF
--- a/.github/release-config.json
+++ b/.github/release-config.json
@@ -22,6 +22,14 @@
     "data-plane/testing": {
       "package-name": "slim-testutils",
       "release-type": "simple"
+    },
+    "multicluster-demo/k8s_troubleshooting_agent": {
+      "package-name": "k8s-agent",
+      "release-type": "simple"
+    },
+    "multicluster-demo/k8s_troubleshooting_agent/chart": {
+      "package-name": "helm-k8s-troubleshooting-agent",
+      "release-type": "helm"
     }
   }
 }

--- a/.github/release-config.json
+++ b/.github/release-config.json
@@ -24,7 +24,7 @@
       "release-type": "simple"
     },
     "multicluster-demo/k8s_troubleshooting_agent": {
-      "package-name": "k8s-agent",
+      "package-name": "k8s-troubleshooting-agent",
       "release-type": "simple"
     },
     "multicluster-demo/k8s_troubleshooting_agent/chart": {

--- a/.github/release-manifest.json
+++ b/.github/release-manifest.json
@@ -2,5 +2,7 @@
   "charts/slim": "1.3.0",
   "data-plane/testing": "0.7.1",
   "control-plane/control-plane": "1.0.0",
-  "charts/slim-control-plane": "1.0.0"
+  "charts/slim-control-plane": "1.0.0",
+  "multicluster-demo/k8s_troubleshooting_agent": "0.1.0",
+  "multicluster-demo/k8s_troubleshooting_agent/chart": "0.1.0"
 }

--- a/.github/workflows/multicluster-demo-k8s-agent-helm.yaml
+++ b/.github/workflows/multicluster-demo-k8s-agent-helm.yaml
@@ -1,0 +1,93 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+---
+name: ci-multicluster-demo-k8s-agent-helm
+
+on:
+  push:
+    tags:
+      - 'helm-k8s-troubleshooting-agent-v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  prepare-build:
+    name: Prepare Build
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Resolve version from tag
+        id: resolve
+        run: |
+          # Tag format: helm-k8s-troubleshooting-agent-v{version}
+          VERSION="${GITHUB_REF_NAME#helm-k8s-troubleshooting-agent-v}"
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "Helm chart version: ${VERSION}"
+
+  release-helm:
+    name: Release Helm Chart
+    runs-on: ubuntu-latest
+    needs: [prepare-build]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: 3.12.1
+
+      - name: Helm lint
+        shell: bash
+        working-directory: ./multicluster-demo/k8s_troubleshooting_agent/chart
+        run: |
+          helm lint . --with-subcharts
+
+      - name: Helm package
+        id: package
+        shell: bash
+        working-directory: ./multicluster-demo/k8s_troubleshooting_agent/chart
+        env:
+          CHART_VERSION: ${{ needs.prepare-build.outputs.version }}
+        run: |
+          helm package . --dependency-update --version "${CHART_VERSION}"
+          PACKAGE_NAME="k8s-troubleshooting-agent-${CHART_VERSION}.tgz"
+          echo "package=${PACKAGE_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Helm push to GHCR OCI registry
+        shell: bash
+        working-directory: ./multicluster-demo/k8s_troubleshooting_agent/chart
+        env:
+          HELM_PACKAGE: ${{ steps.package.outputs.package }}
+        run: |
+          echo "🚧 Pushing ${HELM_PACKAGE} to GHCR OCI registry"
+          helm push "${HELM_PACKAGE}" "oci://ghcr.io/agntcy/slim/multicluster-demo/helm"

--- a/.github/workflows/multicluster-demo-k8s-agent-image.yaml
+++ b/.github/workflows/multicluster-demo-k8s-agent-image.yaml
@@ -1,0 +1,87 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+---
+name: ci-multicluster-demo-k8s-agent-image
+
+on:
+  push:
+    tags:
+      - 'k8s-agent-v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  prepare-build:
+    name: Prepare Build
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Resolve version from tag
+        id: resolve
+        run: |
+          # Tag format: k8s-agent-v{version}
+          VERSION="${GITHUB_REF_NAME#k8s-agent-v}"
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "Docker image version: ${VERSION}"
+
+  build-docker:
+    name: Build and Push Docker
+    needs: [prepare-build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Disk cleanup
+        uses: ./.github/actions/cleanup-disk
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check available disk space
+        run: df -h
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Build and push
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        with:
+          context: ./multicluster-demo/k8s_troubleshooting_agent
+          file: ./multicluster-demo/k8s_troubleshooting_agent/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/agntcy/slim/multicluster-demo/k8s-agent:${{ needs.prepare-build.outputs.version }}
+            ghcr.io/agntcy/slim/multicluster-demo/k8s-agent:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false

--- a/.github/workflows/multicluster-demo-k8s-agent-image.yaml
+++ b/.github/workflows/multicluster-demo-k8s-agent-image.yaml
@@ -7,7 +7,7 @@ name: ci-multicluster-demo-k8s-agent-image
 on:
   push:
     tags:
-      - 'k8s-agent-v*'
+      - 'k8s-troubleshooting-agent-v*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release-check.yaml
+++ b/.github/workflows/release-check.yaml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+      - multicluster-demo
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release-check.yaml
+++ b/.github/workflows/release-check.yaml
@@ -27,3 +27,4 @@ jobs:
           token: ${{ secrets.AGNTCY_BUILD_BOT_GH_TOKEN }}
           config-file: .github/release-config.json
           manifest-file: .github/release-manifest.json
+          target-branch: ${{ github.ref_name }}

--- a/multicluster-demo/k8s_troubleshooting_agent/CHANGELOG.md
+++ b/multicluster-demo/k8s_troubleshooting_agent/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.0 (TBD)
+
+### Features
+
+* Initial release of k8s-troubleshooting-agent
+* Google ADK-based agent for Kubernetes troubleshooting
+* MCP integration via SLIM for cluster access
+

--- a/multicluster-demo/k8s_troubleshooting_agent/chart/CHANGELOG.md
+++ b/multicluster-demo/k8s_troubleshooting_agent/chart/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.0 (TBD)
+
+### Features
+
+* Initial Helm chart release for k8s-troubleshooting-agent
+* Support for SLIM connection configuration
+* Support for SPIRE and shared-secret authentication
+* Configurable MCP server settings


### PR DESCRIPTION
# Description

add workflows to release both the image and the helm chart of the k8s troubleshooting agent

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
