### PR TITLE
feat(helm): allow to expose multiple ports via the service

### DIFF
--- a/charts/slim/templates/daemonset.yaml
+++ b/charts/slim/templates/daemonset.yaml
@@ -64,14 +64,18 @@ spec:
             {{ toYaml . | nindent 12 }}
             {{- end }}
           ports:
-            - name: data-plane
-              containerPort: {{ .Values.slim.service.data.port }}
+            {{- range $i, $data := .Values.slim.service.data }}
+            - name: data-plane-{{ $i }}
+              containerPort: {{ $data.port }}
               protocol: TCP
-              hostPort: {{ .Values.slim.service.data.port }}
-            - name: controller
-              containerPort: {{ .Values.slim.service.control.port }}
+              hostPort: {{ $data.port }}
+            {{- end }}
+            {{- range $i, $ctrl := .Values.slim.service.control }}
+            - name: controller-{{ $i }}
+              containerPort: {{ $ctrl.port }}
               protocol: TCP
-              hostPort: {{ .Values.slim.service.control.port }}
+              hostPort: {{ $ctrl.port }}
+            {{- end }}
           resources:
             {{- toYaml .Values.slim.resources | nindent 12 }}
           volumeMounts:

--- a/charts/slim/templates/ingress.yaml
+++ b/charts/slim/templates/ingress.yaml
@@ -42,7 +42,7 @@ spec:
               service:
                 name: {{ include "slim.fullname" $ }}
                 port:
-                  number: {{ $.Values.slim.service.data.port }}
+                  number: {{ (index $.Values.slim.service.data 0).port }}
           {{- end }}
     {{- end }}
 {{ end }}

--- a/charts/slim/templates/service.yaml
+++ b/charts/slim/templates/service.yaml
@@ -15,14 +15,18 @@ spec:
   clusterIP: None
   {{- end }}
   ports:
-    - port: {{ .Values.slim.service.data.port }}
-      targetPort: data-plane
+    {{- range $i, $data := .Values.slim.service.data }}
+    - port: {{ $data.port }}
+      targetPort: data-plane-{{ $i }}
       protocol: TCP
-      name: data-plane
-    - port: {{ .Values.slim.service.control.port }}
-      targetPort: controller
+      name: data-plane-{{ $i }}
+    {{- end }}
+    {{- range $i, $ctrl := .Values.slim.service.control }}
+    - port: {{ $ctrl.port }}
+      targetPort: controller-{{ $i }}
       protocol: TCP
-      name: controller
+      name: controller-{{ $i }}
+    {{- end }}
   selector:
     {{- include "slim.selectorLabels" . | nindent 4 }}
 {{- if eq .Values.slim.daemonset true }}
@@ -38,14 +42,18 @@ spec:
   type: ClusterIP
   internalTrafficPolicy: Local
   ports:
-    - port: {{ .Values.slim.service.data.port }}
-      targetPort: data-plane
+    {{- range $i, $data := .Values.slim.service.data }}
+    - port: {{ $data.port }}
+      targetPort: data-plane-{{ $i }}
       protocol: TCP
-      name: data-plane
-    - port: {{ .Values.slim.service.control.port }}
-      targetPort: controller
+      name: data-plane-{{ $i }}
+    {{- end }}
+    {{- range $i, $ctrl := .Values.slim.service.control }}
+    - port: {{ $ctrl.port }}
+      targetPort: controller-{{ $i }}
       protocol: TCP
-      name: controller
+      name: controller-{{ $i }}
+    {{- end }}
   selector:
     {{- include "slim.selectorLabels" . | nindent 4 }}
-{{- end }}    
+{{- end }}

--- a/charts/slim/templates/statefulset.yaml
+++ b/charts/slim/templates/statefulset.yaml
@@ -69,12 +69,16 @@ spec:
             {{ toYaml . | nindent 12 }}
             {{- end }}
           ports:
-            - name: data-plane
-              containerPort: {{ .Values.slim.service.data.port }}
+            {{- range $i, $data := .Values.slim.service.data }}
+            - name: data-plane-{{ $i }}
+              containerPort: {{ $data.port }}
               protocol: TCP
-            - name: controller
-              containerPort: {{ .Values.slim.service.control.port }}
+            {{- end }}
+            {{- range $i, $ctrl := .Values.slim.service.control }}
+            - name: controller-{{ $i }}
+              containerPort: {{ $ctrl.port }}
               protocol: TCP
+            {{- end }}
           resources:
             {{- toYaml .Values.slim.resources | nindent 12 }}
           volumeMounts:

--- a/charts/slim/values.yaml
+++ b/charts/slim/values.yaml
@@ -37,12 +37,12 @@ slim:
         # Required in case of multi-cluster setup or when SLIM nodes are behind a NAT or Load Balancer.
         # Used by the Controller to identify which group a SLIM node belongs to.
         # Controller sets up connections between nodes using group names.
-        # SLIM nodes in the same group are connected directly, via local_endpoint:{{ .Values.slim.service.data.port }}.
+        # SLIM nodes in the same group are connected directly, via local_endpoint.
         # SLIM nodes in different groups are connected via external_endpoint. See 'metadata' below.
         # group_name: "cluster-a"
         dataplane:
           servers:
-            - endpoint: "0.0.0.0:{{ .Values.slim.service.data.port }}"
+            - endpoint: "0.0.0.0:{{ (index .Values.slim.service.data 0).port }}"
               tls:
                 insecure: true
                 # Uncomment below to connect to control plane with MTLS by Spire
@@ -55,14 +55,14 @@ slim:
               #   # can use to connect to this node.
               #   local_endpoint: ${env:MY_POD_IP}
               #   # external_endpoint is required to be set when SLIM nodes are behind a NAT or Load Balancer
-              #   external_endpoint: "slim.example.com:{{ .Values.slim.service.data.port }}"
+              #   external_endpoint: "slim.example.com:{{ (index .Values.slim.service.data 0).port }}"
               #   # trust_domain is used to properly setup spire mtls. By default is the same as the group_name (cluster name),
               #   # but can be overridden in case of trust domain names different then group name (cluster name).
               #   trust_domain: "cluster-a"
           clients: []
         controller:
           servers:
-            - endpoint: "0.0.0.0:{{ .Values.slim.service.control.port }}"
+            - endpoint: "0.0.0.0:{{ (index .Values.slim.service.control 0).port }}"
               tls:
                 insecure: true
           # Uncomment below to connect to control plane with MTLS by Spire
@@ -90,10 +90,12 @@ slim:
     # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
     type: ClusterIP
     headless: false
+    # List of dataplane server ports to expose. One entry per dataplane server.
     data:
-      port: 46357
+      - port: 46357
+    # List of controller server ports to expose. One entry per controller server.
     control:
-      port: 46358
+      - port: 46358
 
   # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
   ingress:


### PR DESCRIPTION
# Description

When deploying the helm chart, allow all listeners configured for the
data plane to be exposed as k8s services.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
