### PR TITLE
feat(multicluster-demo): add SPIRE and shared-secret auth to k8s agent client

### DIFF
--- a/multicluster-demo/k8s_troubleshooting_agent/client.py
+++ b/multicluster-demo/k8s_troubleshooting_agent/client.py
@@ -1,3 +1,6 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import asyncio
 import logging
@@ -9,19 +12,77 @@ from dotenv import load_dotenv
 load_dotenv()
 
 import httpx
+import slim_bindings
 from a2a.client import Client, ClientFactory, minimal_agent_card
 from a2a.types import Message, Part, Role, TextPart
-from slima2a import setup_slim_client
 from slima2a.client_transport import ClientConfig, SRPCTransport, slimrpc_channel_factory
 
+# SLIM connection
 SLIM_URL = os.getenv("SLIM_URL", "http://localhost:46357")
 SLIM_NAMESPACE = os.getenv("SLIM_NAMESPACE", "agntcy")
 SLIM_GROUP = os.getenv("SLIM_GROUP", "demo")
 SLIM_NAME = os.getenv("SLIM_NAME", "k8s_troubleshooting_agent")
-SLIM_SECRET = os.getenv("SLIM_SECRET", "secretsecretsecretsecretsecretsecret")
 SLIM_CLIENT_NAME = os.getenv("SLIM_CLIENT_NAME", "k8s_troubleshooting_client")
 
+# Shared-secret auth (used when SPIRE is not configured)
+SLIM_SECRET = os.getenv("SLIM_SECRET", "")
+
+# SPIRE auth (takes precedence over shared secret when SPIRE_SOCKET_PATH is set)
+SPIRE_SOCKET_PATH = os.getenv("SPIRE_SOCKET_PATH", "")
+SPIRE_TARGET_SPIFFE_ID = os.getenv("SPIRE_TARGET_SPIFFE_ID", "") or None
+SPIRE_JWT_AUDIENCE = [
+    a.strip()
+    for a in os.getenv("SPIRE_JWT_AUDIENCE", "").split(",")
+    if a.strip()
+]
+
 logger = logging.getLogger(__name__)
+
+
+async def create_slim_app() -> tuple[slim_bindings.App, slim_bindings.Name, int]:
+    """Initialise SLIM and create an App using SPIRE or shared-secret auth.
+
+    Auth resolution order:
+      1. SPIRE  — when SPIRE_SOCKET_PATH is set.
+      2. Shared secret — when SLIM_SECRET is set.
+    """
+    slim_bindings.uniffi_set_event_loop(asyncio.get_running_loop())  # type: ignore[arg-type]
+
+    tracing_config = slim_bindings.new_tracing_config()
+    runtime_config = slim_bindings.new_runtime_config()
+    service_config = slim_bindings.new_service_config()
+    tracing_config.log_level = "info"
+
+    slim_bindings.initialize_with_configs(
+        tracing_config=tracing_config,
+        runtime_config=runtime_config,
+        service_config=[service_config],
+    )
+
+    service = slim_bindings.get_global_service()
+    local_name = slim_bindings.Name(SLIM_NAMESPACE, SLIM_GROUP, SLIM_CLIENT_NAME)
+
+    client_config = slim_bindings.new_insecure_client_config(SLIM_URL)
+    conn_id = await service.connect_async(client_config)
+
+    if SPIRE_SOCKET_PATH:
+        logger.debug("Using SPIRE dynamic identity authentication.")
+        spire_config = slim_bindings.SpireConfig(
+            trust_domains=[],
+            socket_path=SPIRE_SOCKET_PATH,
+            target_spiffe_id=SPIRE_TARGET_SPIFFE_ID,
+            jwt_audiences=SPIRE_JWT_AUDIENCE,
+        )
+        provider_config = slim_bindings.IdentityProviderConfig.SPIRE(config=spire_config)
+        verifier_config = slim_bindings.IdentityVerifierConfig.SPIRE(config=spire_config)
+        local_app = service.create_app(local_name, provider_config, verifier_config)
+    else:
+        logger.debug("Using shared-secret authentication.")
+        local_app = service.create_app_with_secret(local_name, SLIM_SECRET)
+
+    await local_app.subscribe_async(local_name, conn_id)
+
+    return local_app, local_name, conn_id
 
 
 async def send_message(client: Client, text: str) -> str:
@@ -57,13 +118,7 @@ async def main() -> None:
 
     logging.basicConfig(level=args.log_level)
 
-    service, local_app, local_name, conn_id = await setup_slim_client(
-        namespace=SLIM_NAMESPACE,
-        group=SLIM_GROUP,
-        name=SLIM_CLIENT_NAME,
-        slim_url=SLIM_URL,
-        secret=SLIM_SECRET,
-    )
+    local_app, local_name, conn_id = await create_slim_app()
 
     client_config = ClientConfig(
         supported_transports=["slimrpc"],

--- a/multicluster-demo/k8s_troubleshooting_agent/client.py
+++ b/multicluster-demo/k8s_troubleshooting_agent/client.py
@@ -23,6 +23,7 @@ SLIM_NAMESPACE = os.getenv("SLIM_NAMESPACE", "agntcy")
 SLIM_GROUP = os.getenv("SLIM_GROUP", "demo")
 SLIM_NAME = os.getenv("SLIM_NAME", "k8s_troubleshooting_agent")
 SLIM_CLIENT_NAME = os.getenv("SLIM_CLIENT_NAME", "k8s_troubleshooting_client")
+SLIM_TLS_SKIP_VERIFY = os.getenv("SLIM_TLS_SKIP_VERIFY", "false").lower() == "true"
 
 # Shared-secret auth (used when SPIRE is not configured)
 SLIM_SECRET = os.getenv("SLIM_SECRET", "")
@@ -63,6 +64,10 @@ async def create_slim_app() -> tuple[slim_bindings.App, slim_bindings.Name, int]
     local_name = slim_bindings.Name(SLIM_NAMESPACE, SLIM_GROUP, SLIM_CLIENT_NAME)
 
     client_config = slim_bindings.new_insecure_client_config(SLIM_URL)
+    client_config.tls.insecure = False if SLIM_URL.startswith("https://") else True
+    client_config.tls.insecure_skip_verify = SLIM_TLS_SKIP_VERIFY
+    client_config.tls.include_system_ca_certs_pool = True
+
     conn_id = await service.connect_async(client_config)
 
     if SPIRE_SOCKET_PATH:


### PR DESCRIPTION
## Description

Updates `client.py` in the k8s troubleshooting agent to support both SPIRE dynamic identity and shared-secret authentication for SLIM RPC connectivity, matching the pattern already applied to `main.py`.

### Changes

- Replace `setup_slim_client` with inline SLIM initialization via a `create_slim_app()` coroutine
- Add SPIRE env vars: `SPIRE_SOCKET_PATH`, `SPIRE_TARGET_SPIFFE_ID`, `SPIRE_JWT_AUDIENCE`
- Auth resolution: SPIRE takes precedence when `SPIRE_SOCKET_PATH` is set, otherwise falls back to `SLIM_SECRET`
- `SLIM_SECRET` default changed from hardcoded value to empty string
- Local SLIM identity uses `SLIM_CLIENT_NAME` so it registers under a distinct name from the server

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass