### PR TITLE
feat(slim-chart): add extraEnv param

### DIFF
--- a/charts/slim/templates/daemonset.yaml
+++ b/charts/slim/templates/daemonset.yaml
@@ -58,7 +58,10 @@ spec:
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
-                  fieldPath: status.podIP                  
+                  fieldPath: status.podIP
+{{- with .Values.slim.extraEnv }}
+{{ toYaml . | nindent 12 }}
+{{- end }}
           ports:
             - name: data-plane
               containerPort: {{ .Values.slim.service.data.port }}

--- a/charts/slim/templates/daemonset.yaml
+++ b/charts/slim/templates/daemonset.yaml
@@ -59,9 +59,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-{{- with .Values.slim.extraEnv }}
-{{ toYaml . | nindent 12 }}
-{{- end }}
+            {{- with .Values.slim.extraEnv }}
+            {{ toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: data-plane
               containerPort: {{ .Values.slim.service.data.port }}

--- a/charts/slim/templates/statefulset.yaml
+++ b/charts/slim/templates/statefulset.yaml
@@ -63,7 +63,10 @@ spec:
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
-                  fieldPath: status.podIP                  
+                  fieldPath: status.podIP
+{{- with .Values.slim.extraEnv }}
+{{ toYaml . | nindent 12 }}
+{{- end }}
           ports:
             - name: data-plane
               containerPort: {{ .Values.slim.service.data.port }}

--- a/charts/slim/templates/statefulset.yaml
+++ b/charts/slim/templates/statefulset.yaml
@@ -64,9 +64,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-{{- with .Values.slim.extraEnv }}
-{{ toYaml . | nindent 12 }}
-{{- end }}
+            {{- with .Values.slim.extraEnv }}
+            {{ toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: data-plane
               containerPort: {{ .Values.slim.service.data.port }}

--- a/charts/slim/values.yaml
+++ b/charts/slim/values.yaml
@@ -135,6 +135,21 @@ slim:
     # - name: datastore
     #   mountPath: /etc/datastore
 
+  extraEnv: []
+    # Example:
+    # - name: MY_CUSTOM_VAR
+    #   value: "my-value"
+    # - name: SECRET_VAR
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: my-secret
+    #       key: secret-key
+    # - name: CONFIGMAP_VAR
+    #   valueFrom:
+    #     configMapKeyRef:
+    #       name: my-configmap
+    #       key: config-key
+
 spire:
   enabled: false
   helperImage:


### PR DESCRIPTION
# Description

Add extarEnv parameter in the SLIM helm chart to setup custom env variables

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
