### PR TITLE
fix(data-plane/examples): remove task calling non-existing binary

### DIFF
--- a/data-plane/examples/Taskfile.yaml
+++ b/data-plane/examples/Taskfile.yaml
@@ -63,11 +63,6 @@ tasks:
     cmds:
       - cargo run --bin sdk-mock -- --config ../../../config/base/client-config.yaml --local-name client --remote-name server --mls-group-id mls-group --message "hey there!"
 
-  run:mock-app:moderator-mls:
-    desc: "Run the mock moderator with MLS"
-    cmds:
-      - cargo run --bin moderator -- --config ../config/base/client-config.yaml --name moderator --mls
-
   docker:build-all:
     desc: "Build all Docker images"
     dir: "../.."


### PR DESCRIPTION
closes #1254 

# Description

Data-plane examples Taskfile contains a task calling cargo run targeting the undefined 'moderator' binary.
No references were found of such binary, so the call should be removed.

# Action

Task with invalid cargo run removed.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
