### PR TITLE
feat(multicluster-demo): add second MCP setting in k8s-tba

### DIFF
--- a/.github/workflows/multicluster-demo-a2acli-image.yaml
+++ b/.github/workflows/multicluster-demo-a2acli-image.yaml
@@ -1,0 +1,87 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+---
+name: ci-multicluster-demo-a2acli-image
+
+on:
+  push:
+    tags:
+      - 'a2acli-v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  prepare-build:
+    name: Prepare Build
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Resolve version from tag
+        id: resolve
+        run: |
+          # Tag format: a2acli-v{version}
+          VERSION="${GITHUB_REF_NAME#a2acli-v}"
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "Docker image version: ${VERSION}"
+
+  build-docker:
+    name: Build and Push Docker
+    needs: [prepare-build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Disk cleanup
+        uses: ./.github/actions/cleanup-disk
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check available disk space
+        run: df -h
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Build and push
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        with:
+          context: ./multicluster-demo/a2acli-skill
+          file: ./multicluster-demo/a2acli-skill/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/agntcy/slim/multicluster-demo/a2acli:${{ needs.prepare-build.outputs.version }}
+            ghcr.io/agntcy/slim/multicluster-demo/a2acli:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false

--- a/multicluster-demo/a2acli-skill/.a2aagents/k8s_troubleshooting_agent.json
+++ b/multicluster-demo/a2acli-skill/.a2aagents/k8s_troubleshooting_agent.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "supportedInterfaces": [
     {
-      "url": "agntcy/demo/k8s_troubleshooting_agent",
+      "url": "agntcy/aws-cluster/k8s_troubleshooting_agent",
       "protocolBinding": "slimrpc",
       "protocolVersion": "0.3"
     }

--- a/multicluster-demo/a2acli-skill/Dockerfile
+++ b/multicluster-demo/a2acli-skill/Dockerfile
@@ -1,32 +1,24 @@
 # Dockerfile for running a2acli in K8s jobs
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-bookworm AS builder
 
 # Install dependencies for CGO
-RUN apk add --no-cache gcc musl-dev git task
+RUN apt-get update && apt-get install -y gcc git && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
 
-# Copy the a2acli source
+# Copy go module files first for better caching
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the rest of the source
 COPY . .
 
+# Download slim-bindings-go native libraries (setup step)
+RUN go run github.com/agntcy/slim-bindings-go/cmd/slim-bindings-setup
+
 # Build a2acli
-RUN task build
+RUN CGO_ENABLED=1 go build \
+    -ldflags "-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=ignore" \
+    -o bin/a2acli .
 
-# Runtime image
-FROM alpine:latest
-
-# Install CA certificates for HTTPS
-RUN apk add --no-cache ca-certificates
-
-WORKDIR /app
-
-# Copy the built binary
-COPY --from=builder /build/bin/a2acli /app/a2acli
-
-# Create directory for agent cards
-RUN mkdir -p /app/.a2aagents
-
-# Make binary executable
-RUN chmod +x /app/a2acli
-
-ENTRYPOINT ["/app/a2acli"]
+ENTRYPOINT ["bin/a2acli"]

--- a/multicluster-demo/a2acli-skill/Dockerfile
+++ b/multicluster-demo/a2acli-skill/Dockerfile
@@ -1,0 +1,32 @@
+# Dockerfile for running a2acli in K8s jobs
+FROM golang:1.24-alpine AS builder
+
+# Install dependencies for CGO
+RUN apk add --no-cache gcc musl-dev git task
+
+WORKDIR /build
+
+# Copy the a2acli source
+COPY . .
+
+# Build a2acli
+RUN task build
+
+# Runtime image
+FROM alpine:latest
+
+# Install CA certificates for HTTPS
+RUN apk add --no-cache ca-certificates
+
+WORKDIR /app
+
+# Copy the built binary
+COPY --from=builder /build/bin/a2acli /app/a2acli
+
+# Create directory for agent cards
+RUN mkdir -p /app/.a2aagents
+
+# Make binary executable
+RUN chmod +x /app/a2acli
+
+ENTRYPOINT ["/app/a2acli"]

--- a/multicluster-demo/a2acli-skill/k8s-health-check-cronjob.yaml
+++ b/multicluster-demo/a2acli-skill/k8s-health-check-cronjob.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: k8s-health-check
+  namespace: slim-multicluster-demo
+spec:
+  # Run every minute
+  schedule: "* * * * *"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: k8s-health-check
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: a2acli
+            image: ghcr.io/agntcy/slim/multicluster-demo/a2acli:latest
+            command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              
+              echo "Discovering k8s_troubleshooting_agent..."
+              AGENT_SHA=$(/app/a2acli list \
+                --slim-endpoint "$SLIM_ENDPOINT" \
+                --slim-secret "$SLIM_SECRET" \
+                | grep k8s_troubleshooting_agent \
+                | awk '{print $NF}')
+              
+              if [ -z "$AGENT_SHA" ]; then
+                echo "ERROR: k8s_troubleshooting_agent not found"
+                echo "Available agents:"
+                /app/a2acli list \
+                  --slim-endpoint "$SLIM_ENDPOINT" \
+                  --slim-secret "$SLIM_SECRET"
+                exit 1
+              fi
+              
+              echo "Found agent: $AGENT_SHA"
+              echo ""
+              echo "Sending health check message..."
+              /app/a2acli send-message \
+                --agent "$AGENT_SHA" \
+                --slim-endpoint "$SLIM_ENDPOINT" \
+                --slim-secret "$SLIM_SECRET" \
+                "Check cluster health status of the pods in namespace slim-multicluster-demo. If you see any issues, create a Jira ticket to track it."
+              
+              echo ""
+              echo "Health check completed successfully"
+            env:
+            - name: SLIM_ENDPOINT
+              value: "https://slim-dataplane.dev.eticloud.io:443"
+            - name: SLIM_SECRET
+              value: "default-multicluster-demo-shared-secret"

--- a/multicluster-demo/a2acli-skill/k8s-health-check-cronjob.yaml
+++ b/multicluster-demo/a2acli-skill/k8s-health-check-cronjob.yaml
@@ -30,23 +30,22 @@ spec:
               echo "Discovering k8s_troubleshooting_agent..."
               AGENT_SHA=$(/app/a2acli list \
                 --slim-endpoint "$SLIM_ENDPOINT" \
-                --slim-secret "$SLIM_SECRET" \
                 | grep k8s_troubleshooting_agent \
-                | awk '{print $NF}')
+                | awk '{print $NF}' \
+                | sed 's/\.\.\.//g')
               
               if [ -z "$AGENT_SHA" ]; then
                 echo "ERROR: k8s_troubleshooting_agent not found"
                 echo "Available agents:"
-                /app/a2acli list \
+                bin/a2acli list \
                   --slim-endpoint "$SLIM_ENDPOINT" \
-                  --slim-secret "$SLIM_SECRET"
                 exit 1
               fi
               
               echo "Found agent: $AGENT_SHA"
               echo ""
               echo "Sending health check message..."
-              /app/a2acli send-message \
+              bin/a2acli send-message \
                 --agent "$AGENT_SHA" \
                 --slim-endpoint "$SLIM_ENDPOINT" \
                 --slim-secret "$SLIM_SECRET" \

--- a/multicluster-demo/k8s_troubleshooting_agent/.env.template
+++ b/multicluster-demo/k8s_troubleshooting_agent/.env.template
@@ -19,7 +19,13 @@ SLIM_GROUP=demo
 SLIM_NAME=k8s_troubleshooting_agent
 SLIM_SECRET=secretsecretsecretsecretsecretsecret
 
-# K8s MCP Server Configuration (for connecting to k8s MCP server)
-K8S_MCP_SERVER_NAMESPACE=agntcy
-K8S_MCP_SERVER_GROUP=demo
-K8S_MCP_SERVER_NAME=mcp_server
+# K8s MCP Server Configuration
+K8S_MCP_SERVER_NAMESPACE=org
+K8S_MCP_SERVER_GROUP=mcp
+K8S_MCP_SERVER_NAME=k8s-proxy
+
+# Atlassian MCP Server Configuration
+ATLASSIAN_MCP_SERVER_NAMESPACE=agntcy
+ATLASSIAN_MCP_SERVER_GROUP=mcp
+ATLASSIAN_MCP_SERVER_NAME=atlassian-mcp
+

--- a/multicluster-demo/k8s_troubleshooting_agent/chart/templates/deployment.yaml
+++ b/multicluster-demo/k8s_troubleshooting_agent/chart/templates/deployment.yaml
@@ -74,6 +74,12 @@ spec:
               value: {{ .Values.k8s_mcp_server.group | quote }}
             - name: K8S_MCP_SERVER_NAME
               value: {{ .Values.k8s_mcp_server.name | quote }}
+            - name: ATLASSIAN_MCP_SERVER_NAMESPACE
+              value: {{ .Values.atlassian_mcp_server.namespace | quote }}
+            - name: ATLASSIAN_MCP_SERVER_GROUP
+              value: {{ .Values.atlassian_mcp_server.group | quote }}
+            - name: ATLASSIAN_MCP_SERVER_NAME
+              value: {{ .Values.atlassian_mcp_server.name | quote }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/multicluster-demo/k8s_troubleshooting_agent/chart/values.yaml
+++ b/multicluster-demo/k8s_troubleshooting_agent/chart/values.yaml
@@ -46,8 +46,15 @@ spire:
 # The agent connects to this MCP server via SLIM to query the Kubernetes cluster.
 k8s_mcp_server:
   namespace: "agntcy"
-  group: "demo"
+  group: "mcp"
   name: "mcp_server"
+
+# Atlassian MCP Server configuration.
+# The agent connects to this MCP server via SLIM to interact with Jira.
+atlassian_mcp_server:
+  namespace: "agntcy"
+  group: "mcp"
+  name: "atlassian-mcp"
 
 # Additional environment variables injected into the agent container.
 # Use this to supply LLM API keys (e.g. GEMINI_API_KEY) and any other

--- a/multicluster-demo/k8s_troubleshooting_agent/k8s_troubleshooting_agent/agent.py
+++ b/multicluster-demo/k8s_troubleshooting_agent/k8s_troubleshooting_agent/agent.py
@@ -8,18 +8,24 @@ MODEL = os.getenv("MODEL", "gemini/gemini-2.0-flash")
 root_agent = Agent(
     name="k8s_troubleshooting_agent",
     model=LiteLlm(model=MODEL),
-    description="An agent that helps troubleshoot Kubernetes clusters.",
+    description="An agent that helps troubleshoot Kubernetes clusters and creates Jira Issue if required.",
     instruction=(
         "You are a Kubernetes expert with direct access to query a Kubernetes cluster. "
         "Help the user diagnose and resolve issues in their Kubernetes clusters. "
+        "If explicitly asked, create tickets in Jira to track the issue that you find in your investigation. "
         "\n\n"
         "When troubleshooting:\n"
         "1. Query the cluster using the available MCP tools\n"
-        "2. Ask clarifying questions about symptoms if needed\n"
+        "2. Otherwise, ask clarifying questions about symptoms if needed\n"
         "3. Analyze the data returned from the cluster\n"
         "4. Suggest actionable fixes based on what you observe\n"
-        "\n"
-        "Always check the actual cluster state before making recommendations."
+        "5. Do not create Jira tickets unless explicitly asked by the user\n"
+        "\n\n"
+        "When asked to check the cluster state and create a Jira ticket:\n"
+        "1. Query the cluster using the available MCP tools\n"
+        "2. Analyze the data returned from the cluster\n"
+        "3. Create a Jira ticket using the available MCP tools to track the issue\n"
+        "4. Include detailed information in the Jira ticket about the cluster state and the issue you found\n"
     ),
     tools=[],  # Tools will be set after MCP client initialization
 )

--- a/multicluster-demo/k8s_troubleshooting_agent/main.py
+++ b/multicluster-demo/k8s_troubleshooting_agent/main.py
@@ -4,6 +4,7 @@
 import asyncio
 import logging
 import os
+from uuid import uuid4
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +21,7 @@ logging.basicConfig(
 import slim_bindings
 from a2a.server.request_handlers import DefaultRequestHandler
 from a2a.server.tasks import InMemoryTaskStore
-from a2a.types import AgentCapabilities, AgentCard, AgentSkill
+from a2a.types import AgentCapabilities, AgentCard, AgentSkill, Message, Part, Role, TextPart
 from google.adk.a2a.executor.a2a_agent_executor import A2aAgentExecutor
 from google.adk.artifacts.in_memory_artifact_service import InMemoryArtifactService
 from google.adk.auth.credential_service.in_memory_credential_service import (
@@ -56,8 +57,13 @@ SPIRE_JWT_AUDIENCE = [
 
 # K8s MCP server configuration
 K8S_MCP_SERVER_NAMESPACE = os.getenv("K8S_MCP_SERVER_NAMESPACE", "agntcy")
-K8S_MCP_SERVER_GROUP = os.getenv("K8S_MCP_SERVER_GROUP", "demo")
-K8S_MCP_SERVER_NAME = os.getenv("K8S_MCP_SERVER_NAME", "mcp_server")
+K8S_MCP_SERVER_GROUP = os.getenv("K8S_MCP_SERVER_GROUP", "mpc")
+K8S_MCP_SERVER_NAME = os.getenv("K8S_MCP_SERVER_NAME", "k8s-mcp")
+
+# Atlassian MCP server configuration
+ATLASSIAN_MCP_SERVER_NAMESPACE = os.getenv("ATLASSIAN_MCP_SERVER_NAMESPACE", "agntcy")
+ATLASSIAN_MCP_SERVER_GROUP = os.getenv("ATLASSIAN_MCP_SERVER_GROUP", "mcp")
+ATLASSIAN_MCP_SERVER_NAME = os.getenv("ATLASSIAN_MCP_SERVER_NAME", "atlassian-mcp")
 
 async def create_slim_app() -> tuple[slim_bindings.App, slim_bindings.Name, int]:
     """Initialise SLIM and create an App using SPIRE or shared-secret auth.
@@ -143,20 +149,31 @@ async def main() -> None:
 
     local_app, local_name, conn_id = await create_slim_app()
 
-    # Initialize MCP client after SLIM connection is established
-    mcp_client = K8sMCPClient(
+    # Initialize first MCP client (K8s MCP server)
+    mcp_client_k8s = K8sMCPClient(
         local_app=local_app,
         proxy_name=f"{K8S_MCP_SERVER_NAMESPACE}/{K8S_MCP_SERVER_GROUP}/{K8S_MCP_SERVER_NAME}",
         connection_id=conn_id,
     )
-    await mcp_client.set_proxy_route()
+    await mcp_client_k8s.set_proxy_route()
     
-    # Create the MCP toolset
-    mcp_toolset = SLIMMcpToolSet(mcp_client=mcp_client)
+    # Create the first MCP toolset
+    mcp_toolset_k8s = SLIMMcpToolSet(mcp_client=mcp_client_k8s)
     
-    # Set the toolset on the agent
-    # The toolset will automatically handle tool loading on first use
-    root_agent.tools = [mcp_toolset]
+    # Initialize second MCP client (Atlassian MCP server)
+    mcp_client_atlassian = K8sMCPClient(
+        local_app=local_app,
+        proxy_name=f"{ATLASSIAN_MCP_SERVER_NAMESPACE}/{ATLASSIAN_MCP_SERVER_GROUP}/{ATLASSIAN_MCP_SERVER_NAME}",
+        connection_id=conn_id,
+    )
+    await mcp_client_atlassian.set_proxy_route()
+
+    # Create the second MCP toolset
+    mcp_toolset_atlassian = SLIMMcpToolSet(mcp_client=mcp_client_atlassian)
+
+    # Set both toolsets on the agent
+    # Each toolset will automatically route tool calls to its corresponding MCP proxy
+    root_agent.tools = [mcp_toolset_k8s, mcp_toolset_atlassian]
 
     server = slim_bindings.Server.new_with_connection(local_app, local_name, conn_id)
     add_A2AServiceServicer_to_server(servicer, server)


### PR DESCRIPTION
# Description

- add second MCP setting in k8s-tba settings, this will be used for the JIRA MCP
- add second MCP config in the k8s-tba helm chart
- add Docker and release for a2acli app
- add k8s job file to run periodically the a2acli app

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass