### PR TITLE
chore: bump rand to 0.9.3 in data-plane Cargo.lock

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -59,7 +59,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "prost-types",
- "rand 0.9.2",
+ "rand 0.9.3",
  "reqwest",
  "schemars 1.2.1",
  "serde",
@@ -135,7 +135,7 @@ dependencies = [
  "parking_lot",
  "prost",
  "protoc-bin-vendored",
- "rand 0.9.2",
+ "rand 0.9.3",
  "regex",
  "rustls",
  "rustls-native-certs",
@@ -181,7 +181,7 @@ dependencies = [
  "prost",
  "prost-types",
  "protoc-bin-vendored",
- "rand 0.9.2",
+ "rand 0.9.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -212,7 +212,7 @@ dependencies = [
  "parking_lot",
  "prost",
  "protoc-bin-vendored",
- "rand 0.9.2",
+ "rand 0.9.3",
  "semver",
  "serde",
  "serde_json",
@@ -287,7 +287,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.3",
  "serde",
  "thiserror 2.0.18",
  "tokio",
@@ -325,7 +325,7 @@ dependencies = [
  "jsonwebtoken 10.3.0",
  "libc",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -2598,7 +2598,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.3",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -2996,7 +2996,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3056,9 +3056,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -4322,7 +4322,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.3",
 ]
 
 [[package]]


### PR DESCRIPTION
Summary

task data-plane:licenses fails on main because cargo-deny flags rand 0.9.2 under [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097). This change updates data-plane/Cargo.lock so the workspace resolves rand 0.9.3, matching the advisory’s fix for the 0.9 release line and restoring a clean advisory check.

Verification

task data-plane:licenses completes with advisories OK (you may still see the existing duration-string “no license field” warning, which is separate from this bump).