### PR TITLE
perf(datapath): add pool remove and remove+insert cycle benchmarks

### DIFF
--- a/data-plane/core/datapath/benches/pool_benchmark.rs
+++ b/data-plane/core/datapath/benches/pool_benchmark.rs
@@ -79,6 +79,32 @@ fn bench_capacity(c: &mut Criterion) {
     });
 }
 
+fn bench_remove(c: &mut Criterion) {
+    c.bench_function("pool remove", |b| {
+        b.iter(|| {
+            let mut pool = Pool::with_capacity(1024);
+            let ids: Vec<usize> = (0..1024).map(|i| pool.insert(i)).collect();
+            for id in &ids {
+                black_box(pool.remove(*id));
+            }
+        })
+    });
+}
+
+fn bench_remove_insert_cycle(c: &mut Criterion) {
+    // Measures the cost of alternating remove+insert, exercising slot reuse.
+    c.bench_function("pool remove+insert cycle", |b| {
+        b.iter(|| {
+            let mut pool = Pool::with_capacity(1024);
+            let ids: Vec<usize> = (0..1024).map(|i| pool.insert(i)).collect();
+            for (i, &id) in ids.iter().enumerate() {
+                pool.remove(id);
+                black_box(pool.insert(i as i32));
+            }
+        })
+    });
+}
+
 criterion_group!(
     benches,
     bench_lookup,
@@ -87,6 +113,8 @@ criterion_group!(
     bench_insert,
     bench_grow,
     bench_capacity,
+    bench_remove,
+    bench_remove_insert_cycle,
 );
 
 criterion_main!(benches);


### PR DESCRIPTION
# Description

Adds two Criterion benchmarks to `pool_benchmark.rs` that cover the removal
path — previously untracked — so that alternative `Pool<T>` implementations
can be compared against a documented `main`-branch baseline.

## New benchmarks

**`pool remove`** — fills a pre-allocated 1024-element pool then removes every
element in insertion order.  Exercises the full remove path: bitmap clear,
`pool[idx] = None` drop, and `max_set` maintenance.

**`pool remove+insert cycle`** — fills a 1024-element pool then alternates
one `remove` + one `insert` per element, exercising freed-slot reuse which
is the dominant pattern in steady-state datapath operation (connections
coming and going while the pool size stays roughly constant).

## Baseline numbers (Apple M-series)

| Benchmark | Time |
|---|---|
| pool remove (1024 removes) | ~243 µs |
| pool remove+insert cycle (1024 pairs) | ~479 µs |

These numbers reflect the current bitmap/Vec design and will serve as the
reference for the refactor tracked in #1496.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe)

Benchmark-only change; no production code is modified.

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass