### PR TITLE
feat(multicluster-demo): a2acli SPIRE auth and TLS improvements

### DIFF
--- a/multicluster-demo/a2acli-skill/.a2acli.yaml.example
+++ b/multicluster-demo/a2acli-skill/.a2acli.yaml.example
@@ -15,6 +15,9 @@ slim:
   # Shared-secret auth (used when spire.socket-path is not set)
   secret: "my_shared_secret"
 
+  # Skip TLS certificate verification (https:// endpoints only). Default: false.
+  # tls-skip-verify: false
+
   # SPIRE dynamic identity auth (takes precedence over secret when socket-path is set)
   # spire:
   #   socket-path: "/tmp/spire-agent/public/api.sock"

--- a/multicluster-demo/a2acli-skill/cmd/get_task.go
+++ b/multicluster-demo/a2acli-skill/cmd/get_task.go
@@ -22,6 +22,7 @@ var getTaskCmd = &cobra.Command{
 Prints the task's status, artifacts, and history as JSON.`,
 	Example: `  a2acli get-task --agent sha256:3f7a2c1b "01938f4a-1234-7abc-def0-123456789abc"`,
 	Args:    cobra.ExactArgs(1),
+	PreRunE: func(cmd *cobra.Command, args []string) error { return initSLIM() },
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if getTaskAgentDigest == "" {
 			return fmt.Errorf("--agent flag is required")

--- a/multicluster-demo/a2acli-skill/cmd/root.go
+++ b/multicluster-demo/a2acli-skill/cmd/root.go
@@ -78,58 +78,64 @@ Each agent is identified by the SHA256 digest of its AgentCard file.`,
 		}
 		agentStore = s
 
-		if slimEndpoint != "" {
-			slim_bindings.InitializeWithDefaults()
-			svc := slim_bindings.GetGlobalService()
-
-			localName, err := slim_bindings.NameFromString(slimLocalName)
-			if err != nil {
-				return fmt.Errorf("invalid --slim-local-name %q: %w", slimLocalName, err)
-			}
-
-			connID, err := svc.Connect(slim_bindings.NewInsecureClientConfig(slimEndpoint))
-			if err != nil {
-				return fmt.Errorf("SLIM Connect failed: %w", err)
-			}
-			slimConnID = connID
-
-			var app *slim_bindings.App
-			if spireSocketPath != "" {
-				var socketPath *string
-				if spireSocketPath != "" {
-					socketPath = &spireSocketPath
-				}
-				var targetSpiffeID *string
-				if spireTargetSpiffeID != "" {
-					targetSpiffeID = &spireTargetSpiffeID
-				}
-				spireConfig := slim_bindings.SpireConfig{
-					SocketPath:     socketPath,
-					TargetSpiffeId: targetSpiffeID,
-					JwtAudiences:   spireJwtAudiences,
-					TrustDomains:   []string{},
-				}
-				providerConfig := slim_bindings.IdentityProviderConfigSpire{Config: spireConfig}
-				verifierConfig := slim_bindings.IdentityVerifierConfigSpire{Config: spireConfig}
-				app, err = svc.CreateApp(localName, providerConfig, verifierConfig)
-				if err != nil {
-					return fmt.Errorf("SLIM CreateApp (SPIRE) failed: %w", err)
-				}
-			} else {
-				app, err = svc.CreateAppWithSecret(localName, slimSecret)
-				if err != nil {
-					return fmt.Errorf("SLIM CreateApp (shared secret) failed: %w", err)
-				}
-			}
-			slimApp = app
-
-			if err := app.Subscribe(localName, &slimConnID); err != nil {
-				return fmt.Errorf("SLIM Subscribe failed: %w", err)
-			}
-		}
-
 		return nil
 	},
+}
+
+// initSLIM connects to the SLIM node and creates an App. It is called from the
+// PreRunE of commands that actually communicate with agents (send-message,
+// get-task). Local-only commands (list, get-card) do not call this.
+func initSLIM() error {
+	if slimEndpoint == "" {
+		return nil
+	}
+
+	slim_bindings.InitializeWithDefaults()
+	svc := slim_bindings.GetGlobalService()
+
+	localName, err := slim_bindings.NameFromString(slimLocalName)
+	if err != nil {
+		return fmt.Errorf("invalid --slim-local-name %q: %w", slimLocalName, err)
+	}
+
+	connID, err := svc.Connect(slim_bindings.NewInsecureClientConfig(slimEndpoint))
+	if err != nil {
+		return fmt.Errorf("SLIM Connect failed: %w", err)
+	}
+	slimConnID = connID
+
+	var app *slim_bindings.App
+	if spireSocketPath != "" {
+		socketPath := spireSocketPath
+		var targetSpiffeID *string
+		if spireTargetSpiffeID != "" {
+			targetSpiffeID = &spireTargetSpiffeID
+		}
+		spireConfig := slim_bindings.SpireConfig{
+			SocketPath:     &socketPath,
+			TargetSpiffeId: targetSpiffeID,
+			JwtAudiences:   spireJwtAudiences,
+			TrustDomains:   []string{},
+		}
+		providerConfig := slim_bindings.IdentityProviderConfigSpire{Config: spireConfig}
+		verifierConfig := slim_bindings.IdentityVerifierConfigSpire{Config: spireConfig}
+		app, err = svc.CreateApp(localName, providerConfig, verifierConfig)
+		if err != nil {
+			return fmt.Errorf("SLIM CreateApp (SPIRE) failed: %w", err)
+		}
+	} else {
+		app, err = svc.CreateAppWithSecret(localName, slimSecret)
+		if err != nil {
+			return fmt.Errorf("SLIM CreateApp (shared secret) failed: %w", err)
+		}
+	}
+	slimApp = app
+
+	if err := app.Subscribe(localName, &slimConnID); err != nil {
+		return fmt.Errorf("SLIM Subscribe failed: %w", err)
+	}
+
+	return nil
 }
 
 // newA2AClient creates an A2A client from an AgentCard, registering the SLIM

--- a/multicluster-demo/a2acli-skill/cmd/root.go
+++ b/multicluster-demo/a2acli-skill/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/a2aclient"
@@ -24,11 +25,12 @@ var (
 	agentsDir  string
 	agentStore *store.Store
 
-	slimEndpoint  string
-	slimLocalName string
-	slimSecret    string
-	slimApp       *slim_bindings.App
-	slimConnID    uint64
+	slimEndpoint      string
+	slimLocalName     string
+	slimSecret        string
+	slimTLSSkipVerify bool
+	slimApp           *slim_bindings.App
+	slimConnID        uint64
 
 	spireSocketPath     string
 	spireTargetSpiffeID string
@@ -61,6 +63,9 @@ Each agent is identified by the SHA256 digest of its AgentCard file.`,
 		}
 		if !flags.Changed("slim-secret") && cfg.Slim.Secret != "" {
 			slimSecret = cfg.Slim.Secret
+		}
+		if !flags.Changed("slim-tls-skip-verify") && cfg.Slim.TLSSkipVerify {
+			slimTLSSkipVerify = cfg.Slim.TLSSkipVerify
 		}
 		if !flags.Changed("spire-socket-path") && cfg.Slim.Spire.SocketPath != "" {
 			spireSocketPath = cfg.Slim.Spire.SocketPath
@@ -98,7 +103,16 @@ func initSLIM() error {
 		return fmt.Errorf("invalid --slim-local-name %q: %w", slimLocalName, err)
 	}
 
-	connID, err := svc.Connect(slim_bindings.NewInsecureClientConfig(slimEndpoint))
+	var clientCfg slim_bindings.ClientConfig
+	if strings.HasPrefix(slimEndpoint, "https://") {
+		clientCfg = slim_bindings.NewSecureClientConfig(slimEndpoint)
+		clientCfg.Tls.InsecureSkipVerify = slimTLSSkipVerify
+		clientCfg.Tls.IncludeSystemCaCertsPool = true
+	} else {
+		clientCfg = slim_bindings.NewInsecureClientConfig(slimEndpoint)
+	}
+
+	connID, err := svc.Connect(clientCfg)
 	if err != nil {
 		return fmt.Errorf("SLIM Connect failed: %w", err)
 	}
@@ -162,6 +176,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&slimEndpoint, "slim-endpoint", "", "SLIM node URL (e.g. http://localhost:46357)")
 	rootCmd.PersistentFlags().StringVar(&slimLocalName, "slim-local-name", "agntcy/cli/a2acli", "local SLIM name (namespace/group/name)")
 	rootCmd.PersistentFlags().StringVar(&slimSecret, "slim-secret", "", "shared secret for SLIM authentication")
+	rootCmd.PersistentFlags().BoolVar(&slimTLSSkipVerify, "slim-tls-skip-verify", false, "skip TLS certificate verification for the SLIM endpoint (https:// only)")
 	rootCmd.PersistentFlags().StringVar(&spireSocketPath, "spire-socket-path", "", "SPIRE Workload API socket path; when set, SPIRE identity auth is used instead of shared secret")
 	rootCmd.PersistentFlags().StringVar(&spireTargetSpiffeID, "spire-target-spiffe-id", "", "target SPIFFE ID to request from SPIRE (optional)")
 	rootCmd.PersistentFlags().StringArrayVar(&spireJwtAudiences, "spire-jwt-audience", nil, "JWT audience(s) to request from SPIRE (may be repeated)")

--- a/multicluster-demo/a2acli-skill/cmd/send_message.go
+++ b/multicluster-demo/a2acli-skill/cmd/send_message.go
@@ -33,7 +33,8 @@ without waiting for completion. The Task ID and initial status are printed and
 no polling is performed.`,
 	Example: `  a2acli send-message --agent sha256:3f7a2c1b "What can you do?"
   a2acli send-message --agent sha256:3f7a2c1b --return-immediately "Run a long analysis"`,
-	Args: cobra.ExactArgs(1),
+	Args:    cobra.ExactArgs(1),
+	PreRunE: func(cmd *cobra.Command, args []string) error { return initSLIM() },
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if sendMessageAgentDigest == "" {
 			return fmt.Errorf("--agent flag is required")

--- a/multicluster-demo/a2acli-skill/internal/config/config.go
+++ b/multicluster-demo/a2acli-skill/internal/config/config.go
@@ -23,10 +23,11 @@ type SpireConfig struct {
 
 // SlimConfig holds connection settings for the SLIM messaging node.
 type SlimConfig struct {
-	Endpoint  string      `yaml:"endpoint"`
-	LocalName string      `yaml:"local-name"`
-	Secret    string      `yaml:"secret"`
-	Spire     SpireConfig `yaml:"spire"`
+	Endpoint       string      `yaml:"endpoint"`
+	LocalName      string      `yaml:"local-name"`
+	Secret         string      `yaml:"secret"`
+	TLSSkipVerify  bool        `yaml:"tls-skip-verify"`
+	Spire          SpireConfig `yaml:"spire"`
 }
 
 // Config is the top-level configuration for a2acli.


### PR DESCRIPTION
## Description

Two improvements to the `a2acli` CLI tool:

### 1. Skip SLIM init for local-only commands

`list` and `get-card` only read from the local agents directory and never communicate with a SLIM node. SLIM initialization (which connects to the network) has been moved out of `PersistentPreRunE` into a dedicated `initSLIM()` helper that is called only from `send-message` and `get-task` via `PreRunE`.

### 2. TLS skip-verify support

Adds `--slim-tls-skip-verify` flag (and `slim.tls-skip-verify` config file key) to control server certificate verification for HTTPS SLIM endpoints.

When the endpoint URL starts with `https://`:
- Uses `NewSecureClientConfig` with `IncludeSystemCaCertsPool = true`
- Applies `InsecureSkipVerify` from the flag

When the endpoint uses `http://`, the existing insecure (no-TLS) config is used unchanged.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [x] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass