### PR TITLE
feat(helm): add southbound ingress and named data-plane ports

### DIFF
--- a/charts/slim-control-plane/templates/NOTES.txt
+++ b/charts/slim-control-plane/templates/NOTES.txt
@@ -1,8 +1,8 @@
 1. Get the application URL by running these commands:
-{{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
+{{- if .Values.ingressNorth.enabled }}
+{{- range $host := .Values.ingressNorth.hosts }}
   {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  http{{ if $.Values.ingressNorth.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}

--- a/charts/slim-control-plane/templates/ingress-north.yaml
+++ b/charts/slim-control-plane/templates/ingress-north.yaml
@@ -3,31 +3,29 @@ Copyright AGNTCY Contributors (https://github.com/agntcy)
 SPDX-License-Identifier: Apache-2.0
 */}}
 
-{{- range .Values.slim.ingresses }}
-{{- $ingress := . }}
----
+{{- if .Values.ingressNorth.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "slim.fullname" $ }}-{{ $ingress.portName }}
+  name: {{ include "control-plane.fullname" . }}-north
   labels:
-    {{- include "slim.labels" $ | nindent 4 }}
+    {{- include "control-plane.labels" . | nindent 4 }}
   annotations:
-  {{- if and $ingress.basicAuth $ingress.basicAuth.enabled }}
+  {{- if .Values.ingressNorth.basicAuth.enabled }}
     nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/auth-secret: {{ $ingress.basicAuth.existingBasicAuthSecret }}
-    nginx.ingress.kubernetes.io/auth-realm: {{ $ingress.basicAuth.realm }}
+    nginx.ingress.kubernetes.io/auth-secret: {{ .Values.ingressNorth.basicAuth.existingBasicAuthSecret }}
+    nginx.ingress.kubernetes.io/auth-realm: {{ .Values.ingressNorth.basicAuth.realm }}
   {{- end }}
-  {{- with $ingress.annotations }}
+  {{- with .Values.ingressNorth.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- with $ingress.className }}
+  {{- with .Values.ingressNorth.className }}
   ingressClassName: {{ . }}
   {{- end }}
-  {{- if $ingress.tls }}
+  {{- if .Values.ingressNorth.tls }}
   tls:
-    {{- range $ingress.tls }}
+    {{- range .Values.ingressNorth.tls }}
     - hosts:
         {{- range .hosts }}
         - {{ . | quote }}
@@ -36,7 +34,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    {{- range $ingress.hosts }}
+    {{- range .Values.ingressNorth.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:
@@ -47,9 +45,9 @@ spec:
             {{- end }}
             backend:
               service:
-                name: {{ include "slim.fullname" $ }}
+                name: {{ include "control-plane.fullname" $ }}
                 port:
-                  name: {{ $ingress.portName }}
+                  number: {{ $.Values.service.north.port }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/slim-control-plane/templates/ingress-south.yaml
+++ b/charts/slim-control-plane/templates/ingress-south.yaml
@@ -3,29 +3,29 @@ Copyright AGNTCY Contributors (https://github.com/agntcy)
 SPDX-License-Identifier: Apache-2.0
 */}}
 
-{{- if .Values.ingress.enabled -}}
+{{- if .Values.ingressSouth.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "control-plane.fullname" . }}
+  name: {{ include "control-plane.fullname" . }}-south
   labels:
     {{- include "control-plane.labels" . | nindent 4 }}
   annotations:
-  {{- if .Values.ingress.basicAuth.enabled }}
+  {{- if .Values.ingressSouth.basicAuth.enabled }}
     nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/auth-secret: {{ .Values.ingress.basicAuth.existingBasicAuthSecret }}
-    nginx.ingress.kubernetes.io/auth-realm: {{ .Values.ingress.basicAuth.realm }}
+    nginx.ingress.kubernetes.io/auth-secret: {{ .Values.ingressSouth.basicAuth.existingBasicAuthSecret }}
+    nginx.ingress.kubernetes.io/auth-realm: {{ .Values.ingressSouth.basicAuth.realm }}
   {{- end }}
-  {{- with .Values.ingress.annotations }}
+  {{- with .Values.ingressSouth.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- with .Values.ingress.className }}
+  {{- with .Values.ingressSouth.className }}
   ingressClassName: {{ . }}
   {{- end }}
-  {{- if .Values.ingress.tls }}
+  {{- if .Values.ingressSouth.tls }}
   tls:
-    {{- range .Values.ingress.tls }}
+    {{- range .Values.ingressSouth.tls }}
     - hosts:
         {{- range .hosts }}
         - {{ . | quote }}
@@ -34,7 +34,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    {{- range .Values.ingress.hosts }}
+    {{- range .Values.ingressSouth.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:
@@ -47,7 +47,7 @@ spec:
               service:
                 name: {{ include "control-plane.fullname" $ }}
                 port:
-                  number: {{ $.Values.service.north.port }}
+                  number: {{ $.Values.service.south.port }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/slim-control-plane/values.yaml
+++ b/charts/slim-control-plane/values.yaml
@@ -109,7 +109,28 @@ persistence:
   storageClass: ""
 
 # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
-ingress:
+ingressNorth:
+  enabled: false
+  className: ""
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+  basicAuth:
+    enabled: false
+    existingBasicAuthSecret: ""
+    realm: ""
+
+ingressSouth:
   enabled: false
   className: ""
   annotations:

--- a/charts/slim/templates/NOTES.txt
+++ b/charts/slim/templates/NOTES.txt
@@ -1,9 +1,11 @@
 1. Get the application URL by running these commands:
-{{- if .Values.slim.ingress.enabled }}
-{{- range $host := .Values.slim.ingress.hosts }}
+{{- if .Values.slim.ingresses }}
+{{- range $ingress := .Values.slim.ingresses }}
+{{- range $host := $ingress.hosts }}
   {{- range .paths }}
-  http{{ if $.Values.slim.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  http{{ if $ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.slim.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "slim.fullname" . }})

--- a/charts/slim/templates/daemonset.yaml
+++ b/charts/slim/templates/daemonset.yaml
@@ -65,7 +65,7 @@ spec:
             {{- end }}
           ports:
             {{- range $i, $data := .Values.slim.service.data }}
-            - name: data-plane-{{ $i }}
+            - name: {{ $data.name | default (printf "data-plane-%d" $i) }}
               containerPort: {{ $data.port }}
               protocol: TCP
               hostPort: {{ $data.port }}

--- a/charts/slim/templates/service.yaml
+++ b/charts/slim/templates/service.yaml
@@ -17,9 +17,9 @@ spec:
   ports:
     {{- range $i, $data := .Values.slim.service.data }}
     - port: {{ $data.port }}
-      targetPort: data-plane-{{ $i }}
+      targetPort: {{ $data.name | default (printf "data-plane-%d" $i) }}
       protocol: TCP
-      name: data-plane-{{ $i }}
+      name: {{ $data.name | default (printf "data-plane-%d" $i) }}
     {{- end }}
     {{- range $i, $ctrl := .Values.slim.service.control }}
     - port: {{ $ctrl.port }}
@@ -44,9 +44,9 @@ spec:
   ports:
     {{- range $i, $data := .Values.slim.service.data }}
     - port: {{ $data.port }}
-      targetPort: data-plane-{{ $i }}
+      targetPort: {{ $data.name | default (printf "data-plane-%d" $i) }}
       protocol: TCP
-      name: data-plane-{{ $i }}
+      name: {{ $data.name | default (printf "data-plane-%d" $i) }}
     {{- end }}
     {{- range $i, $ctrl := .Values.slim.service.control }}
     - port: {{ $ctrl.port }}

--- a/charts/slim/templates/statefulset.yaml
+++ b/charts/slim/templates/statefulset.yaml
@@ -70,7 +70,7 @@ spec:
             {{- end }}
           ports:
             {{- range $i, $data := .Values.slim.service.data }}
-            - name: data-plane-{{ $i }}
+            - name: {{ $data.name | default (printf "data-plane-%d" $i) }}
               containerPort: {{ $data.port }}
               protocol: TCP
             {{- end }}

--- a/charts/slim/values.yaml
+++ b/charts/slim/values.yaml
@@ -91,28 +91,37 @@ slim:
     type: ClusterIP
     headless: false
     # List of dataplane server ports to expose. One entry per dataplane server.
+    # Each entry may include an optional 'name' field (max 15 chars, lowercase alphanumeric and dashes).
+    # If omitted, the port is named data-plane-{index}.
     data:
       - port: 46357
+        name: data-plane-0
     # List of controller server ports to expose. One entry per controller server.
     control:
       - port: 46358
 
-  # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
-  ingress:
-    enabled: false
-    className: ""
-    annotations: {}
-      # kubernetes.io/ingress.class: nginx
-      # kubernetes.io/tls-acme: "true"
-    hosts:
-      - host: chart-example.local
-        paths:
-          - path: /
-            pathType: ImplementationSpecific
-    tls: []
-    #  - secretName: chart-example-tls
-    #    hosts:
-    #      - chart-example.local
+  # List of ingresses to expose data plane ports.
+  # Each entry creates a separate Ingress resource targeting the named data port.
+  ingresses: []
+  # - portName: data-plane-0      # Must match a name in service.data (or the default data-plane-{index})
+  #   className: ""
+  #   annotations:
+  #     nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+  #     # kubernetes.io/ingress.class: nginx
+  #     # kubernetes.io/tls-acme: "true"
+  #   hosts:
+  #     - host: chart-example.local
+  #       paths:
+  #         - path: /
+  #           pathType: ImplementationSpecific
+  #   tls: []
+  #   #  - secretName: chart-example-tls
+  #   #    hosts:
+  #   #      - chart-example.local
+  #   basicAuth:
+  #     enabled: false
+  #     existingBasicAuthSecret: ""
+  #     realm: ""
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
## Description

- **slim-control-plane**: split `ingress.yaml` into `ingress-north.yaml` and `ingress-south.yaml`; rename values key `ingress` → `ingressNorth` and add new `ingressSouth` section
- **slim**: replace single `slim.ingress` (with `enabled` flag) with `slim.ingresses` list, so any data port can be independently exposed via its own Ingress resource; add optional `name` field to `service.data` entries (defaults to `data-plane-{index}`); propagate named ports across service, statefulset, and daemonset templates

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass