### PR TITLE
fix(helm-charts): add configmap checksum annotation for auto reload

### DIFF
--- a/charts/slim-control-plane/templates/deployment.yaml
+++ b/charts/slim-control-plane/templates/deployment.yaml
@@ -18,10 +18,11 @@ spec:
       {{- include "control-plane.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "control-plane.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}

--- a/charts/slim/templates/daemonset.yaml
+++ b/charts/slim/templates/daemonset.yaml
@@ -22,10 +22,11 @@ spec:
     {{- end }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "slim.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}

--- a/charts/slim/templates/statefulset.yaml
+++ b/charts/slim/templates/statefulset.yaml
@@ -27,10 +27,11 @@ spec:
     {{- end }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "slim.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}


### PR DESCRIPTION
# Description

Add a `checksum/config` annotation to the pod templates in the `slim` DaemonSet, `slim` StatefulSet, and `slim-control-plane` Deployment. This ensures that when a ConfigMap is updated (e.g. after a `helm upgrade` that changes chart values), Kubernetes will detect the annotation change and trigger a rolling update of the pods.

This follows the [Helm best practices guide for automatically rolling deployments](https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments).

Fixes #1487

## Type of Change

- [x] Bugfix

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass