### PR TITLE
chore: release

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim"
-version = "1.4.0-rc.0"
+version = "1.4.0-rc.1"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-service",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-auth"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-testing",
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-testing",
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.4.12"
+version = "0.5.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-tracing",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -275,7 +275,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-signal"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "agntcy-slim-version",
  "tokio",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-version"
-version = "1.4.0-rc.0"
+version = "1.4.0-rc.1"
 
 [[package]]
 name = "agntcy-slimctl"

--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim"
-version = "1.4.0-rc.1"
+version = "1.4.0-rc.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-service",
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-version"
-version = "1.4.0-rc.1"
+version = "1.4.0-rc.0"
 
 [[package]]
 name = "agntcy-slimctl"

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -38,7 +38,7 @@ resolver = "2"
 
 [workspace.dependencies]
 # Local dependencies
-agntcy-slim = { path = "core/slim", version = "1.4.0-rc.1" }
+agntcy-slim = { path = "core/slim", version = "1.4.0-rc.0" }
 agntcy-slim-auth = { path = "core/auth", version = "0.7.0" }
 agntcy-slim-bindings = { path = "bindings/rust", version = "1.4.0-rc.0" }
 agntcy-slim-config = { path = "core/config", version = "0.9.0" }
@@ -50,7 +50,7 @@ agntcy-slim-session = { path = "core/session", version = "0.1.12" }
 agntcy-slim-signal = { path = "core/signal", version = "0.1.9" }
 agntcy-slim-testing = { path = "testing" }
 agntcy-slim-tracing = { path = "core/tracing", version = "0.3.9" }
-agntcy-slim-version = { path = "core/version", version = "1.4.0-rc.1" }
+agntcy-slim-version = { path = "core/version", version = "1.4.0-rc.0" }
 agntcy-slimctl = { path = "slimctl", version = "1.4.0-rc.0" }
 
 anyhow = "1.0.98"
@@ -147,7 +147,7 @@ uuid = { version = "1.15.1", features = ["v4"] }
 wiremock = "0.6"
 
 [workspace.package]
-version = "1.4.0-rc.1"
+version = "1.4.0-rc.0"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/agntcy/slim"

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -38,19 +38,19 @@ resolver = "2"
 
 [workspace.dependencies]
 # Local dependencies
-agntcy-slim = { path = "core/slim", version = "1.4.0-rc.0" }
-agntcy-slim-auth = { path = "core/auth", version = "0.6.2" }
+agntcy-slim = { path = "core/slim", version = "1.4.0-rc.1" }
+agntcy-slim-auth = { path = "core/auth", version = "0.7.0" }
 agntcy-slim-bindings = { path = "bindings/rust", version = "1.4.0-rc.0" }
-agntcy-slim-config = { path = "core/config", version = "0.8.2" }
-agntcy-slim-controller = { path = "core/controller", version = "0.4.12" }
-agntcy-slim-datapath = { path = "core/datapath", version = "0.12.2" }
-agntcy-slim-mls = { path = "core/mls", version = "0.1.14" }
-agntcy-slim-service = { path = "core/service", version = "0.8.11", default-features = false }
-agntcy-slim-session = { path = "core/session", version = "0.1.11" }
-agntcy-slim-signal = { path = "core/signal", version = "0.1.8" }
+agntcy-slim-config = { path = "core/config", version = "0.9.0" }
+agntcy-slim-controller = { path = "core/controller", version = "0.5.0" }
+agntcy-slim-datapath = { path = "core/datapath", version = "0.12.3" }
+agntcy-slim-mls = { path = "core/mls", version = "0.1.15" }
+agntcy-slim-service = { path = "core/service", version = "0.8.12", default-features = false }
+agntcy-slim-session = { path = "core/session", version = "0.1.12" }
+agntcy-slim-signal = { path = "core/signal", version = "0.1.9" }
 agntcy-slim-testing = { path = "testing" }
-agntcy-slim-tracing = { path = "core/tracing", version = "0.3.8" }
-agntcy-slim-version = { path = "core/version", version = "1.4.0-rc.0" }
+agntcy-slim-tracing = { path = "core/tracing", version = "0.3.9" }
+agntcy-slim-version = { path = "core/version", version = "1.4.0-rc.1" }
 agntcy-slimctl = { path = "slimctl", version = "1.4.0-rc.0" }
 
 anyhow = "1.0.98"
@@ -147,7 +147,7 @@ uuid = { version = "1.15.1", features = ["v4"] }
 wiremock = "0.6"
 
 [workspace.package]
-version = "1.4.0-rc.0"
+version = "1.4.0-rc.1"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/agntcy/slim"

--- a/data-plane/bindings/rust/CHANGELOG.md
+++ b/data-plane/bindings/rust/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0-rc.0](https://github.com/agntcy/slim/compare/slim-bindings-v1.3.0...slim-bindings-v1.4.0-rc.0) - 2026-04-21
+
+### Added
+
+- add tower auth middleware using spire ([#1452](https://github.com/agntcy/slim/pull/1452))
+
+### Fixed
+
+- adding linters to Golang, Java and Kotlin bindings and generaliz… ([#1502](https://github.com/agntcy/slim/pull/1502))
+
+### Other
+
+- prepare 1.4.0-rc.0 ([#1530](https://github.com/agntcy/slim/pull/1530))
+
 ## [1.3.0](https://github.com/agntcy/slim/compare/slim-bindings-v1.2.0...slim-bindings-v1.3.0) - 2026-03-31
 
 ### Added

--- a/data-plane/core/auth/CHANGELOG.md
+++ b/data-plane/core/auth/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/agntcy/slim/compare/slim-auth-v0.6.2...slim-auth-v0.7.0) - 2026-04-21
+
+### Added
+
+- update controller connection ([#1485](https://github.com/agntcy/slim/pull/1485))
+- add tower auth middleware using spire ([#1452](https://github.com/agntcy/slim/pull/1452))
+
+### Fixed
+
+- revert "build(deps): upgrade to spire 0.12" ([#1528](https://github.com/agntcy/slim/pull/1528))
+- *(spire)* typo in error message ([#1521](https://github.com/agntcy/slim/pull/1521))
+
+### Other
+
+- *(deps)* upgrade to spire 0.12 ([#1436](https://github.com/agntcy/slim/pull/1436))
+
 ## [0.6.2](https://github.com/agntcy/slim/compare/slim-auth-v0.6.1...slim-auth-v0.6.2) - 2026-03-31
 
 ### Other

--- a/data-plane/core/auth/Cargo.toml
+++ b/data-plane/core/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-auth"
-version = "0.6.2"
+version = "0.7.0"
 license = { workspace = true }
 edition = { workspace = true }
 description = "Authentication utilities for the Agntcy Slim framework"

--- a/data-plane/core/config/CHANGELOG.md
+++ b/data-plane/core/config/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/agntcy/slim/compare/slim-config-v0.8.2...slim-config-v0.9.0) - 2026-04-21
+
+### Added
+
+- add tower auth middleware using spire ([#1452](https://github.com/agntcy/slim/pull/1452))
+
+### Fixed
+
+- revert "build(deps): upgrade to spire 0.12" ([#1528](https://github.com/agntcy/slim/pull/1528))
+
+### Other
+
+- *(deps)* upgrade to spire 0.12 ([#1436](https://github.com/agntcy/slim/pull/1436))
+
 ## [0.8.2](https://github.com/agntcy/slim/compare/slim-config-v0.8.1...slim-config-v0.8.2) - 2026-03-31
 
 ### Other

--- a/data-plane/core/config/Cargo.toml
+++ b/data-plane/core/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-config"
-version = "0.8.2"
+version = "0.9.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Configuration utilities"

--- a/data-plane/core/controller/CHANGELOG.md
+++ b/data-plane/core/controller/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/agntcy/slim/compare/slim-controller-v0.4.12...slim-controller-v0.5.0) - 2026-04-21
+
+### Added
+
+- update controller connection ([#1485](https://github.com/agntcy/slim/pull/1485))
+
 ## [0.4.12](https://github.com/agntcy/slim/compare/slim-controller-v0.4.11...slim-controller-v0.4.12) - 2026-03-31
 
 ### Other

--- a/data-plane/core/controller/Cargo.toml
+++ b/data-plane/core/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-controller"
-version = "0.4.12"
+version = "0.5.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Controller service and control API to configure the SLIM data plane through the control plane."

--- a/data-plane/core/datapath/CHANGELOG.md
+++ b/data-plane/core/datapath/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.3](https://github.com/agntcy/slim/compare/slim-datapath-v0.12.2...slim-datapath-v0.12.3) - 2026-04-21
+
+### Added
+
+- update controller connection ([#1485](https://github.com/agntcy/slim/pull/1485))
+
+### Other
+
+- *(datapath)* use Arc instead of Box for Name string storage ([#1435](https://github.com/agntcy/slim/pull/1435))
+
 ## [0.12.2](https://github.com/agntcy/slim/compare/slim-datapath-v0.12.1...slim-datapath-v0.12.2) - 2026-03-31
 
 ### Other

--- a/data-plane/core/datapath/Cargo.toml
+++ b/data-plane/core/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-datapath"
-version = "0.12.2"
+version = "0.12.3"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Core data plane functionality for SLIM"

--- a/data-plane/core/mls/CHANGELOG.md
+++ b/data-plane/core/mls/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.15](https://github.com/agntcy/slim/compare/slim-mls-v0.1.14...slim-mls-v0.1.15) - 2026-04-21
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-datapath
+
 ## [0.1.14](https://github.com/agntcy/slim/compare/slim-mls-v0.1.13...slim-mls-v0.1.14) - 2026-03-31
 
 ### Other

--- a/data-plane/core/mls/Cargo.toml
+++ b/data-plane/core/mls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-mls"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.14"
+version = "0.1.15"
 description = "Messaging Layer Security for SLIM data plane."
 
 [lib]

--- a/data-plane/core/service/CHANGELOG.md
+++ b/data-plane/core/service/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.12](https://github.com/agntcy/slim/compare/slim-service-v0.8.11...slim-service-v0.8.12) - 2026-04-21
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-controller, agntcy-slim-mls, agntcy-slim-session
+
 ## [0.8.11](https://github.com/agntcy/slim/compare/slim-service-v0.8.10...slim-service-v0.8.11) - 2026-03-31
 
 ### Other

--- a/data-plane/core/service/Cargo.toml
+++ b/data-plane/core/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-service"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.8.11"
+version = "0.8.12"
 description = "Main service and public API to interact with SLIM data plane."
 
 [lib]

--- a/data-plane/core/session/CHANGELOG.md
+++ b/data-plane/core/session/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12](https://github.com/agntcy/slim/compare/slim-session-v0.1.11...slim-session-v0.1.12) - 2026-04-21
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-datapath, agntcy-slim-mls
+
 ## [0.1.11](https://github.com/agntcy/slim/compare/slim-session-v0.1.10...slim-session-v0.1.11) - 2026-03-31
 
 ### Other

--- a/data-plane/core/session/Cargo.toml
+++ b/data-plane/core/session/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-session"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.11"
+version = "0.1.12"
 description = "SLIM session internal implementation."
 
 [lib]

--- a/data-plane/core/signal/CHANGELOG.md
+++ b/data-plane/core/signal/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/agntcy/slim/compare/slim-signal-v0.1.8...slim-signal-v0.1.9) - 2026-04-21
+
+### Other
+
+- updated the following local packages: agntcy-slim-version
+
 ## [0.1.8](https://github.com/agntcy/slim/compare/slim-signal-v0.1.7...slim-signal-v0.1.8) - 2026-03-31
 
 ### Other

--- a/data-plane/core/signal/Cargo.toml
+++ b/data-plane/core/signal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-signal"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.8"
+version = "0.1.9"
 description = "Small library to handle OS signals."
 
 [lib]

--- a/data-plane/core/slim/CHANGELOG.md
+++ b/data-plane/core/slim/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0-rc.1](https://github.com/agntcy/slim/compare/slim-v1.4.0-rc.0...slim-v1.4.0-rc.1) - 2026-04-21
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [1.3.0](https://github.com/agntcy/slim/compare/slim-v1.1.0...slim-v1.3.0) - 2026-03-30
 
 ### Added

--- a/data-plane/core/slim/CHANGELOG.md
+++ b/data-plane/core/slim/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.4.0-rc.1](https://github.com/agntcy/slim/compare/slim-v1.4.0-rc.0...slim-v1.4.0-rc.1) - 2026-04-21
+## [1.4.0-rc.0](https://github.com/agntcy/slim/compare/slim-v1.3.0...slim-v1.4.0-rc.0) - 2026-04-21
 
 ### Other
 

--- a/data-plane/core/tracing/CHANGELOG.md
+++ b/data-plane/core/tracing/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.9](https://github.com/agntcy/slim/compare/slim-tracing-v0.3.8...slim-tracing-v0.3.9) - 2026-04-21
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-config
+
 ## [0.3.8](https://github.com/agntcy/slim/compare/slim-tracing-v0.3.7...slim-tracing-v0.3.8) - 2026-03-31
 
 ### Other

--- a/data-plane/core/tracing/Cargo.toml
+++ b/data-plane/core/tracing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-tracing"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.8"
+version = "0.3.9"
 description = "Observability for SLIM data plane: logs, traces and metrics infrastructure."
 
 [lib]

--- a/data-plane/slimctl/CHANGELOG.md
+++ b/data-plane/slimctl/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0-rc.0](https://github.com/agntcy/slim/compare/slimctl-v1.3.0...slimctl-v1.4.0-rc.0) - 2026-04-21
+
+### Added
+
+- update controller connection ([#1485](https://github.com/agntcy/slim/pull/1485))
+
+### Fixed
+
+- *(slimctl)* correct test name spelling (writable) ([#1464](https://github.com/agntcy/slim/pull/1464))
+
+### Other
+
+- prepare 1.4.0-rc.0 ([#1530](https://github.com/agntcy/slim/pull/1530))
+
 ## [1.3.0](https://github.com/agntcy/slim/compare/slimctl-v1.2.0...slimctl-v1.3.0) - 2026-03-31
 
 ### Added

--- a/data-plane/slimrpc-compiler/CHANGELOG.md
+++ b/data-plane/slimrpc-compiler/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0-rc.0](https://github.com/agntcy/slim/compare/protoc-slimrpc-plugin-v1.3.0...protoc-slimrpc-plugin-v1.4.0-rc.0) - 2026-04-21
+
+### Fixed
+
+- *(bindings/go)* use ChannelInterface and ServerInterface in generated stubs ([#1426](https://github.com/agntcy/slim/pull/1426))
+
+### Other
+
+- prepare 1.4.0-rc.0 ([#1530](https://github.com/agntcy/slim/pull/1530))
+
 ## [1.3.0](https://github.com/agntcy/slim/compare/protoc-slimrpc-plugin-v1.2.0...protoc-slimrpc-plugin-v1.3.0) - 2026-03-31
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-version`: 1.3.0 -> 1.4.0-rc.0
* `agntcy-slim-auth`: 0.6.2 -> 0.7.0 (⚠ API breaking changes)
* `agntcy-slim-config`: 0.8.2 -> 0.9.0 (⚠ API breaking changes)
* `agntcy-slim-datapath`: 0.12.2 -> 0.12.3 (✓ API compatible changes)
* `agntcy-slim-controller`: 0.4.12 -> 0.5.0 (⚠ API breaking changes)
* `agntcy-slim`: 1.3.0 -> 1.4.0-rc.0 (✓ API compatible changes)
* `agntcy-slim-bindings`: 1.3.0 -> 1.4.0-rc.0
* `agntcy-slimctl`: 1.3.0 -> 1.4.0-rc.0
* `agntcy-protoc-slimrpc-plugin`: 1.3.0 -> 1.4.0-rc.0
* `agntcy-slim-tracing`: 0.3.8 -> 0.3.9
* `agntcy-slim-mls`: 0.1.14 -> 0.1.15
* `agntcy-slim-session`: 0.1.11 -> 0.1.12
* `agntcy-slim-signal`: 0.1.8 -> 0.1.9
* `agntcy-slim-service`: 0.8.11 -> 0.8.12

### ⚠ `agntcy-slim-auth` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant MetadataValue:Bool in /tmp/.tmpWFvzkT/slim/data-plane/core/auth/src/metadata.rs:29
```

### ⚠ `agntcy-slim-config` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant AuthenticationConfig:Spire in /tmp/.tmpWFvzkT/slim/data-plane/core/config/src/grpc/server.rs:77
  variant AuthenticationConfig:Spire in /tmp/.tmpWFvzkT/slim/data-plane/core/config/src/grpc/client.rs:213
```

### ⚠ `agntcy-slim-controller` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ConfigurationCommand.connections_to_delete in /tmp/.tmpWFvzkT/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:109
  field ConnectionEntry.link_id in /tmp/.tmpWFvzkT/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:162
  field ConnectionEntry.direction in /tmp/.tmpWFvzkT/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:164
  field Subscription.link_id in /tmp/.tmpWFvzkT/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:87
  field Subscription.direction in /tmp/.tmpWFvzkT/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:89
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `agntcy-slim-version`

<blockquote>

## [1.3.0](https://github.com/agntcy/slim/releases/tag/slim-version-v1.3.0) - 2026-03-20

### Added

- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
</blockquote>

## `agntcy-slim-auth`

<blockquote>

## [0.7.0](https://github.com/agntcy/slim/compare/slim-auth-v0.6.2...slim-auth-v0.7.0) - 2026-04-21

### Added

- update controller connection ([#1485](https://github.com/agntcy/slim/pull/1485))
- add tower auth middleware using spire ([#1452](https://github.com/agntcy/slim/pull/1452))

### Fixed

- revert "build(deps): upgrade to spire 0.12" ([#1528](https://github.com/agntcy/slim/pull/1528))
- *(spire)* typo in error message ([#1521](https://github.com/agntcy/slim/pull/1521))

### Other

- *(deps)* upgrade to spire 0.12 ([#1436](https://github.com/agntcy/slim/pull/1436))
</blockquote>

## `agntcy-slim-config`

<blockquote>

## [0.9.0](https://github.com/agntcy/slim/compare/slim-config-v0.8.2...slim-config-v0.9.0) - 2026-04-21

### Added

- add tower auth middleware using spire ([#1452](https://github.com/agntcy/slim/pull/1452))

### Fixed

- revert "build(deps): upgrade to spire 0.12" ([#1528](https://github.com/agntcy/slim/pull/1528))

### Other

- *(deps)* upgrade to spire 0.12 ([#1436](https://github.com/agntcy/slim/pull/1436))
</blockquote>

## `agntcy-slim-datapath`

<blockquote>

## [0.12.3](https://github.com/agntcy/slim/compare/slim-datapath-v0.12.2...slim-datapath-v0.12.3) - 2026-04-21

### Added

- update controller connection ([#1485](https://github.com/agntcy/slim/pull/1485))

### Other

- *(datapath)* use Arc instead of Box for Name string storage ([#1435](https://github.com/agntcy/slim/pull/1435))
</blockquote>

## `agntcy-slim-controller`

<blockquote>

## [0.5.0](https://github.com/agntcy/slim/compare/slim-controller-v0.4.12...slim-controller-v0.5.0) - 2026-04-21

### Added

- update controller connection ([#1485](https://github.com/agntcy/slim/pull/1485))
</blockquote>

## `agntcy-slim`

<blockquote>

## [1.4.0-rc.1](https://github.com/agntcy/slim/compare/slim-v1.4.0-rc.0...slim-v1.4.0-rc.1) - 2026-04-21

### Other

- update Cargo.lock dependencies
</blockquote>

## `agntcy-slim-bindings`

<blockquote>

## [1.4.0-rc.0](https://github.com/agntcy/slim/compare/slim-bindings-v1.3.0...slim-bindings-v1.4.0-rc.0) - 2026-04-21

### Added

- add tower auth middleware using spire ([#1452](https://github.com/agntcy/slim/pull/1452))

### Fixed

- adding linters to Golang, Java and Kotlin bindings and generaliz… ([#1502](https://github.com/agntcy/slim/pull/1502))

### Other

- prepare 1.4.0-rc.0 ([#1530](https://github.com/agntcy/slim/pull/1530))
</blockquote>

## `agntcy-slimctl`

<blockquote>

## [1.4.0-rc.0](https://github.com/agntcy/slim/compare/slimctl-v1.3.0...slimctl-v1.4.0-rc.0) - 2026-04-21

### Added

- update controller connection ([#1485](https://github.com/agntcy/slim/pull/1485))

### Fixed

- *(slimctl)* correct test name spelling (writable) ([#1464](https://github.com/agntcy/slim/pull/1464))

### Other

- prepare 1.4.0-rc.0 ([#1530](https://github.com/agntcy/slim/pull/1530))
</blockquote>

## `agntcy-protoc-slimrpc-plugin`

<blockquote>

## [1.4.0-rc.0](https://github.com/agntcy/slim/compare/protoc-slimrpc-plugin-v1.3.0...protoc-slimrpc-plugin-v1.4.0-rc.0) - 2026-04-21

### Fixed

- *(bindings/go)* use ChannelInterface and ServerInterface in generated stubs ([#1426](https://github.com/agntcy/slim/pull/1426))

### Other

- prepare 1.4.0-rc.0 ([#1530](https://github.com/agntcy/slim/pull/1530))
</blockquote>

## `agntcy-slim-tracing`

<blockquote>

## [0.3.9](https://github.com/agntcy/slim/compare/slim-tracing-v0.3.8...slim-tracing-v0.3.9) - 2026-04-21

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-config
</blockquote>

## `agntcy-slim-mls`

<blockquote>

## [0.1.15](https://github.com/agntcy/slim/compare/slim-mls-v0.1.14...slim-mls-v0.1.15) - 2026-04-21

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-datapath
</blockquote>

## `agntcy-slim-session`

<blockquote>

## [0.1.12](https://github.com/agntcy/slim/compare/slim-session-v0.1.11...slim-session-v0.1.12) - 2026-04-21

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-datapath, agntcy-slim-mls
</blockquote>

## `agntcy-slim-signal`

<blockquote>

## [0.1.9](https://github.com/agntcy/slim/compare/slim-signal-v0.1.8...slim-signal-v0.1.9) - 2026-04-21

### Other

- updated the following local packages: agntcy-slim-version
</blockquote>

## `agntcy-slim-service`

<blockquote>

## [0.8.12](https://github.com/agntcy/slim/compare/slim-service-v0.8.11...slim-service-v0.8.12) - 2026-04-21

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-controller, agntcy-slim-mls, agntcy-slim-session
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).