### PR TITLE
feat(multicluster-demo): add local env template workflow

### DIFF
--- a/multicluster-demo/.env.local.example
+++ b/multicluster-demo/.env.local.example
@@ -1,0 +1,8 @@
+# Copy this file to .env.local and replace the values with your local environment.
+MULTICLUSTER_DEMO_K8S_CONTEXT=<target-kubernetes-context>
+MULTICLUSTER_DEMO_SPIRE_NAMESPACE=<spire-namespace>
+MULTICLUSTER_DEMO_SPIRE_SERVER_POD=<spire-server-pod-name>
+MULTICLUSTER_DEMO_SPIRE_SERVER_ADDRESS=<spire-server-hostname>
+MULTICLUSTER_DEMO_TRUST_DOMAIN=<spiffe-trust-domain>
+MULTICLUSTER_DEMO_SLIM_ENDPOINT=https://<slim-dataplane-host>:443
+MULTICLUSTER_DEMO_SLIM_SECRET=<slim-shared-secret>

--- a/multicluster-demo/.gitignore
+++ b/multicluster-demo/.gitignore
@@ -1,2 +1,3 @@
 bin/
 spire/data/
+.env.local

--- a/multicluster-demo/README.md
+++ b/multicluster-demo/README.md
@@ -2,31 +2,31 @@
 
 This directory contains a macOS workflow for:
 
-1. Building and running a local SPIRE agent against the EKS SPIRE server.
+1. Building and running a local SPIRE agent against the target SPIRE server.
 2. Registering the local `a2acli` binary as a SPIRE-authenticated workload.
-3. Using `a2acli` to connect to a SLIM dataplane exposed by a target cluster.
+3. Using `a2acli` to connect to the target SLIM dataplane.
 
 ## What Is In This Directory
 
-- `Taskfile.yml`: builds the local SPIRE agent, fetches the bootstrap bundle from EKS, generates a join token, starts the agent, and registers the `a2acli` workload.
+- `Taskfile.yml`: builds the local SPIRE agent, fetches the bootstrap bundle from the target cluster, generates a join token, starts the agent, registers the `a2acli` workload, and renders a local `a2acli` config.
+- `.env.local.example`: tracked example of the local environment file.
 - `spire/agent.conf.tmpl`: SPIRE agent config template used to render a local runtime config.
+- `a2acli-skill/.a2acli.yaml.tmpl`: template used to render the ignored local `a2acli` config.
 - `a2acli-skill/`: the `a2acli` source, local agent cards, and CLI config examples.
 
 ## Prerequisites
 
 1. macOS.
 2. `go`, `task`, `kubectl`, and `git` installed.
-3. Valid cloud credentials with access to the target Kubernetes cluster.
-4. The following environment variables exported in your shell:
+3. Valid credentials with access to the target Kubernetes cluster.
+
+Create a local environment file first:
 
 ```bash
-export MULTICLUSTER_DEMO_K8S_CONTEXT="<target-kubernetes-context>"
-export MULTICLUSTER_DEMO_SPIRE_NAMESPACE="<spire-namespace>"
-export MULTICLUSTER_DEMO_SPIRE_SERVER_POD="<spire-server-pod-name>"
-export MULTICLUSTER_DEMO_SPIRE_SERVER_ADDRESS="<spire-server-hostname>"
-export MULTICLUSTER_DEMO_TRUST_DOMAIN="<spiffe-trust-domain>"
-export MULTICLUSTER_DEMO_SLIM_ENDPOINT="https://<slim-dataplane-host>:443"
+cp .env.local.example .env.local
 ```
+
+Then edit `.env.local` with your local values.
 
 ## Build And Run SPIRE
 
@@ -43,10 +43,11 @@ task run
 `task run` performs the full bootstrap flow:
 
 1. Builds `bin/spire-agent` from SPIRE source if it does not already exist.
-2. Fetches the target cluster SPIRE bootstrap bundle in PEM format.
-3. Generates a join token for `spiffe://<trust-domain>/macos/agent/<hostname>`.
-4. Renders a local runtime config under `spire/data/agent.conf`.
-5. Starts the agent and exposes the Workload API on `/tmp/spire-agent/public/api.sock`.
+2. Regenerates `a2acli-skill/.a2acli.yaml` from `.env.local`.
+3. Fetches the target SPIRE bootstrap bundle in PEM format.
+4. Generates a join token for `spiffe://<trust-domain>/macos/agent/<hostname>`.
+5. Renders a local runtime config under `spire/data/agent.conf`.
+6. Starts the agent and exposes the Workload API on `/tmp/spire-agent/public/api.sock`.
 
 Keep `task run` running in a dedicated terminal.
 
@@ -85,27 +86,21 @@ task fetch-svid
 
 ## Configure a2acli
 
-Create a local runtime config at `a2acli-skill/.a2acli.yaml`.
+Generate the ignored local runtime config from `.env.local`:
 
-That file is intentionally ignored by Git so it can stay machine-local.
-
-Example:
-
-```yaml
-slim:
-  endpoint: "${MULTICLUSTER_DEMO_SLIM_ENDPOINT}"
-  local-name: "agntcy/cli/a2acli"
-  spire:
-    socket-path: "/tmp/spire-agent/public/api.sock"
-    jwt-audiences:
-      - "slim"
+```bash
+task a2acli-config
 ```
+
+This writes `a2acli-skill/.a2acli.yaml` locally and keeps the endpoint out of tracked files.
+`task run` also refreshes this file automatically.
 
 ## Send A Test Request Through The Target Dataplane
 
 From `a2acli-skill`:
 
 ```bash
+task -d .. a2acli-config
 ./bin/a2acli list
 ./bin/a2acli send-message --agent sha256:df721aea --return-immediately "What can you do?"
 ```
@@ -113,7 +108,7 @@ From `a2acli-skill`:
 The expected outcome is:
 
 1. `a2acli` initializes the SPIRE provider from the local Workload API socket.
-2. `a2acli` connects to the SLIM dataplane configured in `MULTICLUSTER_DEMO_SLIM_ENDPOINT`.
+2. `a2acli` connects to the endpoint configured in `.env.local`.
 3. The request is accepted and returns a task ID.
 
 ## Useful Tasks
@@ -122,6 +117,7 @@ The expected outcome is:
 task build
 task run
 task register
+task a2acli-config
 task show-entries
 task fetch-svid
 task stop
@@ -134,6 +130,7 @@ Tracked files in this directory do not contain laptop-specific absolute paths.
 
 Local-only artifacts are kept out of Git:
 
+- `.env.local`
 - `a2acli-skill/.a2acli.yaml`
 - `spire/data/`
 - `bin/`

--- a/multicluster-demo/Taskfile.yml
+++ b/multicluster-demo/Taskfile.yml
@@ -5,6 +5,9 @@ version: "3"
 
 silent: true
 
+dotenv:
+  - .env.local
+
 vars:
   SPIRE_VERSION: v1.14.2
   SPIRE_REPO: https://github.com/spiffe/spire
@@ -80,6 +83,7 @@ tasks:
     desc: Build, configure, and start the SPIRE agent (Ctrl-C to stop)
     cmds:
       - task: build
+      - task: a2acli-config
       - task: agent-conf
       - echo "==> Starting spire-agent — socket at {{.SOCKET_PATH}}"
       - "{{.AGENT_BIN}} run -config {{.RUNTIME_CONF}}"
@@ -123,6 +127,15 @@ tasks:
         echo "      spire:"
         echo "        socket-path: \"{{.SOCKET_PATH}}\""
         echo "        jwt-audiences: [\"slim\"]"
+
+  a2acli-config:
+    desc: Generate a local a2acli config from .env.local
+    cmds:
+      - |
+        SLIM_ENDPOINT="${MULTICLUSTER_DEMO_SLIM_ENDPOINT:?set MULTICLUSTER_DEMO_SLIM_ENDPOINT}"
+        sed -e "s|SLIM_ENDPOINT_PLACEHOLDER|$SLIM_ENDPOINT|g" \
+          a2acli-skill/.a2acli.yaml.tmpl > a2acli-skill/.a2acli.yaml
+        echo "==> Config written: a2acli-skill/.a2acli.yaml"
 
   show-entries:
     desc: Show all SPIRE workload entries registered for this macOS agent

--- a/multicluster-demo/a2acli-skill/.a2acli.yaml.example
+++ b/multicluster-demo/a2acli-skill/.a2acli.yaml.example
@@ -25,8 +25,9 @@ slim:
   #   jwt-audiences:                                    # optional
   #     - "my-audience"
 
-# Multicluster demo example using the EKS SLIM dataplane and a local SPIRE agent.
-# Copy this block into .a2acli.yaml for the shared demo setup.
+# Multicluster demo example using a local SPIRE agent and a target SLIM dataplane.
+# For local use, prefer generating .a2acli.yaml via `task a2acli-config` from
+# the parent multicluster-demo directory. That keeps the endpoint in .env.local.
 # slim:
 #   endpoint: "https://<slim-dataplane-host>:443"
 #   local-name: "agntcy/cli/a2acli"

--- a/multicluster-demo/a2acli-skill/.a2acli.yaml.tmpl
+++ b/multicluster-demo/a2acli-skill/.a2acli.yaml.tmpl
@@ -1,0 +1,7 @@
+slim:
+  endpoint: "SLIM_ENDPOINT_PLACEHOLDER"
+  local-name: "agntcy/cli/a2acli"
+  spire:
+    socket-path: "/tmp/spire-agent/public/api.sock"
+    jwt-audiences:
+      - "slim"


### PR DESCRIPTION
## Summary
- add a tracked .env.local.example for the macOS SPIRE and a2acli workflow
- generate the ignored local a2acli config from .env.local via Taskfile automation
- document the local env driven flow and keep .env.local out of git

## Testing
- task a2acli-config
