### PR TITLE
feat(multicluster-demo): add macos SPIRE workflow for a2acli

### DIFF
--- a/multicluster-demo/.gitignore
+++ b/multicluster-demo/.gitignore
@@ -1,0 +1,2 @@
+bin/
+spire/data/

--- a/multicluster-demo/README.md
+++ b/multicluster-demo/README.md
@@ -1,1 +1,151 @@
-Multicluster demo
+# Multicluster demo
+
+This directory contains a macOS workflow for:
+
+1. Building and running a local SPIRE agent against the EKS SPIRE server.
+2. Registering the local `a2acli` binary as a SPIRE-authenticated workload.
+3. Using `a2acli` to connect to a SLIM dataplane exposed by a target cluster.
+
+## What Is In This Directory
+
+- `Taskfile.yml`: builds the local SPIRE agent, fetches the bootstrap bundle from EKS, generates a join token, starts the agent, and registers the `a2acli` workload.
+- `spire/agent.conf.tmpl`: SPIRE agent config template used to render a local runtime config.
+- `a2acli-skill/`: the `a2acli` source, local agent cards, and CLI config examples.
+
+## Prerequisites
+
+1. macOS.
+2. `go`, `task`, `kubectl`, and `git` installed.
+3. Valid cloud credentials with access to the target Kubernetes cluster.
+4. The following environment variables exported in your shell:
+
+```bash
+export MULTICLUSTER_DEMO_K8S_CONTEXT="<target-kubernetes-context>"
+export MULTICLUSTER_DEMO_SPIRE_NAMESPACE="<spire-namespace>"
+export MULTICLUSTER_DEMO_SPIRE_SERVER_POD="<spire-server-pod-name>"
+export MULTICLUSTER_DEMO_SPIRE_SERVER_ADDRESS="<spire-server-hostname>"
+export MULTICLUSTER_DEMO_TRUST_DOMAIN="<spiffe-trust-domain>"
+export MULTICLUSTER_DEMO_SLIM_ENDPOINT="https://<slim-dataplane-host>:443"
+```
+
+## Build And Run SPIRE
+
+Run these commands from this directory.
+
+```bash
+# Build the local SPIRE agent binary
+task build
+
+# Start the SPIRE agent
+task run
+```
+
+`task run` performs the full bootstrap flow:
+
+1. Builds `bin/spire-agent` from SPIRE source if it does not already exist.
+2. Fetches the target cluster SPIRE bootstrap bundle in PEM format.
+3. Generates a join token for `spiffe://<trust-domain>/macos/agent/<hostname>`.
+4. Renders a local runtime config under `spire/data/agent.conf`.
+5. Starts the agent and exposes the Workload API on `/tmp/spire-agent/public/api.sock`.
+
+Keep `task run` running in a dedicated terminal.
+
+## Build a2acli
+
+From the `a2acli-skill` directory:
+
+```bash
+cd a2acli-skill
+task build
+```
+
+This creates `a2acli-skill/bin/a2acli`.
+
+## Register a2acli As A SPIRE Workload
+
+From the `multicluster-demo` directory, after the SPIRE agent is already running:
+
+```bash
+task register
+```
+
+On macOS, the `unix` workload attestor emits `uid`, `user`, `gid`, and `group` selectors. The registration task uses those selectors so the local `a2acli` process can obtain an SVID from the Workload API.
+
+To inspect the entries registered for the current host:
+
+```bash
+task show-entries
+```
+
+To verify the local Workload API is issuing an SVID:
+
+```bash
+task fetch-svid
+```
+
+## Configure a2acli
+
+Create a local runtime config at `a2acli-skill/.a2acli.yaml`.
+
+That file is intentionally ignored by Git so it can stay machine-local.
+
+Example:
+
+```yaml
+slim:
+  endpoint: "${MULTICLUSTER_DEMO_SLIM_ENDPOINT}"
+  local-name: "agntcy/cli/a2acli"
+  spire:
+    socket-path: "/tmp/spire-agent/public/api.sock"
+    jwt-audiences:
+      - "slim"
+```
+
+## Send A Test Request Through The Target Dataplane
+
+From `a2acli-skill`:
+
+```bash
+./bin/a2acli list
+./bin/a2acli send-message --agent sha256:df721aea --return-immediately "What can you do?"
+```
+
+The expected outcome is:
+
+1. `a2acli` initializes the SPIRE provider from the local Workload API socket.
+2. `a2acli` connects to the SLIM dataplane configured in `MULTICLUSTER_DEMO_SLIM_ENDPOINT`.
+3. The request is accepted and returns a task ID.
+
+## Useful Tasks
+
+```bash
+task build
+task run
+task register
+task show-entries
+task fetch-svid
+task stop
+task clean
+```
+
+## Shareable Git State
+
+Tracked files in this directory do not contain laptop-specific absolute paths.
+
+Local-only artifacts are kept out of Git:
+
+- `a2acli-skill/.a2acli.yaml`
+- `spire/data/`
+- `bin/`
+
+The generated file `spire/data/agent.conf` does contain machine-local absolute paths by design, but it is runtime output only and is excluded from Git.
+
+This keeps the workflow PR-ready while still allowing each developer to generate their own local runtime config and local SPIRE state.
+
+## Troubleshooting
+
+If `task run` fails with `Unauthorized` or `ExpiredToken`, refresh AWS credentials and try again.
+
+If the agent fails with `no PEM blocks`, the bootstrap bundle source is wrong. The current Taskfile fetches the PEM bundle directly from the live SPIRE server to avoid that problem.
+
+If `a2acli` fails with `No identity issued`, the workload entry selectors do not match the selectors emitted by the local SPIRE agent. Re-run `task register` after the agent is already running.

--- a/multicluster-demo/Taskfile.yml
+++ b/multicluster-demo/Taskfile.yml
@@ -1,0 +1,156 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+version: "3"
+
+silent: true
+
+vars:
+  SPIRE_VERSION: v1.14.2
+  SPIRE_REPO: https://github.com/spiffe/spire
+  SPIRE_SRC_DIR: /tmp/spire-build-{{.SPIRE_VERSION}}
+  BIN_DIR: bin
+  AGENT_BIN: "{{.BIN_DIR}}/spire-agent"
+  SPIRE_DIR: spire
+  AGENT_CONF_TPL: "{{.SPIRE_DIR}}/agent.conf.tmpl"
+  DATA_DIR: "{{.SPIRE_DIR}}/data"
+  BUNDLE_PATH: "{{.DATA_DIR}}/bootstrap.crt"
+  RUNTIME_CONF: "{{.DATA_DIR}}/agent.conf"
+  SOCKET_DIR: /tmp/spire-agent/public
+  SOCKET_PATH: /tmp/spire-agent/public/api.sock
+
+tasks:
+  default:
+    cmds:
+      - task -l
+
+  build:
+    desc: Build the SPIRE agent binary for macOS from source ({{.SPIRE_VERSION}})
+    cmds:
+      - |
+        if [ -f "{{.AGENT_BIN}}" ]; then
+          echo "==> {{.AGENT_BIN}} already built — run 'task clean' to force rebuild"
+          exit 0
+        fi
+        if [ ! -d "{{.SPIRE_SRC_DIR}}" ]; then
+          echo "==> Cloning spire {{.SPIRE_VERSION}}..."
+          git clone --depth 1 --branch {{.SPIRE_VERSION}} {{.SPIRE_REPO}} {{.SPIRE_SRC_DIR}}
+        fi
+        echo "==> Building spire-agent from source (~2 min)..."
+        mkdir -p {{.BIN_DIR}}
+        OUT="$(pwd)/{{.AGENT_BIN}}"
+        cd {{.SPIRE_SRC_DIR}} && CGO_ENABLED=0 go build -o "$OUT" ./cmd/spire-agent/main.go
+        echo "==> Built: {{.AGENT_BIN}}"
+
+  agent-conf:
+    desc: Generate runtime agent.conf with a fresh join token from the EKS SPIRE server
+    cmds:
+      - mkdir -p {{.DATA_DIR}} {{.SOCKET_DIR}}
+      - |
+        K8S_CONTEXT="${MULTICLUSTER_DEMO_K8S_CONTEXT:?set MULTICLUSTER_DEMO_K8S_CONTEXT}"
+        SPIRE_NS="${MULTICLUSTER_DEMO_SPIRE_NAMESPACE:?set MULTICLUSTER_DEMO_SPIRE_NAMESPACE}"
+        SPIRE_SERVER_POD="${MULTICLUSTER_DEMO_SPIRE_SERVER_POD:?set MULTICLUSTER_DEMO_SPIRE_SERVER_POD}"
+        SPIRE_SERVER_ADDRESS="${MULTICLUSTER_DEMO_SPIRE_SERVER_ADDRESS:?set MULTICLUSTER_DEMO_SPIRE_SERVER_ADDRESS}"
+        TRUST_DOMAIN="${MULTICLUSTER_DEMO_TRUST_DOMAIN:?set MULTICLUSTER_DEMO_TRUST_DOMAIN}"
+        AGENT_SPIFFE_ID="spiffe://$TRUST_DOMAIN/macos/agent/$(hostname -s)"
+        echo "==> Fetching bootstrap PEM bundle ..."
+        kubectl --context "$K8S_CONTEXT" \
+          -n "$SPIRE_NS" \
+          exec "$SPIRE_SERVER_POD" -c spire-server -- \
+          spire-server bundle show -format pem > {{.BUNDLE_PATH}}
+        echo "==> Generating join token for $AGENT_SPIFFE_ID ..."
+        TOKEN=$(kubectl --context "$K8S_CONTEXT" \
+          -n "$SPIRE_NS" \
+          exec "$SPIRE_SERVER_POD" -c spire-server -- \
+          spire-server token generate -spiffeID "$AGENT_SPIFFE_ID" 2>/dev/null \
+          | awk '{print $2}')
+        [ -z "$TOKEN" ] && echo "ERROR: failed to generate token" && exit 1
+        echo "==> Token: $TOKEN"
+        DATA_DIR_ABS="$(pwd)/{{.DATA_DIR}}"
+        BUNDLE_PATH_ABS="$(pwd)/{{.BUNDLE_PATH}}"
+        sed -e "s|TOKEN_PLACEHOLDER|$TOKEN|g" \
+            -e "s|DATA_DIR_PLACEHOLDER|$DATA_DIR_ABS|g" \
+            -e "s|BUNDLE_PATH_PLACEHOLDER|$BUNDLE_PATH_ABS|g" \
+            -e "s|SPIRE_SERVER_ADDRESS_PLACEHOLDER|$SPIRE_SERVER_ADDRESS|g" \
+            -e "s|TRUST_DOMAIN_PLACEHOLDER|$TRUST_DOMAIN|g" \
+            {{.AGENT_CONF_TPL}} > {{.RUNTIME_CONF}}
+        echo "==> Config written: {{.RUNTIME_CONF}}"
+
+  run:
+    desc: Build, configure, and start the SPIRE agent (Ctrl-C to stop)
+    cmds:
+      - task: build
+      - task: agent-conf
+      - echo "==> Starting spire-agent — socket at {{.SOCKET_PATH}}"
+      - "{{.AGENT_BIN}} run -config {{.RUNTIME_CONF}}"
+
+  register:
+    desc: Register a workload SPIFFE entry for a2acli on the EKS SPIRE server (run once after agent is attested)
+    cmds:
+      - |
+        K8S_CONTEXT="${MULTICLUSTER_DEMO_K8S_CONTEXT:?set MULTICLUSTER_DEMO_K8S_CONTEXT}"
+        SPIRE_NS="${MULTICLUSTER_DEMO_SPIRE_NAMESPACE:?set MULTICLUSTER_DEMO_SPIRE_NAMESPACE}"
+        SPIRE_SERVER_POD="${MULTICLUSTER_DEMO_SPIRE_SERVER_POD:?set MULTICLUSTER_DEMO_SPIRE_SERVER_POD}"
+        TRUST_DOMAIN="${MULTICLUSTER_DEMO_TRUST_DOMAIN:?set MULTICLUSTER_DEMO_TRUST_DOMAIN}"
+        AGENT_SPIFFE_ID="spiffe://$TRUST_DOMAIN/macos/agent/$(hostname -s)"
+        A2ACLI_SPIFFE_ID="spiffe://$TRUST_DOMAIN/macos/workload/a2acli"
+        USER_NAME="$(id -un)"
+        USER_UID="$(id -u)"
+        GROUP_NAME="$(id -gn)"
+        GROUP_GID="$(id -g)"
+        echo "==> Registering workload entry:"
+        echo "    parentID : $AGENT_SPIFFE_ID"
+        echo "    spiffeID : $A2ACLI_SPIFFE_ID"
+        echo "    selectors:"
+        echo "      - unix:uid:$USER_UID"
+        echo "      - unix:user:$USER_NAME"
+        echo "      - unix:gid:$GROUP_GID"
+        echo "      - unix:group:$GROUP_NAME"
+        kubectl --context "$K8S_CONTEXT" \
+          -n "$SPIRE_NS" \
+          exec "$SPIRE_SERVER_POD" -c spire-server -- \
+          spire-server entry create \
+            -parentID "$AGENT_SPIFFE_ID" \
+            -spiffeID "$A2ACLI_SPIFFE_ID" \
+            -selector "unix:uid:$USER_UID" \
+            -selector "unix:user:$USER_NAME" \
+            -selector "unix:gid:$GROUP_GID" \
+            -selector "unix:group:$GROUP_NAME" \
+          || echo "==> Entry may already exist — run 'task show-entries' to verify"
+        echo ""
+        echo "==> Enable SPIRE auth in a2acli-skill/.a2acli.yaml:"
+        echo "    slim:"
+        echo "      spire:"
+        echo "        socket-path: \"{{.SOCKET_PATH}}\""
+        echo "        jwt-audiences: [\"slim\"]"
+
+  show-entries:
+    desc: Show all SPIRE workload entries registered for this macOS agent
+    cmds:
+      - |
+        K8S_CONTEXT="${MULTICLUSTER_DEMO_K8S_CONTEXT:?set MULTICLUSTER_DEMO_K8S_CONTEXT}"
+        SPIRE_NS="${MULTICLUSTER_DEMO_SPIRE_NAMESPACE:?set MULTICLUSTER_DEMO_SPIRE_NAMESPACE}"
+        SPIRE_SERVER_POD="${MULTICLUSTER_DEMO_SPIRE_SERVER_POD:?set MULTICLUSTER_DEMO_SPIRE_SERVER_POD}"
+        TRUST_DOMAIN="${MULTICLUSTER_DEMO_TRUST_DOMAIN:?set MULTICLUSTER_DEMO_TRUST_DOMAIN}"
+        AGENT_SPIFFE_ID="spiffe://$TRUST_DOMAIN/macos/agent/$(hostname -s)"
+        kubectl --context "$K8S_CONTEXT" \
+          -n "$SPIRE_NS" \
+          exec "$SPIRE_SERVER_POD" -c spire-server -- \
+          spire-server entry show -parentID "$AGENT_SPIFFE_ID"
+
+  fetch-svid:
+    desc: Fetch X.509 SVID from the Workload API socket to verify the agent is running
+    cmds:
+      - "{{.AGENT_BIN}} api fetch x509 -socketPath {{.SOCKET_PATH}}"
+
+  stop:
+    desc: Stop any running spire-agent process
+    cmds:
+      - pkill -f "spire-agent run -config" && echo "==> Stopped" || echo "==> No running agent found"
+
+  clean:
+    desc: Remove the built binary and agent data (forces full rebuild and re-attestation)
+    cmds:
+      - rm -f {{.AGENT_BIN}} {{.RUNTIME_CONF}}
+      - rm -rf {{.DATA_DIR}}
+      - echo "==> Cleaned"

--- a/multicluster-demo/a2acli-skill/.a2acli.yaml.example
+++ b/multicluster-demo/a2acli-skill/.a2acli.yaml.example
@@ -24,3 +24,13 @@ slim:
   #   target-spiffe-id: "spiffe://example.org/agent"   # optional
   #   jwt-audiences:                                    # optional
   #     - "my-audience"
+
+# Multicluster demo example using the EKS SLIM dataplane and a local SPIRE agent.
+# Copy this block into .a2acli.yaml for the shared demo setup.
+# slim:
+#   endpoint: "https://<slim-dataplane-host>:443"
+#   local-name: "agntcy/cli/a2acli"
+#   spire:
+#     socket-path: "/tmp/spire-agent/public/api.sock"
+#     jwt-audiences:
+#       - "slim"

--- a/multicluster-demo/a2acli-skill/.gitignore
+++ b/multicluster-demo/a2acli-skill/.gitignore
@@ -1,2 +1,3 @@
 bin/
 a2acli/scripts/a2acli
+.a2acli.yaml

--- a/multicluster-demo/a2acli-skill/k8s-health-check-cronjob.yaml
+++ b/multicluster-demo/a2acli-skill/k8s-health-check-cronjob.yaml
@@ -26,14 +26,14 @@ spec:
             - -c
             - |
               set -e
-              
+
               echo "Discovering k8s_troubleshooting_agent..."
               AGENT_SHA=$(/app/a2acli list \
                 --slim-endpoint "$SLIM_ENDPOINT" \
                 | grep k8s_troubleshooting_agent \
                 | awk '{print $NF}' \
                 | sed 's/\.\.\.//g')
-              
+
               if [ -z "$AGENT_SHA" ]; then
                 echo "ERROR: k8s_troubleshooting_agent not found"
                 echo "Available agents:"
@@ -41,7 +41,7 @@ spec:
                   --slim-endpoint "$SLIM_ENDPOINT" \
                 exit 1
               fi
-              
+
               echo "Found agent: $AGENT_SHA"
               echo ""
               echo "Sending health check message..."
@@ -50,11 +50,11 @@ spec:
                 --slim-endpoint "$SLIM_ENDPOINT" \
                 --slim-secret "$SLIM_SECRET" \
                 "Check cluster health status of the pods in namespace slim-multicluster-demo. If you see any issues, create a Jira ticket to track it."
-              
+
               echo ""
               echo "Health check completed successfully"
             env:
             - name: SLIM_ENDPOINT
-              value: "https://slim-dataplane.dev.eticloud.io:443"
+              value: "https://<slim-dataplane-host>:443"
             - name: SLIM_SECRET
-              value: "default-multicluster-demo-shared-secret"
+              value: "<slim-shared-secret>"

--- a/multicluster-demo/spire/agent.conf.tmpl
+++ b/multicluster-demo/spire/agent.conf.tmpl
@@ -1,0 +1,40 @@
+agent {
+    data_dir       = "DATA_DIR_PLACEHOLDER"
+    log_level      = "INFO"
+    server_address = "SPIRE_SERVER_ADDRESS_PLACEHOLDER"
+    server_port    = "443"
+    socket_path    = "/tmp/spire-agent/public/api.sock"
+    join_token     = "TOKEN_PLACEHOLDER"
+
+    # Bootstrap the server trust bundle from a local PEM file fetched from the
+    # EKS SPIRE server via `spire-server bundle show -format pem`.
+    trust_bundle_path = "BUNDLE_PATH_PLACEHOLDER"
+    trust_domain      = "TRUST_DOMAIN_PLACEHOLDER"
+}
+
+plugins {
+    NodeAttestor "join_token" {
+        plugin_data {}
+    }
+
+    # Private key storage on disk (no TPM or macOS Keychain required)
+    KeyManager "disk" {
+        plugin_data {
+            directory = "DATA_DIR_PLACEHOLDER"
+        }
+    }
+
+    # Workload attestation via UNIX process metadata.
+    # On macOS this is matched through selectors such as uid/user/gid/group.
+    WorkloadAttestor "unix" {
+        plugin_data {}
+    }
+}
+
+health_checks {
+    listener_enabled = true
+    bind_address     = "0.0.0.0"
+    bind_port        = "8080"
+    live_path        = "/live"
+    ready_path       = "/ready"
+}


### PR DESCRIPTION
## Summary
- add a shareable macOS SPIRE workflow under multicluster-demo
- build and run a local SPIRE agent against a target cluster without hardcoding cluster or endpoint values
- document and example the a2acli SPIRE-authenticated flow to a SLIM dataplane

## Validation
- task build
- task run
- task register
- ./bin/a2acli send-message --agent sha256:df721aea --return-immediately "What can you do?"