### PR TITLE
fix(session): fix need_drains with app direction set to None

### DIFF
--- a/data-plane/core/session/src/session.rs
+++ b/data-plane/core/session/src/session.rs
@@ -320,8 +320,9 @@ impl MessageHandler for Session {
     }
 
     fn needs_drain(&self) -> bool {
-        !(self.sender.as_ref().is_some_and(|s| s.drain_completed())
-            && self.receiver.as_ref().is_some_and(|r| r.drain_completed()))
+        let sender_done = self.sender.as_ref().is_none_or(|s| s.drain_completed());
+        let receiver_done = self.receiver.as_ref().is_none_or(|r| r.drain_completed());
+        !(sender_done && receiver_done)
     }
 
     fn processing_state(&self) -> ProcessingState {


### PR DESCRIPTION
# Description

Fix needs_drain() hanging when Direction is None

### Problem:

When an application is created with Direction::None, session deletion hangs for up to 60 seconds (the graceful_shutdown_timeout).

With Direction::None, both sender and receiver are None. The previous implementation used is_some_and(), which returns false for None values, causing  needs_drain() to always return true. This prevented the draining exit condition in the SessionController processing loop from ever being satisfied.

### Fix:

Replace is_some_and() with is_none_or(), so that absent sender/receiver are treated as already drained. This allows the processing loop to exit immediately when there is nothing to drain.

fix: #1573

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
