### PR TITLE
feat(multicluster-demo): add Copilot skill for a2acli

### DIFF
--- a/multicluster-demo/README.md
+++ b/multicluster-demo/README.md
@@ -1,10 +1,18 @@
 # Multicluster demo
 
-This directory contains a macOS workflow for:
+This directory contains the local IT-OPS side of the multicluster demo.
+
+The end-to-end demo has three moving parts:
+
+1. An adversary in the deployed multicluster environment injects standard Kubernetes issues such as `CrashLoopBackOff`, `ImagePullBackOff`, failed Jobs, and unschedulable pods.
+2. The existing `k8s_troubleshooting_agent` inspects cluster state through MCP tools and can create Jira issues when asked.
+3. The human operator uses local `a2acli`, optionally through the local Copilot skill, to interact with the cloud agent from a laptop.
+
+This directory focuses on the operator workflow for:
 
 1. Building and running a local SPIRE agent against the target SPIRE server.
 2. Registering the local `a2acli` binary as a SPIRE-authenticated workload.
-3. Using `a2acli` to connect to the target SLIM dataplane.
+3. Using `a2acli` or the local Copilot skill to connect to the target SLIM dataplane.
 
 ## What Is In This Directory
 
@@ -13,6 +21,7 @@ This directory contains a macOS workflow for:
 - `spire/agent.conf.tmpl`: SPIRE agent config template used to render a local runtime config.
 - `a2acli-skill/.a2acli.yaml.tmpl`: template used to render the ignored local `a2acli` config.
 - `a2acli-skill/`: the `a2acli` source, local agent cards, and CLI config examples.
+- `copilot-skills/a2acli/`: Copilot skill source for the locally installed `copilot` app.
 
 ## Prerequisites
 
@@ -62,6 +71,19 @@ task build
 
 This creates `a2acli-skill/bin/a2acli`.
 
+## Install The Copilot Skill
+
+From the `a2acli-skill` directory:
+
+```bash
+cd a2acli-skill
+task install-copilot-skill
+```
+
+This refreshes `~/.copilot/skills/a2acli` with the repo-local skill source from `copilot-skills/a2acli/` and installs the built binary into `~/.copilot/skills/a2acli/scripts/a2acli`.
+
+Use this when the IT-OPS workflow should be available directly inside the local `copilot` app.
+
 ## Register a2acli As A SPIRE Workload
 
 From the `multicluster-demo` directory, after the SPIRE agent is already running:
@@ -110,6 +132,8 @@ The expected outcome is:
 1. `a2acli` initializes the SPIRE provider from the local Workload API socket.
 2. `a2acli` connects to the endpoint configured in `.env.local`.
 3. The request is accepted and returns a task ID.
+
+The same runtime config can be reused by the local Copilot skill because it delegates to the same `a2acli` binary and `.a2acli.yaml` settings.
 
 ## Useful Tasks
 

--- a/multicluster-demo/a2acli-skill/README.md
+++ b/multicluster-demo/a2acli-skill/README.md
@@ -1,6 +1,6 @@
 # a2acli
 
-A CLI tool and Claude Code skill for interacting with agents that expose the [A2A (Agent-to-Agent) protocol](https://github.com/a2aproject/A2A). Supports both standard HTTP transports (JSON-RPC, REST) and [SLIM RPC](https://docs.agntcy.org/slim/) for agents deployed behind a SLIM messaging node.
+A CLI tool plus local skill assets for interacting with agents that expose the [A2A (Agent-to-Agent) protocol](https://github.com/a2aproject/A2A). Supports both standard HTTP transports (JSON-RPC, REST) and [SLIM RPC](https://docs.agntcy.org/slim/) for agents deployed behind a SLIM messaging node.
 
 ## Building
 
@@ -16,11 +16,20 @@ task build
 # Build and place binary in the skill's scripts/ directory
 task build-skill
 
+# Build and place binary in the Copilot skill's scripts/ directory
+task build-copilot-skill
+
 # Build, copy to scripts/, and zip the skill for distribution
 task package-skill
 
 # Install to GOPATH/bin (adds to PATH)
 task install
+
+# Install the Copilot skill to ~/.copilot/skills/a2acli
+task install-copilot-skill
+
+# Install both the Claude and Copilot skill variants
+task install-all-skills
 ```
 
 `CGO_ENABLED=1` is set automatically by the Taskfile. The `setup` step is also run automatically as a dependency of `build`, `build-skill`, and `install`.
@@ -180,6 +189,15 @@ a2acli send-message \
   "What pods are failing in my cluster?"
 ```
 
-## Claude Code Skill
+## Skill Variants
 
-The `a2acli/` directory contains a Claude Code skill that exposes `a2acli` as a restricted tool (`Bash(a2acli:*)`). Run `task package-skill` to produce `bin/a2acli.zip` for distribution.
+- `a2acli/` contains the existing Claude-oriented skill.
+- `../copilot-skills/a2acli/` contains the Copilot skill source that is kept alongside the multicluster demo.
+
+Run `task install-skill` to refresh `~/.claude/skills/a2acli`, or `task install-copilot-skill` to refresh `~/.copilot/skills/a2acli` for the locally installed `copilot` app.
+
+The Copilot skill assumes:
+
+1. `a2acli` has been built into `~/.copilot/skills/a2acli/scripts/a2acli`.
+2. AgentCard files are present in `.a2aagents/` or `~/.a2aagents/`.
+3. A local `.a2acli.yaml` or `~/.a2acli.yaml` provides the SLIM endpoint and any SPIRE settings needed for the multicluster demo.

--- a/multicluster-demo/a2acli-skill/Taskfile.yaml
+++ b/multicluster-demo/a2acli-skill/Taskfile.yaml
@@ -13,6 +13,8 @@ vars:
   BIN_DIR: bin
   SKILL_DIR: a2acli
   SCRIPTS_DIR: "{{.SKILL_DIR}}/scripts"
+  COPILOT_SKILL_DIR: "../copilot-skills/a2acli"
+  COPILOT_SCRIPTS_DIR: "{{.COPILOT_SKILL_DIR}}/scripts"
   LDFLAGS: "-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=ignore"
 
 tasks:
@@ -37,7 +39,16 @@ tasks:
     deps:
       - setup
     cmds:
+      - mkdir -p {{.SCRIPTS_DIR}}
       - go build -ldflags "{{.LDFLAGS}}" -o {{.SCRIPTS_DIR}}/{{.BINARY}} .
+
+  build-copilot-skill:
+    desc: Compile the binary into the Copilot skill's scripts/ directory
+    deps:
+      - setup
+    cmds:
+      - mkdir -p {{.COPILOT_SCRIPTS_DIR}}
+      - go build -ldflags "{{.LDFLAGS}}" -o {{.COPILOT_SCRIPTS_DIR}}/{{.BINARY}} .
 
   package-skill:
     desc: Build the skill binary, copy it to scripts/, and zip the skill directory
@@ -62,9 +73,27 @@ tasks:
       - build-skill
     cmds:
       - mkdir -p {{.SKILLS_DIR}}
-      - cp -r {{.SKILL_DIR}} {{.SKILLS_DIR}}/{{.SKILL_DIR}}
+      - rm -rf {{.SKILLS_DIR}}/{{.SKILL_DIR}}
+      - cp -R {{.SKILL_DIR}} {{.SKILLS_DIR}}/{{.SKILL_DIR}}
+
+  install-copilot-skill:
+    desc: Build and install the Copilot skill into ~/.copilot/skills/
+    vars:
+      SKILLS_DIR: "{{.HOME}}/.copilot/skills"
+    deps:
+      - build-copilot-skill
+    cmds:
+      - mkdir -p {{.SKILLS_DIR}}
+      - rm -rf {{.SKILLS_DIR}}/a2acli
+      - cp -R {{.COPILOT_SKILL_DIR}} {{.SKILLS_DIR}}/a2acli
+
+  install-all-skills:
+    desc: Build and install both the Claude and Copilot skill variants
+    deps:
+      - install-skill
+      - install-copilot-skill
 
   clean:
     desc: Remove compiled binaries
     cmds:
-      - rm -f {{.BIN_DIR}}/{{.BINARY}} {{.SCRIPTS_DIR}}/{{.BINARY}} {{.BIN_DIR}}/{{.BINARY}}.zip
+      - rm -f {{.BIN_DIR}}/{{.BINARY}} {{.SCRIPTS_DIR}}/{{.BINARY}} {{.COPILOT_SCRIPTS_DIR}}/{{.BINARY}} {{.BIN_DIR}}/{{.BINARY}}.zip

--- a/multicluster-demo/copilot-skills/a2acli/SKILL.md
+++ b/multicluster-demo/copilot-skills/a2acli/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: a2acli
+description: 'Use a2acli to list A2A agents, inspect AgentCards, send messages, and fetch task results. Use when the multicluster demo operator needs to interact with the cloud Kubernetes troubleshooting agent from a local laptop, especially with local SPIRE-backed SLIM auth.'
+argument-hint: 'list agents | inspect card | send message | get task'
+user-invocable: true
+---
+
+# a2acli
+
+Use this skill when you need to:
+
+- discover A2A agents from `.a2aagents/` or `~/.a2aagents/`
+- inspect an agent card before you delegate work
+- send a message to the multicluster-demo troubleshooting agent from the IT-OPS laptop
+- fetch a task result after sending an asynchronous request
+
+## Before You Use It
+
+1. From `slim/multicluster-demo/a2acli-skill`, run `task install-copilot-skill`.
+2. Confirm the installed binary exists at `~/.copilot/skills/a2acli/scripts/a2acli`.
+3. Ensure AgentCard JSON files exist in `.a2aagents/` in the current workspace or in `~/.a2aagents/`.
+4. Ensure `.a2acli.yaml` or `~/.a2acli.yaml` points at the correct SLIM endpoint and, for the multicluster demo, the local SPIRE Workload API socket.
+
+## Common Tasks
+
+1. Discover agents:
+   `~/.copilot/skills/a2acli/scripts/a2acli list`
+2. Inspect an agent card:
+   `~/.copilot/skills/a2acli/scripts/a2acli get-card --agent <digest>`
+3. Send a message:
+   `~/.copilot/skills/a2acli/scripts/a2acli send-message --agent <digest> "<message>"`
+4. Submit an asynchronous task and fetch it later:
+   `~/.copilot/skills/a2acli/scripts/a2acli send-message --agent <digest> --return-immediately "<message>"`
+   `~/.copilot/skills/a2acli/scripts/a2acli get-task --agent <digest> <task-id>`
+
+## Multicluster Demo Workflow
+
+1. The adversary injects standard Kubernetes issues into the demo cluster.
+2. The existing troubleshooting agent inspects the cluster and can create Jira issues when asked.
+3. The IT-OPS operator uses local `a2acli` to query the cloud agent, ask follow-up questions, or pull task results.
+
+Keep secrets and environment-specific values in local config files such as `.a2acli.yaml` or the multicluster-demo `.env.local` workflow. Do not embed secrets directly into skill instructions.
+
+See [command patterns](./references/command-patterns.md) and [multicluster demo workflow](./references/multicluster-demo.md).

--- a/multicluster-demo/copilot-skills/a2acli/references/command-patterns.md
+++ b/multicluster-demo/copilot-skills/a2acli/references/command-patterns.md
@@ -1,0 +1,38 @@
+# a2acli Command Patterns
+
+Use the installed binary at `~/.copilot/skills/a2acli/scripts/a2acli`.
+
+## Discover Agents
+
+```bash
+~/.copilot/skills/a2acli/scripts/a2acli list
+```
+
+If AgentCard files are not in the current working directory, pass `--agents-dir <path>` or place them in `~/.a2aagents/`.
+
+## Inspect An Agent
+
+```bash
+~/.copilot/skills/a2acli/scripts/a2acli get-card --agent sha256:<digest-prefix>
+```
+
+Use this before delegation when you need to confirm the agent skills, capabilities, or protocol binding.
+
+## Send A Message
+
+```bash
+~/.copilot/skills/a2acli/scripts/a2acli send-message --agent sha256:<digest-prefix> "What issues do you see in the cluster?"
+```
+
+For asynchronous work:
+
+```bash
+~/.copilot/skills/a2acli/scripts/a2acli send-message --agent sha256:<digest-prefix> --return-immediately "Check the cluster and create a Jira issue if needed."
+~/.copilot/skills/a2acli/scripts/a2acli get-task --agent sha256:<digest-prefix> <task-id>
+```
+
+## Multicluster Demo Prompt Shapes
+
+- `Check the cluster and summarize any failing workloads in the demo namespace.`
+- `Explain whether the current failures look like CrashLoopBackOff, ImagePullBackOff, a failed Job, or an unschedulable pod.`
+- `Create a Jira issue for the current failure and include the affected workload names.`

--- a/multicluster-demo/copilot-skills/a2acli/references/multicluster-demo.md
+++ b/multicluster-demo/copilot-skills/a2acli/references/multicluster-demo.md
@@ -1,0 +1,29 @@
+# Multicluster Demo Workflow
+
+The multicluster demo has three distinct roles:
+
+1. An adversary running in the deployed environment injects standard Kubernetes issues.
+2. The `k8s_troubleshooting_agent` inspects the cluster through MCP tools and can create Jira issues when asked.
+3. The IT-OPS operator uses local `a2acli`, optionally through the local Copilot skill, to interact with the cloud agent.
+
+## Local Operator Prerequisites
+
+1. From `slim/multicluster-demo`, run `task run` to start the local SPIRE agent.
+2. Run `task register` so the local `a2acli` binary can obtain an identity from the Workload API.
+3. Run `task a2acli-config` to render the local `.a2acli.yaml` from `.env.local`.
+4. From `slim/multicluster-demo/a2acli-skill`, run `task install-copilot-skill`.
+
+## Expected Local Files
+
+- `.env.local` contains the local cluster and endpoint values and stays out of Git.
+- `a2acli-skill/.a2acli.yaml` contains the rendered local `a2acli` runtime config.
+- `~/.copilot/skills/a2acli/scripts/a2acli` is the installed binary used by the Copilot skill.
+
+## Operator Flow
+
+1. Use `a2acli list` to identify the troubleshooting agent digest.
+2. Use `a2acli get-card --agent <digest>` if you need to inspect the agent capabilities first.
+3. Send a troubleshooting request to the cloud agent.
+4. If the task is asynchronous, fetch it later with `a2acli get-task`.
+
+This keeps the operator path local while the troubleshooting logic and Jira integration remain on the deployed agent side.

--- a/multicluster-demo/copilot-skills/a2acli/scripts/.gitignore
+++ b/multicluster-demo/copilot-skills/a2acli/scripts/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!.gitkeep

--- a/multicluster-demo/k8s_troubleshooting_agent/README.md
+++ b/multicluster-demo/k8s_troubleshooting_agent/README.md
@@ -1,0 +1,24 @@
+# k8s_troubleshooting_agent
+
+This agent is the diagnosis component of the multicluster demo. It inspects Kubernetes state through a Kubernetes MCP server and, when asked, uses an Atlassian MCP server to check for duplicate Jira issues and create a new ticket.
+
+The agent is not responsible for generating failures and it is not the human operator client.
+
+## Demo Role
+
+1. The adversary injects standard Kubernetes failure scenarios into the demo cluster.
+2. A periodic workflow or a human operator invokes the troubleshooting agent over A2A.
+3. The agent uses MCP tools to inspect cluster state and summarize what it finds.
+4. If the caller asks for Jira tracking and Atlassian MCP is available, the agent checks for duplicates and creates a Jira issue.
+
+## Key Files
+
+- `main.py`: wires the agent to SLIM, the Kubernetes MCP proxy, and the Atlassian MCP proxy.
+- `k8s_troubleshooting_agent/agent.py`: defines the troubleshooting and Jira-ticketing instructions.
+- `chart/values.yaml`: configures the SLIM connection, MCP proxy names, and optional SPIRE settings.
+
+## Current Scope Boundary
+
+- The agent code should stay focused on inspection and ticketing.
+- The adversary is a separate deployment concern in the multicluster demo environment.
+- The IT-OPS operator workflow lives in the local `a2acli` and Copilot skill setup under the parent `multicluster-demo` directory.


### PR DESCRIPTION
## Summary
- add a repo-local Copilot skill source for a2acli under multicluster-demo
- wire build and install tasks for ~/.copilot/skills/a2acli
- document the adversary, troubleshooting agent, and IT-OPS operator flow

## Validation
- task install-copilot-skill
- ~/.copilot/skills/a2acli/scripts/a2acli --help
