### PR TITLE
fix(slimctl): correct test name spelling (writable)

### DIFF
--- a/data-plane/slimctl/src/commands/slim_cmd.rs
+++ b/data-plane/slimctl/src/commands/slim_cmd.rs
@@ -139,7 +139,7 @@ mod tests {
     }
 
     #[test]
-    fn create_temp_config_file_is_writeable() {
+    fn create_temp_config_file_is_writable() {
         let tmp = create_temp_config(Some("0.0.0.0:1234")).unwrap();
         assert!(tmp.path().exists());
         let content = std::fs::read_to_string(tmp.path()).unwrap();


### PR DESCRIPTION
Rename create_temp_config_file_is_writeable to create_temp_config_file_is_writable.

The CI task failed due to the typo in the name of test function 